### PR TITLE
feat: add a label to the release PR for automation

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "bin": "./build/src/bin/release-please.js",
   "scripts": {
     "test": "cross-env ENVIRONMENT=test c8 --reporter=html --reporter=text mocha --recursive --timeout=5000 build/test",
-    "system-test": "cross-env ENVIRONMENT=test mocha --timeout=5000 build/system-test",
+    "system-test": "cross-env ENVIRONMENT=test mocha --timeout=20000 build/system-test",
     "test:all": "cross-env ENVIRONMENT=test c8 --reporter=html --reporter=text mocha --recursive --timeout=20000 build/system-test build/test",
     "test:snap": "SNAPSHOT_UPDATE=1 npm test",
     "clean": "gts clean",

--- a/src/bin/release-please.ts
+++ b/src/bin/release-please.ts
@@ -43,6 +43,10 @@ yargs
       options: ['node'],
       default: 'node'
     })
+    .option('label', {
+      default: 'autorelease: pending',
+      describe: 'label to add to generated PR'
+    })
     .demandCommand(1)
     .strict(true)
     .parse();

--- a/src/github.ts
+++ b/src/github.ts
@@ -109,6 +109,10 @@ export class GitHub {
   }
 
   async addLabel(pr: number, label: string) {
+    checkpoint(
+        `adding label ${chalk.green(label)} to https://github.com/${
+            this.owner}/${this.repo}/pull/${pr}`,
+        CheckpointType.Success);
     await this.octokit.issues.addLabels({
       owner: this.owner,
       repo: this.repo,

--- a/src/mint-release.ts
+++ b/src/mint-release.ts
@@ -31,6 +31,7 @@ enum ReleaseType {
 }
 
 export interface MintReleaseOptions {
+  label: string;
   token?: string;
   repoUrl: string;
   packageName: string;
@@ -38,6 +39,7 @@ export interface MintReleaseOptions {
 }
 
 export class MintRelease {
+  label: string;
   gh: GitHub;
   repoUrl: string;
   token: string|undefined;
@@ -45,6 +47,7 @@ export class MintRelease {
   releaseType: ReleaseType;
 
   constructor(options: MintReleaseOptions) {
+    this.label = options.label;
     this.repoUrl = options.repoUrl;
     this.token = options.token;
     this.packageName = options.packageName;
@@ -98,8 +101,9 @@ export class MintRelease {
     }));
 
     const sha = this.shaFromCommits(commits);
-    await this.gh.openPR(
+    const pr: number = await this.gh.openPR(
         {branch: `release-v${version}`, version, sha, updates});
+    await this.gh.addLabel(pr, this.label);
   }
   private async commits(latestTag: GitHubTag): Promise<string[]> {
     const commits = await this.gh.commitsSinceSha(latestTag.sha);


### PR DESCRIPTION
Add a label (defaulting to `autorelease: pending`) to the PRs generated by `release-please`, this should allow our existing auto-release machinery to take over.

We should be able to perform end-to-end testing once https://github.com/googleapis/releasetool/pull/181 is released.