### PR TITLE
build!: upgrade engines field to >=8.10.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -57,5 +57,8 @@
     "parse-github-repo-url": "^1.4.1",
     "semver": "^6.0.0",
     "yargs": "^13.2.2"
+  },
+  "engines": {
+    "node": ">=8.10.0"
   }
 }


### PR DESCRIPTION
This drops support for all Node.js versions < 8.10.0, please upgrade

BREAKING CHANGE: library now requires Node >= 8.10.0