### PR TITLE
feat: you must now opt in to bumping minor pre-major

### DIFF
--- a/src/bin/release-please.ts
+++ b/src/bin/release-please.ts
@@ -43,6 +43,11 @@ yargs
       options: ['node'],
       default: 'node'
     })
+    .option('bump-minor-pre-major', {
+      describe: 'should we bump the semver minor prior to the first major release',
+      default: false,
+      type: 'boolean'
+    })
     .option('label', {
       default: 'autorelease: pending',
       describe: 'label to add to generated PR'

--- a/src/conventional-commits.ts
+++ b/src/conventional-commits.ts
@@ -32,6 +32,7 @@ interface ConventionalCommitsOptions {
   commits: string[];
   githubRepoUrl: string;
   host?: string;
+  bumpMinorPreMajor?: boolean;
 }
 
 interface ChangelogEntryOptions {
@@ -65,18 +66,20 @@ export class ConventionalCommits {
   host: string;
   owner: string;
   repository: string;
+  bumpMinorPreMajor?: boolean;
 
   constructor(options: ConventionalCommitsOptions) {
     const parsedGithubRepoUrl = parseGithubRepoUrl(options.githubRepoUrl);
     if (!parsedGithubRepoUrl) throw Error('could not parse githubRepoUrl');
     const [owner, repository] = parsedGithubRepoUrl;
     this.commits = options.commits;
+    this.bumpMinorPreMajor = options.bumpMinorPreMajor || false;
     this.host = options.host || 'https://www.github.com';
     this.owner = owner;
     this.repository = repository;
   }
   async suggestBump(version: string): Promise<BumpSuggestion> {
-    const preMajor = semver.lt(version, 'v1.0.0');
+    const preMajor = this.bumpMinorPreMajor ? semver.lt(version, 'v1.0.0') : false;
     const bump: BumpSuggestion = await this.guessReleaseType(preMajor);
     checkpoint(
         `release as ${chalk.green(bump.releaseType)}: ${

--- a/src/mint-release.ts
+++ b/src/mint-release.ts
@@ -31,6 +31,7 @@ enum ReleaseType {
 }
 
 export interface MintReleaseOptions {
+  bumpMinorPreMajor?: boolean;
   label: string;
   token?: string;
   repoUrl: string;
@@ -41,12 +42,14 @@ export interface MintReleaseOptions {
 export class MintRelease {
   label: string;
   gh: GitHub;
+  bumpMinorPreMajor?: boolean;
   repoUrl: string;
   token: string|undefined;
   packageName: string;
   releaseType: ReleaseType;
 
   constructor(options: MintReleaseOptions) {
+    this.bumpMinorPreMajor = options.bumpMinorPreMajor || false;
     this.label = options.label;
     this.repoUrl = options.repoUrl;
     this.token = options.token;
@@ -68,7 +71,11 @@ export class MintRelease {
     const latestTag: GitHubTag = await this.gh.latestTag();
     const commits: string[] = await this.commits(latestTag);
 
-    const cc = new ConventionalCommits({commits, githubRepoUrl: this.repoUrl});
+    const cc = new ConventionalCommits({
+      commits,
+      githubRepoUrl: this.repoUrl,
+      bumpMinorPreMajor: this.bumpMinorPreMajor
+    });
     const bump = await cc.suggestBump(latestTag.version);
     const version = semver.inc(latestTag.version, bump.releaseType);
 

--- a/test/conventional-commits.ts
+++ b/test/conventional-commits.ts
@@ -27,7 +27,8 @@ describe('ConventionalCommits', () => {
           'chore: upgrade to Node 7\n\nBREAKING CHANGE: we were on Node 6',
           'feat: awesome feature'
         ],
-        githubRepoUrl: 'https://github.com/bcoe/release-please.git'
+        githubRepoUrl: 'https://github.com/bcoe/release-please.git',
+        bumpMinorPreMajor: true
       });
       const bump = await cc.suggestBump('0.3.0');
       expect(bump.releaseType).to.equal('minor');


### PR DESCRIPTION
By default a breaking change will now always bump the semver major, unless you run with `--bump-monor-pre-major`.

BREAKING CHANGE: prior to this the minor was bumped rather than major for pre-major releases