### PR TITLE
build: apply ACL to the creation of releases

### DIFF
--- a/.github/action/mint-release/Dockerfile
+++ b/.github/action/mint-release/Dockerfile
@@ -26,6 +26,7 @@ LABEL "com.github.actions.icon"="book-open"
 LABEL "com.github.actions.color"="green"
 
 RUN npm i release-please json -g
+RUN cd /; npm i node-fetch
 COPY entrypoint.sh check.js /
 
 ENTRYPOINT ["/entrypoint.sh"]

--- a/.github/action/mint-release/check.js
+++ b/.github/action/mint-release/check.js
@@ -19,13 +19,35 @@
 // made by user with write access to repo.
 // TODO: check that user has write access.
 
-const partialIssueTitle = 'proposal for next release';
 const event = require(process.env.GITHUB_EVENT_PATH);
-console.info(JSON.stringify(event, null, 2));
+const fetch = require('node-fetch');
 
-if (issue.title.indexOf(partialIssueTitle) !== -1) {
-  process.exit(0);
+// only users in ORGS_ACL may create releases.
+const ORGS_ACL = process.env.ORGS_ACL.split(',')
+
+// releases can only be created if issue has PARTIALS_ISSUE_TITLE.
+const PARTIALS_ISSUE_TITLE = 'proposal for next release';
+
+if (event.action === 'created' && event.issue.title.indexOf(PARTIALS_ISSUE_TITLE) !== -1) {
+  console.info(`comment created on issue containing: ${PARTIALS_ISSUE_TITLE}`);
+  // ensure the user was in one of our supported organizations:
+  fetch(event.sender.organizations_url)
+    .then(res => res.json())
+    .then(orgs => {
+      for (let i = 0, org; (org = orgs[i]) !== undefined; i++) {
+        if (ORGS_ACL.indexOf(org.login) !== -1) {
+          console.info(`${process.env.GITHUB_ACTOR} was in ${org.login} creating release`);
+          process.exit(0);
+        }
+      }
+      console.error(`${process.env.GITHUB_ACTOR} not found in ${ORGS_ACL}`);
+      process.exit(1);
+    })
+    .catch((err) => {
+      console.error(err.stack);
+      process.exit(1);
+    });
 } else {
-  console.info(`issue title did not contain ${partialIssueTitle}`)
+  console.info(`issue title did not contain: ${partialIssueTitle}`)
   process.exit(1);
 }

--- a/.github/main.workflow
+++ b/.github/main.workflow
@@ -5,5 +5,8 @@ workflow "Mint Release" {
 
 action "./.github/action/mint-release" {
   uses = "./.github/action/mint-release"
+  env = {
+    ORGS_ACL = "GoogleCloudPlatform,google"
+  }
   secrets = ["GITHUB_TOKEN"]
 }


### PR DESCRIPTION
Releases will only be created if a comment is added by a user in a Googley org, and if the comment is made on the appropriate issue.