### PR TITLE
feat: adds command for creating candidate releases

### DIFF
--- a/src/bin/release-please.ts
+++ b/src/bin/release-please.ts
@@ -19,6 +19,7 @@
 'use strict';
 
 import {MintRelease, MintReleaseOptions} from '../mint-release';
+import {CandidateIssue, CandidateIssueOptions} from '../candidate-issue';
 
 const yargs = require('yargs');
 
@@ -28,6 +29,13 @@ yargs
         async (argv: MintReleaseOptions) => {
           const mr = new MintRelease(argv);
           await mr.run();
+        })
+    .command(
+        'candidate-issue',
+        'create an issue that\'s an example of the next release', () => {},
+        async (argv: CandidateIssueOptions) => {
+          const ci = new CandidateIssue(argv);
+          await ci.run();
         })
     .option(
         'token', {describe: 'GitHub repo token', default: process.env.GH_TOKEN})

--- a/system-test/github.ts
+++ b/system-test/github.ts
@@ -73,7 +73,7 @@ describe('GitHub', () => {
     it('returns undefined if no tags exist', async () => {
       const gh = new GitHub({owner: 'bcoe', repo: 'node-25650-bug'});
       const latestTag =
-          await nockBack('latest-tag.json').then((nbr: NockBackResponse) => {
+          await nockBack('no-tag-exists.json').then((nbr: NockBackResponse) => {
             return gh.latestTag(4).then((res: GitHubTag|undefined) => {
               nbr.nockDone();
               return res;
@@ -102,7 +102,7 @@ describe('GitHub', () => {
 
     it('returns all commits if sha is undefined', async () => {
       const gh = new GitHub({owner: 'bcoe', repo: 'node-25650-bug'});
-      const commitsSinceSha = await nockBack('commits-since-sha.json')
+      const commitsSinceSha = await nockBack('commits-since-undefined-sha.json')
                                   .then((nbr: NockBackResponse) => {
                                     return gh.commitsSinceSha(undefined, 10)
                                         .then((res: string[]) => {
@@ -131,6 +131,22 @@ describe('GitHub', () => {
               err.message.should.equal('unauthorized');
             });
       });
+    });
+  });
+
+  describe('findExistingReleaseIssue', () => {
+    it('returns an open issue matching the title provided', async () => {
+      const gh = new GitHub({owner: 'bcoe', repo: 'node-25650-bug'});
+      const issue =
+          await nockBack('find-matching-issue.json')
+              .then((nbr: NockBackResponse) => {
+                return gh.findExistingReleaseIssue('this issue is a fixture')
+                    .then((res) => {
+                      nbr.nockDone();
+                      return res;
+                    });
+              });
+      issue.number.should.be.gt(0);
     });
   });
 });


### PR DESCRIPTION
This PR adds the command for generating candidate releases, [one pictured here](https://github.com/googleapis/release-please/issues/65)

The idea is that these candidate releases demonstrate what the release would look like, and by commenting on the issue a PR for the release actually gets created -- updating CHANGELOG, pertinent files, etc.