### PR TITLE
feat: checkbox based releases

### DIFF
--- a/src/bin/release-please.ts
+++ b/src/bin/release-please.ts
@@ -19,7 +19,7 @@
 'use strict';
 
 import {MintRelease, MintReleaseOptions} from '../mint-release';
-import {CandidateIssue, CandidateIssueOptions} from '../candidate-issue';
+import {CandidateIssue} from '../candidate-issue';
 
 const yargs = require('yargs');
 
@@ -33,7 +33,7 @@ yargs
     .command(
         'candidate-issue',
         'create an issue that\'s an example of the next release', () => {},
-        async (argv: CandidateIssueOptions) => {
+        async (argv: MintReleaseOptions) => {
           const ci = new CandidateIssue(argv);
           await ci.run();
         })

--- a/src/candidate-issue.ts
+++ b/src/candidate-issue.ts
@@ -144,7 +144,8 @@ export class CandidateIssue {
   }
 
   private bodyTemplate(changelogEntry: string): string {
-    return `_:robot: Here's what the next release of **${this.packageName}** would look like._
+    return `_:robot: Here's what the next release of **${
+        this.packageName}** would look like._
 
 ---
 

--- a/src/candidate-issue.ts
+++ b/src/candidate-issue.ts
@@ -14,35 +14,33 @@
  * limitations under the License.
  */
 
+import {IssuesListResponseItem} from '@octokit/rest';
 import * as semver from 'semver';
 
 import {checkpoint, CheckpointType} from './checkpoint';
 import {ConventionalCommits} from './conventional-commits';
 import {GitHub, GitHubTag} from './github';
 import {ReleaseCandidate, ReleaseType} from './mint-release';
+import {MintRelease, MintReleaseOptions} from './mint-release';
 
 const parseGithubRepoUrl = require('parse-github-repo-url');
 
-export interface CandidateIssueOptions {
-  bumpMinorPreMajor?: boolean;
-  token?: string;
-  repoUrl: string;
-  packageName: string;
-  releaseType: ReleaseType;
-}
-
 const ISSUE_TITLE = 'chore(release): proposal for next release';
+const CHECKBOX = '* [ ] **Should I create this release for you :robot:?**';
+const CHECK_REGEX = /\[x]/;
 
 export class CandidateIssue {
-  bumpMinorPreMajor?: boolean;
+  label: string;
   gh: GitHub;
+  bumpMinorPreMajor?: boolean;
   repoUrl: string;
   token: string|undefined;
   packageName: string;
   releaseType: ReleaseType;
 
-  constructor(options: CandidateIssueOptions) {
+  constructor(options: MintReleaseOptions) {
     this.bumpMinorPreMajor = options.bumpMinorPreMajor || false;
+    this.label = options.label;
     this.repoUrl = options.repoUrl;
     this.token = options.token;
     this.packageName = options.packageName;
@@ -50,6 +48,7 @@ export class CandidateIssue {
 
     this.gh = this.gitHubInstance();
   }
+
   async run() {
     switch (this.releaseType) {
       case ReleaseType.Node:
@@ -78,7 +77,37 @@ export class CandidateIssue {
       previousTag: candidate.previousTag
     });
 
-    await this.gh.openIssue(ISSUE_TITLE, this.bodyTemplate(changelogEntry));
+    const issue: IssuesListResponseItem|undefined =
+        await this.gh.findExistingReleaseIssue(ISSUE_TITLE);
+    let body: string = this.bodyTemplate(changelogEntry);
+
+    if (issue) {
+      if (CHECK_REGEX.test(issue.body)) {
+        // if the checkox has been clicked for a release
+        // mint the release.
+        checkpoint(
+            `release checkbox was checked, creating release`,
+            CheckpointType.Success);
+        const mr = new MintRelease({
+          bumpMinorPreMajor: this.bumpMinorPreMajor,
+          label: this.label,
+          token: this.token,
+          repoUrl: this.repoUrl,
+          packageName: this.packageName,
+          releaseType: this.releaseType
+        });
+        const prNumber = await mr.run();
+        body = body.replace(CHECKBOX, `**release created at #${prNumber}**`);
+      } else if (issue.body === body) {
+        // don't update the issue if the content is the same for the release.
+        checkpoint(
+            `skipping update to #${issue.number}, no change to body`,
+            CheckpointType.Failure);
+        return;
+      }
+    }
+
+    await this.gh.openIssue(ISSUE_TITLE, body, issue);
   }
 
   private async coerceReleaseCandidate(
@@ -115,16 +144,15 @@ export class CandidateIssue {
   }
 
   private bodyTemplate(changelogEntry: string): string {
-    return `_:robot: This issue was created by robots! :robot:._
-  
-Its purpose is to show you what the next release of **${
-        this.packageName}** would look like... _If we published it right now._
-
-If you're a maintainer, and would like create a PR for this release, simply comment on this issue.
+    return `_:robot: Here's what the next release of **${this.packageName}** would look like._
 
 ---
 
 ${changelogEntry}
+
+---
+
+${CHECKBOX}
 `;
   }
 }

--- a/src/mint-release.ts
+++ b/src/mint-release.ts
@@ -117,7 +117,9 @@ export class MintRelease {
 
     const sha = this.shaFromCommits(commits);
     const title = `chore: release ${candidate.version}`;
-    const body = `:robot: I have created a release \\*beep\\* \\*boop\\* \n---\n${changelogEntry}`;
+    const body =
+        `:robot: I have created a release \\*beep\\* \\*boop\\* \n---\n${
+            changelogEntry}`;
     const pr: number = await this.gh.openPR({
       branch: `release-v${candidate.version}`,
       version: candidate.version,

--- a/src/mint-release.ts
+++ b/src/mint-release.ts
@@ -66,16 +66,15 @@ export class MintRelease {
 
     this.gh = this.gitHubInstance();
   }
-  async run() {
+  async run(): Promise<number> {
     switch (this.releaseType) {
       case ReleaseType.Node:
-        await this.nodeRelease();
-        break;
+        return await this.nodeRelease();
       default:
         throw Error('unknown release type');
     }
   }
-  private async nodeRelease() {
+  private async nodeRelease(): Promise<number> {
     const latestTag: GitHubTag|undefined = await this.gh.latestTag();
     const commits: string[] =
         await this.commits(latestTag ? latestTag.sha : undefined);
@@ -117,13 +116,18 @@ export class MintRelease {
     }));
 
     const sha = this.shaFromCommits(commits);
+    const title = `chore: release ${candidate.version}`;
+    const body = `:robot: I have created a release \\*beep\\* \\*boop\\* \n---\n${changelogEntry}`;
     const pr: number = await this.gh.openPR({
       branch: `release-v${candidate.version}`,
       version: candidate.version,
       sha,
-      updates
+      updates,
+      title,
+      body
     });
     await this.gh.addLabel(pr, this.label);
+    return pr;
   }
   private async coerceReleaseCandidate(
       cc: ConventionalCommits,

--- a/system-test/github.ts
+++ b/system-test/github.ts
@@ -123,6 +123,8 @@ describe('GitHub', () => {
               branch: 'greenkeeper/@types/node-10.10.0',
               sha: 'abc123',
               version: '1.3.0',
+              title: 'version 1.3.0',
+              body: 'my PR body',
               updates: []
             })
             .catch(err => {


### PR DESCRIPTION
based on @alexander-fenster's recommendation I've simplified the design significantly; to create a release you now just click on a checkbox:

<img width="590" alt="Screen Shot 2019-05-09 at 11 33 45 PM" src="https://user-images.githubusercontent.com/194609/57507196-ed26d100-72b2-11e9-9cb2-4663f9dd7930.png">
