### PR TITLE
refactor: `MintRelease` is better described as `ReleasePR`

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
   "scripts": {
     "test": "cross-env ENVIRONMENT=test c8 mocha --recursive --timeout=5000 build/test",
     "docs-test": "echo add docs tests",
-    "system-test": "cross-env ENVIRONMENT=test c8 mocha --timeout=40000 build/system-test",
+    "system-test": "cross-env ENVIRONMENT=test c8 mocha --timeout=20000 build/system-test",
     "presystem-test": "npm run compile",
     "test:all": "cross-env ENVIRONMENT=test c8 mocha --recursive --timeout=20000 build/system-test build/test",
     "test:snap": "SNAPSHOT_UPDATE=1 npm test",

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
   "scripts": {
     "test": "cross-env ENVIRONMENT=test c8 mocha --recursive --timeout=5000 build/test",
     "docs-test": "echo add docs tests",
-    "system-test": "cross-env ENVIRONMENT=test c8 mocha --timeout=20000 build/system-test",
+    "system-test": "cross-env ENVIRONMENT=test c8 mocha --timeout=40000 build/system-test",
     "presystem-test": "npm run compile",
     "test:all": "cross-env ENVIRONMENT=test c8 mocha --recursive --timeout=20000 build/system-test build/test",
     "test:snap": "SNAPSHOT_UPDATE=1 npm test",

--- a/src/bin/release-please.ts
+++ b/src/bin/release-please.ts
@@ -18,25 +18,29 @@
 
 'use strict';
 
-import {MintRelease, MintReleaseOptions} from '../mint-release';
+import {ReleasePR, ReleasePROptions} from '../release-pr';
 import {CandidateIssue} from '../candidate-issue';
 
 const yargs = require('yargs');
 
 yargs
     .command(
-        'mint-release', 'mint a new release for a repo', () => {},
-        async (argv: MintReleaseOptions) => {
-          const mr = new MintRelease(argv);
-          await mr.run();
-        })
-    .command(
         'candidate-issue',
         'create an issue that\'s an example of the next release', () => {},
-        async (argv: MintReleaseOptions) => {
+        async (argv: ReleasePROptions) => {
           const ci = new CandidateIssue(argv);
           await ci.run();
         })
+    .command(
+        'release-pr', 'create a new release PR from a candidate issue',
+        () => {},
+        async (argv: ReleasePROptions) => {
+          const rp = new ReleasePR(argv);
+          await rp.run();
+        })
+    .command(
+        'github-release', 'create a GitHub release from am release PR',
+        () => {}, async (argv: ReleasePROptions) => {})
     .option(
         'token', {describe: 'GitHub repo token', default: process.env.GH_TOKEN})
     .option('package-name', {

--- a/src/candidate-issue.ts
+++ b/src/candidate-issue.ts
@@ -20,8 +20,8 @@ import * as semver from 'semver';
 import {checkpoint, CheckpointType} from './checkpoint';
 import {ConventionalCommits} from './conventional-commits';
 import {GitHub, GitHubTag} from './github';
-import {ReleaseCandidate, ReleaseType} from './mint-release';
-import {MintRelease, MintReleaseOptions} from './mint-release';
+import {ReleaseCandidate, ReleaseType} from './release-pr';
+import {ReleasePR, ReleasePROptions} from './release-pr';
 
 const parseGithubRepoUrl = require('parse-github-repo-url');
 
@@ -38,7 +38,7 @@ export class CandidateIssue {
   packageName: string;
   releaseType: ReleaseType;
 
-  constructor(options: MintReleaseOptions) {
+  constructor(options: ReleasePROptions) {
     this.bumpMinorPreMajor = options.bumpMinorPreMajor || false;
     this.label = options.label;
     this.repoUrl = options.repoUrl;
@@ -88,7 +88,7 @@ export class CandidateIssue {
         checkpoint(
             `release checkbox was checked, creating release`,
             CheckpointType.Success);
-        const mr = new MintRelease({
+        const rp = new ReleasePR({
           bumpMinorPreMajor: this.bumpMinorPreMajor,
           label: this.label,
           token: this.token,
@@ -96,7 +96,7 @@ export class CandidateIssue {
           packageName: this.packageName,
           releaseType: this.releaseType
         });
-        const prNumber = await mr.run();
+        const prNumber = await rp.run();
         body = body.replace(CHECKBOX, `**release created at #${prNumber}**`);
       } else if (issue.body === body) {
         // don't update the issue if the content is the same for the release.

--- a/src/github.ts
+++ b/src/github.ts
@@ -65,6 +65,7 @@ export class GitHub {
     })) {
       for (let i = 0, commit; response.data[i] !== undefined; i++) {
         commit = response.data[i];
+        console.info(JSON.stringify(commit, null, 2));
         if (commit.sha === sha) {
           return commits;
         } else {

--- a/src/release-pr.ts
+++ b/src/release-pr.ts
@@ -30,7 +30,7 @@ export enum ReleaseType {
   Node = 'node'
 }
 
-export interface MintReleaseOptions {
+export interface ReleasePROptions {
   bumpMinorPreMajor?: boolean;
   label: string;
   token?: string;
@@ -45,7 +45,7 @@ export interface ReleaseCandidate {
   previousTag?: string;
 }
 
-export class MintRelease {
+export class ReleasePR {
   label: string;
   gh: GitHub;
   bumpMinorPreMajor?: boolean;
@@ -55,7 +55,7 @@ export class MintRelease {
   releaseAs?: string;
   releaseType: ReleaseType;
 
-  constructor(options: MintReleaseOptions) {
+  constructor(options: ReleasePROptions) {
     this.bumpMinorPreMajor = options.bumpMinorPreMajor || false;
     this.label = options.label;
     this.repoUrl = options.repoUrl;


### PR DESCRIPTION
`MintRelease` does not facilitate an entire release, rather it opens the PR for a release (I'm starting work on the next step called GitHub release, which actually creates the release with the GitHub API).