### PR TITLE
feat: don't remove link to PR until new commits landed

### DIFF
--- a/__snapshots__/candidate-issue.js
+++ b/__snapshots__/candidate-issue.js
@@ -1,0 +1,30 @@
+exports['CandidateIssue bodySansFooter returns the body with the footer removed 1'] = `
+_:robot: Here's what the next release of **@foo/bar** would look like._
+
+---
+
+Features:
+* deps: upgrade foo
+
+
+---
+
+
+`
+
+exports['CandidateIssue bodyTemplate generates body for issue 1'] = `
+_:robot: Here's what the next release of **@foo/bar** would look like._
+
+---
+
+Features:
+* deps: upgrade foo
+
+
+---
+
+[//]: # footer follows.
+
+* [ ] **Should I create this release for you :robot:?**
+
+`

--- a/test/candidate-issue.ts
+++ b/test/candidate-issue.ts
@@ -1,0 +1,39 @@
+/**
+ * Copyright 2019 Google LLC. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import * as snapshot from 'snap-shot-it';
+
+import {CandidateIssue} from '../src/candidate-issue';
+
+const fixturesPath = './test/fixtures';
+
+describe('CandidateIssue', () => {
+  describe('bodyTemplate', () => {
+    it('generates body for issue', () => {
+      const body = CandidateIssue.bodyTemplate(
+          'Features:\n* deps: upgrade foo\n', '@foo/bar');
+      snapshot(body);
+    });
+  });
+
+  describe('bodySansFooter', () => {
+    it('returns the body with the footer removed', () => {
+      const body = CandidateIssue.bodyTemplate(
+        'Features:\n* deps: upgrade foo\n', '@foo/bar');
+      snapshot(CandidateIssue.bodySansFooter(body));
+    })
+  })
+});


### PR DESCRIPTION
when a PR is created from a candidate issue, we replace the `[x]` with a link to the PR that was created (this is neat) ... *but* when the bot comes back around and updates the candidate issue, we overwrite the updated footer with an empty checkbox.

This PR introduces a footer comment, which is used to avoid updating the candidate issue until the PR generated is landed.