### PR TITLE
refactor: reworked release-pr logic, to work better in isolation

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "release-please",
-  "version": "1.3.0",
+  "version": "1.4.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/src/bin/release-please.ts
+++ b/src/bin/release-please.ts
@@ -50,7 +50,7 @@ yargs
                 demand: true
               })
               .option('label', {
-                default: 'autorelease: pending',
+                default: 'autorelease: pending,type: process',
                 describe:
                     'label that will be added to PR created from candidate issue'
               })
@@ -77,7 +77,7 @@ yargs
                 demand: true
               })
               .option('label', {
-                default: 'autorelease: pending',
+                default: 'autorelease: pending,type: process',
                 describe:
                     'label that will be added to PR created from candidate issue'
               })
@@ -103,7 +103,7 @@ yargs
                 demand: true
               })
               .option('label', {
-                default: 'autorelease: pending',
+                default: 'autorelease: pending,type: process',
                 describe: 'label(s) to add to generated PR'
               });
         },
@@ -141,7 +141,7 @@ yargs
           console.info(chalk.green(
               '----- put the content below in .github/main.workflow -----'));
           console.info(`workflow "Candidate Issue" {
-  on = "schedule(*/8 * * * *)"
+  on = "push"
   resolves = ["candidate-issue"]
 }
 

--- a/src/candidate-issue.ts
+++ b/src/candidate-issue.ts
@@ -125,8 +125,9 @@ export class CandidateIssue {
           releaseType: this.releaseType
         });
         const prNumber: number|undefined = await rp.run();
-        if (prNumber)
+        if (prNumber) {
           body = body.replace(CHECKBOX, `**release created at #${prNumber}**`);
+        }
       } else if (
           CandidateIssue.bodySansFooter(issue.body) ===
           CandidateIssue.bodySansFooter(body)) {

--- a/src/candidate-issue.ts
+++ b/src/candidate-issue.ts
@@ -124,8 +124,9 @@ export class CandidateIssue {
           packageName: this.packageName,
           releaseType: this.releaseType
         });
-        const prNumber = await rp.run();
-        body = body.replace(CHECKBOX, `**release created at #${prNumber}**`);
+        const prNumber: number|undefined = await rp.run();
+        if (prNumber)
+          body = body.replace(CHECKBOX, `**release created at #${prNumber}**`);
       } else if (
           CandidateIssue.bodySansFooter(issue.body) ===
           CandidateIssue.bodySansFooter(body)) {

--- a/src/candidate-issue.ts
+++ b/src/candidate-issue.ts
@@ -60,8 +60,7 @@ export class CandidateIssue {
 
   async detectChecked() {
     const issue: IssuesListResponseItem|undefined =
-        await this.gh.findExistingReleaseIssue(
-            ISSUE_TITLE, this.issueLabels.join(','));
+        await this.gh.findExistingReleaseIssue(ISSUE_TITLE, this.issueLabels);
     if (issue) {
       checkpoint(
           `release candidate #${issue.number} found`, CheckpointType.Success);
@@ -106,8 +105,7 @@ export class CandidateIssue {
     });
 
     issue = issue ||
-        await this.gh.findExistingReleaseIssue(
-            ISSUE_TITLE, this.issueLabels.join(','));
+        await this.gh.findExistingReleaseIssue(ISSUE_TITLE, this.issueLabels);
     let body: string =
         CandidateIssue.bodyTemplate(changelogEntry, this.packageName);
 

--- a/src/github.ts
+++ b/src/github.ts
@@ -88,14 +88,6 @@ export class GitHub {
   }
 
   async latestTag(perPage = 100): Promise<GitHubTag|undefined> {
-    const latestRelease = await this.latestRelease();
-    if (latestRelease) {
-      checkpoint(
-          `found existing release ${latestRelease.name}`,
-          CheckpointType.Success);
-      return latestRelease;
-    }
-
     const tags: {[version: string]: GitHubTag;} = await this.allTags(perPage);
     const versions = Object.keys(tags);
     // no tags have been created yet.
@@ -109,6 +101,9 @@ export class GitHub {
     };
   }
 
+  // TODO: investigate why this returns a target_commitish of `master`
+  // even months after the release is created; is there a way to
+  // get the SHA that the release was created at?
   async latestRelease(): Promise<GitHubTag|undefined> {
     try {
       const latestRelease: Response<ReposGetLatestReleaseResponse> =
@@ -116,6 +111,7 @@ export class GitHub {
               {owner: this.owner, repo: this.repo});
       const version = semver.valid(latestRelease.data.name);
       if (version) {
+        console.info(latestRelease.data);
         return {
           name: latestRelease.data.name,
           sha: latestRelease.data.target_commitish,

--- a/src/release-pr.ts
+++ b/src/release-pr.ts
@@ -14,11 +14,12 @@
  * limitations under the License.
  */
 
+import {PullsListResponseItem} from '@octokit/rest';
 import * as semver from 'semver';
 
 import {checkpoint, CheckpointType} from './checkpoint';
 import {ConventionalCommits} from './conventional-commits';
-import {GitHub, GitHubTag} from './github';
+import {GitHub, GitHubReleasePR, GitHubTag} from './github';
 import {Changelog} from './updaters/changelog';
 import {PackageJson} from './updaters/package-json';
 import {SamplesPackageJson} from './updaters/samples-package-json';
@@ -47,7 +48,7 @@ export interface ReleaseCandidate {
 }
 
 export class ReleasePR {
-  label: string;
+  labels: string[];
   gh: GitHub;
   bumpMinorPreMajor?: boolean;
   repoUrl: string;
@@ -58,7 +59,7 @@ export class ReleasePR {
 
   constructor(options: ReleasePROptions) {
     this.bumpMinorPreMajor = options.bumpMinorPreMajor || false;
-    this.label = options.label;
+    this.labels = options.label.split(',');
     this.repoUrl = options.repoUrl;
     this.token = options.token;
     this.packageName = options.packageName;
@@ -68,17 +69,28 @@ export class ReleasePR {
     this.gh = this.gitHubInstance();
   }
   async run(): Promise<number> {
-    switch (this.releaseType) {
-      case ReleaseType.Node:
-        return await this.nodeRelease();
-      default:
-        throw Error('unknown release type');
+    const pr: GitHubReleasePR|undefined =
+        await this.gh.findMergedReleasePR(this.labels);
+    if (pr) {
+      // a PR already exists in the autorelease: pending state.
+      checkpoint(
+          `pull #${pr.number} ${pr.sha} has not yet been released`,
+          CheckpointType.Failure);
+      return pr.number;
+    } else {
+      switch (this.releaseType) {
+        case ReleaseType.Node:
+          return await this.nodeRelease();
+        default:
+          throw Error('unknown release type');
+      }
     }
   }
   private async nodeRelease(): Promise<number> {
     const latestTag: GitHubTag|undefined = await this.gh.latestTag();
     const commits: string[] =
         await this.commits(latestTag ? latestTag.sha : undefined);
+
     const cc = new ConventionalCommits({
       commits,
       githubRepoUrl: this.repoUrl,
@@ -129,9 +141,24 @@ export class ReleasePR {
       title,
       body
     });
-    await this.gh.addLabels(pr, [this.label]);
+    await this.gh.addLabels(pr, this.labels);
+    await this.closeStaleReleasePRs(pr);
     return pr;
   }
+
+  private async closeStaleReleasePRs(currentPRNumber: number) {
+    const prs: PullsListResponseItem[] =
+        await this.gh.findOpenReleasePRs(this.labels);
+    for (let i = 0, pr: PullsListResponseItem; i < prs.length; i++) {
+      pr = prs[i];
+      // don't close the most up-to-date release PR.
+      if (pr.number !== currentPRNumber) {
+        checkpoint(`closing pull #${pr.number}`, CheckpointType.Failure);
+        await this.gh.closePR(pr.number);
+      }
+    }
+  }
+
   private async coerceReleaseCandidate(
       cc: ConventionalCommits,
       latestTag: GitHubTag|undefined): Promise<ReleaseCandidate> {
@@ -149,6 +176,7 @@ export class ReleasePR {
 
     return {version, previousTag};
   }
+
   private async commits(sha: string|undefined): Promise<string[]> {
     const commits = await this.gh.commitsSinceSha(sha);
     if (commits.length) {
@@ -160,10 +188,12 @@ export class ReleasePR {
     }
     return commits;
   }
+
   private gitHubInstance(): GitHub {
     const [owner, repo] = parseGithubRepoUrl(this.repoUrl);
     return new GitHub({token: this.token, owner, repo});
   }
+
   private shaFromCommits(commits: string[]): string {
     // The conventional commits parser expects an array of string commit
     // messages terminated by `-hash-` followed by the commit sha. We

--- a/system-test/github.ts
+++ b/system-test/github.ts
@@ -144,7 +144,7 @@ describe('GitHub', () => {
                           return gh
                               .findExistingReleaseIssue(
                                   'this issue is a fixture',
-                                  'type: process,release-candidate')
+                                  ['type: process', 'release-candidate'])
                               .then((res) => {
                                 nbr.nockDone();
                                 return res;
@@ -158,14 +158,15 @@ describe('GitHub', () => {
     it('returns the latest closed PR with "autorelease: pending" tag',
        async () => {
          const gh = new GitHub({owner: 'bcoe', repo: 'node-25650-bug'});
-         const pr = await nockBack('latest-release-pr.json')
-                        .then((nbr: NockBackResponse) => {
-                          return gh.latestReleasePR('autorelease: pending')
-                              .then((res) => {
-                                nbr.nockDone();
-                                return res;
-                              });
-                        });
+         const pr =
+             await nockBack('latest-release-pr.json')
+                 .then((nbr: NockBackResponse) => {
+                   return gh.findMergedReleasePR(['autorelease: pending'])
+                       .then((res) => {
+                         nbr.nockDone();
+                         return res;
+                       });
+                 });
          pr.should.eql({
            version: 'v1.1.0',
            sha: 'f52c585f1319b789ff75e864fe9bf7479f72ae0e',


### PR DESCRIPTION
This reworks the ReleasePR logic, such that it could be invoked whenever a PR is merged, and keep a candidate release issue up-to-date. Mainly it:

- [x] does a better job of closing older release PRs, if the version # of the release has changed.
- [x] standardizes on `labels` being an array (my plan was to put the `type: process` tag on the PRs with the goal of not holding them to a tight SLO yet).
- ~[x] switches to checking for a `latestRelease` before falling back to looking up tags (my hope being that this will be a cheaper operation, and eliminates bugs related to tags on branches).~ it turns out `latestRelease` does not include an appropriate git sha, so holding off on this functionality for now.
- [x] short-circuits on opening a release PR if no user-facing changes are found, e.g., all the work that's happened is chores.
