### PR TITLE
fix: if we generate a CHANGELOG with only a header, don't open a PR

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "release-please",
-  "version": "1.4.1",
+  "version": "1.5.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/src/github.ts
+++ b/src/github.ts
@@ -139,20 +139,20 @@ export class GitHub {
         });
     for (let i = 0, pull; i < pullsResponse.data.length; i++) {
       pull = pullsResponse.data[i];
-      for (let ii = 0, label; ii < pull.labels.length; ii++) {
-        label = pull.labels[ii];
-        if (labels.indexOf(label.name) !== -1) {
-          // it's expected that a release PR will have a
-          // HEAD matching the format repo:release-v1.0.0.
-          if (!pull.head) continue;
-          const match = pull.head.label.match(VERSION_FROM_BRANCH_RE);
-          if (!match || !pull.merged_at) continue;
-          return {
-            number: pull.number,
-            sha: pull.merge_commit_sha,
-            version: match[1]
-          } as GitHubReleasePR;
-        }
+      // we look for a PR that has autorelease: pending, and type: process; once
+      // a release occurs, the autorelease: pending label is removed.
+      if (pull.labels.slice(0).sort().join(',') ===
+          labels.slice(0).sort().join(',')) {
+        // it's expected that a release PR will have a
+        // HEAD matching the format repo:release-v1.0.0.
+        if (!pull.head) continue;
+        const match = pull.head.label.match(VERSION_FROM_BRANCH_RE);
+        if (!match || !pull.merged_at) continue;
+        return {
+          number: pull.number,
+          sha: pull.merge_commit_sha,
+          version: match[1]
+        } as GitHubReleasePR;
       }
     }
     return undefined;

--- a/src/github.ts
+++ b/src/github.ts
@@ -141,7 +141,7 @@ export class GitHub {
       pull = pullsResponse.data[i];
       // we look for a PR that has autorelease: pending, and type: process; once
       // a release occurs, the autorelease: pending label is removed.
-      if (pull.labels.slice(0).sort().join(',') ===
+      if (pull.labels.map(l => l.name).sort().join(',') ===
           labels.slice(0).sort().join(',')) {
         // it's expected that a release PR will have a
         // HEAD matching the format repo:release-v1.0.0.

--- a/system-test/github.ts
+++ b/system-test/github.ts
@@ -155,18 +155,19 @@ describe('GitHub', () => {
   });
 
   describe('latestReleasePR', () => {
-    it('returns the latest closed PR with "autorelease: pending" tag',
+    it('returns the latest closed PR with "autorelease: pending"/"type: process" tag',
        async () => {
          const gh = new GitHub({owner: 'bcoe', repo: 'node-25650-bug'});
-         const pr =
-             await nockBack('latest-release-pr.json')
-                 .then((nbr: NockBackResponse) => {
-                   return gh.findMergedReleasePR(['autorelease: pending'])
-                       .then((res) => {
-                         nbr.nockDone();
-                         return res;
-                       });
-                 });
+         const pr = await nockBack('latest-release-pr.json')
+                        .then((nbr: NockBackResponse) => {
+                          return gh
+                              .findMergedReleasePR(
+                                  ['type: process', 'autorelease: pending'])
+                              .then((res) => {
+                                nbr.nockDone();
+                                return res;
+                              });
+                        });
          pr.should.eql({
            version: 'v1.1.0',
            sha: 'f52c585f1319b789ff75e864fe9bf7479f72ae0e',


### PR DESCRIPTION
To test this, I also had to fix a bug with how we were comparing labels; we should ensure all labels match on the PR, not just one of them.