### PR TITLE
fix: force update branch rather than closing and reopening PRs

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "release-please",
-  "version": "1.5.1",
+  "version": "1.6.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/src/release-pr.ts
+++ b/src/release-pr.ts
@@ -152,7 +152,8 @@ export class ReleasePR {
       sha,
       updates,
       title,
-      body
+      body,
+      labels: this.labels
     });
     await this.gh.addLabels(pr, this.labels);
     await this.closeStaleReleasePRs(pr);

--- a/system-test/github.ts
+++ b/system-test/github.ts
@@ -125,7 +125,8 @@ describe('GitHub', () => {
               version: '1.3.0',
               title: 'version 1.3.0',
               body: 'my PR body',
-              updates: []
+              updates: [],
+              labels: []
             })
             .catch(err => {
               nbr.nockDone();


### PR DESCRIPTION
Now looks for an existing PR with the same ref before creating a new PR.

fixes: #141, #128