### PR TITLE
chore: remove nodejs-repo-tools

### DIFF
--- a/__snapshots__/samples-package-json.js
+++ b/__snapshots__/samples-package-json.js
@@ -16,7 +16,6 @@ exports['SamplesPackageJson updateContent updates package version in dependencie
     "@google-cloud/firestore": "^14.0.0"
   },
   "devDependencies": {
-    "@google-cloud/nodejs-repo-tools": "^3.0.0",
     "mocha": "^6.0.0"
   }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "release-please",
-  "version": "1.6.0",
+  "version": "1.6.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/test/updaters/fixtures/samples-package.json
+++ b/test/updaters/fixtures/samples-package.json
@@ -15,7 +15,6 @@
     "@google-cloud/firestore": "^1.3.0"
   },
   "devDependencies": {
-    "@google-cloud/nodejs-repo-tools": "^3.0.0",
     "mocha": "^6.0.0"
   }
 }


### PR DESCRIPTION
We don't really use it anymore, so I'm trying to eliminate all traces.