### PR TITLE
feat!: update GitHub action to run on PR rather than commit

### DIFF
--- a/.github/action/release-please/Dockerfile
+++ b/.github/action/release-please/Dockerfile
@@ -25,7 +25,7 @@ LABEL "com.github.actions.description"="Automatic releases with conventional com
 LABEL "com.github.actions.icon"="book-open"
 LABEL "com.github.actions.color"="green"
 
-RUN npm i release-please@1.6.1 json -g
+RUN npm i release-please@2.0.0 json -g
 COPY entrypoint.sh /
 
 ENTRYPOINT ["/entrypoint.sh"]

--- a/.github/action/release-please/entrypoint.sh
+++ b/.github/action/release-please/entrypoint.sh
@@ -15,8 +15,12 @@
 
 set -e
 
-export COMMAND=${RELEASE_PLEASE_COMMAND:-candidate-issue}
+export COMMAND=${RELEASE_PLEASE_COMMAND:-release-pr}
+export ACTION==$(json "$GITHUB_EVENT_PATH" action)
+export MERGED=$(json "$GITHUB_EVENT_PATH" pull_reuest.merged)
 
-release-please $COMMAND --token=$GITHUB_TOKEN \
-  --repo-url="git@github.com:$GITHUB_REPOSITORY.git" \
-  --package-name=$PACKAGE_NAME
+if [[ "$ACTION" = "closed" ]] && [[ "$MERGED" == "true" ]]; then
+  release-please $COMMAND --token=$GITHUB_TOKEN \
+    --repo-url="git@github.com:$GITHUB_REPOSITORY.git" \
+    --package-name=$PACKAGE_NAME
+fi

--- a/src/bin/release-please.ts
+++ b/src/bin/release-please.ts
@@ -100,7 +100,7 @@ const argv = yargs
         )
       );
       console.info(`workflow "Groom Release PR" {
-  on = "push"
+  on = "pull_request"
   resolves = ["release-pr"]
 }
 
@@ -114,7 +114,7 @@ action "release-pr" {
 }
 
 workflow "GitHub Release" {
-  on = "push"
+  on = "pull_request"
   resolves = ["github-release"]
 }
 

--- a/src/github.ts
+++ b/src/github.ts
@@ -653,20 +653,30 @@ export class GitHub {
   }
 
   async closePR(prNumber: number) {
-    await this.request(`PATCH /repos/:owner/:repo/pulls/:pull_number${this.proxyKey ? `?key=${this.proxyKey}` : ''}`, {
-      owner: this.owner,
-      repo: this.repo,
-      pull_number: prNumber,
-      state: 'closed',
-    });
+    await this.request(
+      `PATCH /repos/:owner/:repo/pulls/:pull_number${
+        this.proxyKey ? `?key=${this.proxyKey}` : ''
+      }`,
+      {
+        owner: this.owner,
+        repo: this.repo,
+        pull_number: prNumber,
+        state: 'closed',
+      }
+    );
   }
 
   async getFileContents(path: string): Promise<GitHubFileContents> {
-    const resp = await this.request(`GET /repos/:owner/:repo/contents/:path${this.proxyKey ? `?key=${this.proxyKey}` : ''}`, {
-      owner: this.owner,
-      repo: this.repo,
-      path,
-    });
+    const resp = await this.request(
+      `GET /repos/:owner/:repo/contents/:path${
+        this.proxyKey ? `?key=${this.proxyKey}` : ''
+      }`,
+      {
+        owner: this.owner,
+        repo: this.repo,
+        path,
+      }
+    );
     return {
       parsedContent: Buffer.from(resp.data.content, 'base64').toString('utf8'),
       content: resp.data.content,
@@ -676,14 +686,19 @@ export class GitHub {
 
   async createRelease(version: string, sha: string, releaseNotes: string) {
     checkpoint(`creating release ${version}`, CheckpointType.Success);
-    await this.request(`POST /repos/:owner/:repo/releases${this.proxyKey ? `?key=${this.proxyKey}` : ''}`, {
-      owner: this.owner,
-      repo: this.repo,
-      tag_name: version,
-      target_commitish: sha,
-      body: releaseNotes,
-      name: version,
-    });
+    await this.request(
+      `POST /repos/:owner/:repo/releases${
+        this.proxyKey ? `?key=${this.proxyKey}` : ''
+      }`,
+      {
+        owner: this.owner,
+        repo: this.repo,
+        tag_name: version,
+        target_commitish: sha,
+        body: releaseNotes,
+        name: version,
+      }
+    );
   }
 
   async removeLabels(labels: string[], prNumber: number) {
@@ -696,7 +711,9 @@ export class GitHub {
         CheckpointType.Success
       );
       await this.request(
-        `DELETE /repos/:owner/:repo/issues/:issue_number/labels/:name${this.proxyKey ? `?key=${this.proxyKey}` : ''}`,
+        `DELETE /repos/:owner/:repo/issues/:issue_number/labels/:name${
+          this.proxyKey ? `?key=${this.proxyKey}` : ''
+        }`,
         {
           owner: this.owner,
           repo: this.repo,


### PR DESCRIPTION
Running the action on every commit seems to kick off too many actions, and leads to race conditions. Let's instead kick off the action when a PR is merged.