### PR TITLE
feat: avoid updating release PR if no additional changes

### DIFF
--- a/__snapshots__/release-pr.js
+++ b/__snapshots__/release-pr.js
@@ -61,4 +61,5 @@ exports['GitHub Yoshi PHP Mono-Repo generates CHANGELOG and aborts if duplicate 
 * Add Web Security Center Client ([#1961](https://www.github.com/googleapis/release-please/issues/1961)) ([fa5761e](https://www.github.com/googleapis/release-please/commit/fa5761e))
 
 ----
+This PR was generated with [Release Please](https://github.com/googleapis/release-please).
 `

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "release-please",
-  "version": "1.6.1",
+  "version": "2.0.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/src/github.ts
+++ b/src/github.ts
@@ -471,6 +471,18 @@ export class GitHub {
           }
         );
 
+        // short-circuit of there have been no changes to the
+        // pull-request body.
+        if (openReleasePR && openReleasePR.body === options.body) {
+          checkpoint(
+            `PR https://github.com/${this.owner}/${this.repo}/pull/${
+              openReleasePR.number
+            } remained the same`,
+            CheckpointType.Failure
+          );
+          return openReleasePR.number;
+        }
+
         await this.request(
           `PATCH /repos/:owner/:repo/git/refs/:ref${
             this.proxyKey ? `?key=${this.proxyKey}` : ''

--- a/src/github.ts
+++ b/src/github.ts
@@ -480,7 +480,7 @@ export class GitHub {
             } remained the same`,
             CheckpointType.Failure
           );
-          return openReleasePR.number;
+          return -1;
         }
 
         await this.request(

--- a/src/release-pr.ts
+++ b/src/release-pr.ts
@@ -171,7 +171,7 @@ export class ReleasePR {
 
     await this.openPR(
       commits[0].sha,
-      changelogEntry,
+      `${changelogEntry}\n---\n`,
       updates,
       candidate.version
     );
@@ -341,7 +341,7 @@ export class ReleasePR {
     version: string
   ) {
     const title = `chore: release ${version}`;
-    const body = `:robot: I have created a release \\*beep\\* \\*boop\\* \n---\n${changelogEntry}`;
+    const body = `:robot: I have created a release \\*beep\\* \\*boop\\* \n---\n${changelogEntry}\nThis PR was generated with [Release Please](https://github.com/googleapis/release-please).`;
     const pr: number = await this.gh.openPR({
       branch: `release-v${version}`,
       version,

--- a/src/release-pr.ts
+++ b/src/release-pr.ts
@@ -351,8 +351,11 @@ export class ReleasePR {
       body,
       labels: this.labels,
     });
-    await this.gh.addLabels(pr, this.labels);
-    await this.closeStaleReleasePRs(pr);
+    // a return of -1 indicates that PR was not updated.
+    if (pr > 0) {
+      await this.gh.addLabels(pr, this.labels);
+      await this.closeStaleReleasePRs(pr);
+    }
   }
 }
 


### PR DESCRIPTION
currently, whenever we land a PR we update a release PR, even if there have been no additional changes.

fixes #158