### PR TITLE
feat: adds additional updaters/logic for PHP mono-repo

### DIFF
--- a/__snapshots__/changelog.js
+++ b/__snapshots__/changelog.js
@@ -80,10 +80,6 @@ exports['ChangelogUpdater updateContent inserts content at appropriate location 
 exports['ChangelogUpdater updateContent populates a new CHANGELOG if none exists 1'] = `
 # Changelog
 
-[npm history][1]
-
-[1]: https://www.npmjs.com/package/foo-package?activeTab=versions
-
 ## 2.0.0
 
 * added a new foo to bar.

--- a/__snapshots__/github-release.js
+++ b/__snapshots__/github-release.js
@@ -64,3 +64,37 @@ exports['GitHubRelease extractLatestReleaseNotes handles CHANGELOG with old form
 - build: use per-repo npm publish token ([#216](https://github.com/googleapis/nodejs-language/pull/216))
 
 `
+
+exports['GitHubRelease extractLatestReleaseNotes php-yoshi extracts appropriate release notes, when multiple packages updated 1'] = `
+
+<details><summary>google/cloud-bigquerydatatransfer 0.11.1</summary>
+
+
+
+### Bug Fixes
+
+* Fix BigQueryDataTransfer smoke test ([#2046](https://www.github.com/googleapis/google-cloud-php/issues/2046)) ([98c7c9e](https://www.github.com/googleapis/google-cloud-php/commit/98c7c9e))
+
+</details>
+
+<details><summary>google/cloud-dlp 0.20.0</summary>
+
+
+
+### Features
+
+* Add support for avro ([#2050](https://www.github.com/googleapis/google-cloud-php/issues/2050)) ([4137f3d](https://www.github.com/googleapis/google-cloud-php/commit/4137f3d))
+
+</details>
+
+<details><summary>google/cloud-kms 1.4.0</summary>
+
+
+
+### Features
+
+* Update KMS client. ([#2045](https://www.github.com/googleapis/google-cloud-php/issues/2045)) ([c96da32](https://www.github.com/googleapis/google-cloud-php/commit/c96da32))
+
+</details>
+
+`

--- a/__snapshots__/release-pr.js
+++ b/__snapshots__/release-pr.js
@@ -1,9 +1,9 @@
 exports['GitHub Yoshi PHP Mono-Repo generates CHANGELOG and aborts if duplicate 1'] = `
 :robot: I have created a release \\*beep\\* \\*boop\\* 
 ---
-## 0.21.0 release highlights:
+## 0.21.0
 
-## AutoMl
+<details><summary>automl 1.8.4</summary>
 
 ### 1.8.4 
 
@@ -12,9 +12,9 @@ exports['GitHub Yoshi PHP Mono-Repo generates CHANGELOG and aborts if duplicate 
 
 * correctly label as beta ([#1963](https://www.github.com/googleapis/release-please/issues/1963)) ([52f4fbf](https://www.github.com/googleapis/release-please/commit/52f4fbf))
 
-----
+</details>
 
-## Datastore
+<details><summary>datastore 2.0.1</summary>
 
 ### 2.0.1 
 
@@ -23,9 +23,9 @@ exports['GitHub Yoshi PHP Mono-Repo generates CHANGELOG and aborts if duplicate 
 
 * Assorted minor fixes for Cloud Datastore client ([#1964](https://www.github.com/googleapis/release-please/issues/1964)) ([269cf92](https://www.github.com/googleapis/release-please/commit/269cf92))
 
-----
+</details>
 
-## PubSub
+<details><summary>pubsub 1.0.2</summary>
 
 ### 1.0.2 
 
@@ -34,9 +34,9 @@ exports['GitHub Yoshi PHP Mono-Repo generates CHANGELOG and aborts if duplicate 
 
 * Update PubSub timeouts. ([#1967](https://www.github.com/googleapis/release-please/issues/1967)) ([0a84771](https://www.github.com/googleapis/release-please/commit/0a84771))
 
-----
+</details>
 
-## Speech
+<details><summary>speech 2.0.0</summary>
 
 ## 2.0.0 
 
@@ -49,9 +49,9 @@ exports['GitHub Yoshi PHP Mono-Repo generates CHANGELOG and aborts if duplicate 
 
 * move speech from alpha -> beta ([#1962](https://www.github.com/googleapis/release-please/issues/1962)) ([8db7f3b](https://www.github.com/googleapis/release-please/commit/8db7f3b))
 
-----
+</details>
 
-## WebSecurityScanner
+<details><summary>websecurityscanner 0.9.0</summary>
 
 ## 0.9.0 
 
@@ -60,6 +60,7 @@ exports['GitHub Yoshi PHP Mono-Repo generates CHANGELOG and aborts if duplicate 
 
 * Add Web Security Center Client ([#1961](https://www.github.com/googleapis/release-please/issues/1961)) ([fa5761e](https://www.github.com/googleapis/release-please/commit/fa5761e))
 
-----
+</details>
+
 This PR was generated with [Release Please](https://github.com/googleapis/release-please).
 `

--- a/__snapshots__/release-pr.js
+++ b/__snapshots__/release-pr.js
@@ -5,7 +5,6 @@ exports['GitHub Yoshi PHP Mono-Repo generates CHANGELOG and aborts if duplicate 
 
 <details><summary>automl 1.8.4</summary>
 
-### 1.8.4 
 
 
 ### Bug Fixes
@@ -16,7 +15,6 @@ exports['GitHub Yoshi PHP Mono-Repo generates CHANGELOG and aborts if duplicate 
 
 <details><summary>datastore 2.0.1</summary>
 
-### 2.0.1 
 
 
 ### Bug Fixes
@@ -27,7 +25,6 @@ exports['GitHub Yoshi PHP Mono-Repo generates CHANGELOG and aborts if duplicate 
 
 <details><summary>pubsub 1.0.2</summary>
 
-### 1.0.2 
 
 
 ### Bug Fixes
@@ -38,7 +35,6 @@ exports['GitHub Yoshi PHP Mono-Repo generates CHANGELOG and aborts if duplicate 
 
 <details><summary>speech 2.0.0</summary>
 
-## 2.0.0 
 
 
 ### ⚠ BREAKING CHANGES
@@ -53,7 +49,6 @@ exports['GitHub Yoshi PHP Mono-Repo generates CHANGELOG and aborts if duplicate 
 
 <details><summary>websecurityscanner 0.9.0</summary>
 
-## 0.9.0 
 
 
 ### Features

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "release-please",
-  "version": "2.0.1",
+  "version": "2.1.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/src/bin/release-please.ts
+++ b/src/bin/release-please.ts
@@ -70,6 +70,10 @@ const argv = yargs
     'create a GitHub release from a release PR',
     (yargs: YargsOptionsBuilder) => {
       yargs
+        .option('package-name', {
+          describe: 'name of package release is being minted for',
+          demand: true,
+        })
         .option('repo-url', {
           describe: 'GitHub URL to generate release for',
           demand: true,

--- a/src/github-release.ts
+++ b/src/github-release.ts
@@ -31,6 +31,7 @@ const parseGithubRepoUrl = require('parse-github-repo-url');
 export interface GitHubReleaseOptions {
   label: string;
   repoUrl: string;
+  packageName: string;
   token: string;
   apiUrl: string;
   proxyKey?: string;
@@ -42,6 +43,7 @@ export class GitHubRelease {
   gh: GitHub;
   labels: string[];
   repoUrl: string;
+  packageName: string;
   token?: string;
   proxyKey?: string;
 
@@ -51,6 +53,7 @@ export class GitHubRelease {
     this.labels = options.label.split(',');
     this.repoUrl = options.repoUrl;
     this.token = options.token;
+    this.packageName = options.packageName;
 
     this.changelogPath = 'CHANGELOG.md';
 
@@ -82,6 +85,7 @@ export class GitHubRelease {
       );
 
       await this.gh.createRelease(
+        this.packageName,
         gitHubReleasePR.version,
         gitHubReleasePR.sha,
         latestReleaseNotes

--- a/src/github.ts
+++ b/src/github.ts
@@ -696,7 +696,12 @@ export class GitHub {
     };
   }
 
-  async createRelease(version: string, sha: string, releaseNotes: string) {
+  async createRelease(
+    packageName: string,
+    version: string,
+    sha: string,
+    releaseNotes: string
+  ) {
     checkpoint(`creating release ${version}`, CheckpointType.Success);
     await this.request(
       `POST /repos/:owner/:repo/releases${
@@ -708,7 +713,7 @@ export class GitHub {
         tag_name: version,
         target_commitish: sha,
         body: releaseNotes,
-        name: version,
+        name: `${packageName} ${version}`,
       }
     );
   }

--- a/src/github.ts
+++ b/src/github.ts
@@ -608,7 +608,7 @@ export class GitHub {
             owner: this.owner,
             repo: this.repo,
             path: update.path,
-            message: `updated ${update.path}`,
+            message: `updated ${update.path} [ci skip]`,
             content: Buffer.from(updatedContent, 'utf8').toString('base64'),
             sha: content.data.sha,
             branch,
@@ -623,7 +623,7 @@ export class GitHub {
             owner: this.owner,
             repo: this.repo,
             path: update.path,
-            message: `created ${update.path}`,
+            message: `created ${update.path} [ci skip]`,
             content: Buffer.from(updatedContent, 'utf8').toString('base64'),
             branch,
           }

--- a/src/release-pr.ts
+++ b/src/release-pr.ts
@@ -426,7 +426,7 @@ export class ReleasePR {
     updates: Update[],
     version: string
   ) {
-    const title = `[DO NOT LAND] chore: release ${version}`;
+    const title = `chore: release ${version}`;
     const body = `:robot: I have created a release \\*beep\\* \\*boop\\* \n---\n${changelogEntry}\nThis PR was generated with [Release Please](https://github.com/googleapis/release-please).`;
     const pr: number = await this.gh.openPR({
       branch: `release-v${version}`,

--- a/src/release-pr.ts
+++ b/src/release-pr.ts
@@ -294,7 +294,7 @@ export class ReleasePR {
           );
           versionUpdates[meta.name] = candidate;
 
-          changelogEntry = updateChangelogEntry(
+          changelogEntry = updatePHPChangelogEntry(
             `${meta.name} ${candidate}`,
             changelogEntry,
             await cc.generateChangelogEntry({ version: candidate })
@@ -449,11 +449,19 @@ function changelogEmpty(changelogEntry: string) {
   return changelogEntry.split('\n').length === 1;
 }
 
-function updateChangelogEntry(
+function updatePHPChangelogEntry(
   pkgKey: string,
   changelogEntry: string,
   entryUpdate: string
 ) {
+  {
+    // Remove the first line of the entry, in favor of <summary>.
+    // This also allows us to use the same regex for extracting release
+    // notes (since the string "## v0.0.0" doesn't show up multiple times).
+    const entryUpdateSplit: string[] = entryUpdate.split(/\r?\n/);
+    entryUpdateSplit.shift();
+    entryUpdate = entryUpdateSplit.join('\n');
+  }
   return `${changelogEntry}
 
 <details><summary>${pkgKey}</summary>

--- a/src/release-pr.ts
+++ b/src/release-pr.ts
@@ -208,7 +208,7 @@ export class ReleasePR {
     // updated since our last release -- the set of string keys
     // is sorted to ensure consistency in the CHANGELOG.
     const updates: Update[] = [];
-    let changelogEntry = `## ${candidate.version} release highlights:`;
+    let changelogEntry = `## ${candidate.version}`;
 
     changelogEntry = await this.releaseAllPHPLibraries(
       commits,
@@ -295,7 +295,7 @@ export class ReleasePR {
           versionUpdates[meta.name] = candidate;
 
           changelogEntry = updateChangelogEntry(
-            meta.name,
+            `${meta.name} ${candidate}`,
             changelogEntry,
             await cc.generateChangelogEntry({ version: candidate })
           );
@@ -427,7 +427,7 @@ export class ReleasePR {
     version: string
   ) {
     const title = `chore: release ${version}`;
-    const body = `:robot: I have created a release \\*beep\\* \\*boop\\* \n---\n${changelogEntry}\nThis PR was generated with [Release Please](https://github.com/googleapis/release-please).`;
+    const body = `:robot: I have created a release \\*beep\\* \\*boop\\* \n---\n${changelogEntry}\n\nThis PR was generated with [Release Please](https://github.com/googleapis/release-please).`;
     const pr: number = await this.gh.openPR({
       branch: `release-v${version}`,
       version,
@@ -456,9 +456,9 @@ function updateChangelogEntry(
 ) {
   return `${changelogEntry}
 
-## ${pkgKey}
+<details><summary>${pkgKey}</summary>
 
 ${entryUpdate}
 
-----`;
+</details>`;
 }

--- a/src/updaters/changelog.ts
+++ b/src/updaters/changelog.ts
@@ -22,6 +22,7 @@ export class Changelog implements Update {
   path: string;
   changelogEntry: string;
   version: string;
+  versions?: { [key: string]: string };
   packageName: string;
   create: boolean;
   contents?: GitHubFileContents;
@@ -52,7 +53,6 @@ export class Changelog implements Update {
   private header() {
     return `\
 # Changelog
-
 `;
   }
 }

--- a/src/updaters/changelog.ts
+++ b/src/updaters/changelog.ts
@@ -53,9 +53,6 @@ export class Changelog implements Update {
     return `\
 # Changelog
 
-[npm history][1]
-
-[1]: https://www.npmjs.com/package/${this.packageName}?activeTab=versions
 `;
   }
 }

--- a/src/updaters/package-json.ts
+++ b/src/updaters/package-json.ts
@@ -22,6 +22,7 @@ export class PackageJson implements Update {
   path: string;
   changelogEntry: string;
   version: string;
+  versions?: { [key: string]: string };
   packageName: string;
   create: boolean;
   contents?: GitHubFileContents;

--- a/src/updaters/php-class-versions.ts
+++ b/src/updaters/php-class-versions.ts
@@ -1,0 +1,44 @@
+/**
+ * Copyright 2019 Google LLC. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { GitHubFileContents } from '../github';
+
+import { checkpoint, CheckpointType } from '../util/checkpoint';
+import { Update, UpdateOptions } from './update';
+
+export class PHPClassVersions implements Update {
+  path: string;
+  changelogEntry: string;
+  version: string;
+  packageName: string;
+  create: boolean;
+  contents?: GitHubFileContents;
+
+  constructor(options: UpdateOptions) {
+    this.create = false;
+    this.path = options.path;
+    this.changelogEntry = options.changelogEntry;
+    this.version = options.version;
+    this.packageName = options.packageName;
+    this.contents = options.contents;
+  }
+  updateContent(content: string): string {
+    return content.replace(
+      /const VERSION = '[0-9]+\.[0-9]+\.[0-9]+'/,
+      `const VERSION = '${this.version}'`
+    );
+  }
+}

--- a/src/updaters/php-client-version.ts
+++ b/src/updaters/php-client-version.ts
@@ -19,10 +19,11 @@ import { GitHubFileContents } from '../github';
 import { checkpoint, CheckpointType } from '../util/checkpoint';
 import { Update, UpdateOptions } from './update';
 
-export class PHPClassVersions implements Update {
+export class PHPClientVersion implements Update {
   path: string;
   changelogEntry: string;
   version: string;
+  versions?: { [key: string]: string };
   packageName: string;
   create: boolean;
   contents?: GitHubFileContents;

--- a/src/updaters/php-manifest.ts
+++ b/src/updaters/php-manifest.ts
@@ -14,12 +14,16 @@
  * limitations under the License.
  */
 
-import { GitHubFileContents } from '../github';
-
 import { checkpoint, CheckpointType } from '../util/checkpoint';
 import { Update, UpdateOptions } from './update';
+import { GitHubFileContents } from '../github';
 
-export class Version implements Update {
+interface ManifestModule {
+  name: string;
+  versions: string[];
+}
+
+export class PHPManifest implements Update {
   path: string;
   changelogEntry: string;
   version: string;
@@ -33,10 +37,35 @@ export class Version implements Update {
     this.path = options.path;
     this.changelogEntry = options.changelogEntry;
     this.version = options.version;
+    this.versions = options.versions;
     this.packageName = options.packageName;
-    this.contents = options.contents;
   }
   updateContent(content: string): string {
-    return `${this.version}`;
+    if (!this.versions || Object.keys(this.versions).length === 0) {
+      checkpoint(
+        `no updates necessary for ${this.path}`,
+        CheckpointType.Failure
+      );
+      return content;
+    }
+    const parsed = JSON.parse(content);
+    Object.keys(this.versions).forEach((key: string) => {
+      if (this.versions) {
+        const version: string = this.versions[key]
+          ? this.versions[key]
+          : '1.0.0';
+        parsed.modules.forEach((module: ManifestModule) => {
+          if (module.name === key) {
+            checkpoint(
+              `adding ${key}@${version} to manifest`,
+              CheckpointType.Success
+            );
+            module.versions.unshift(version);
+          }
+        });
+      }
+    });
+
+    return JSON.stringify(parsed, null, 4) + '\n';
   }
 }

--- a/src/updaters/root-composer.ts
+++ b/src/updaters/root-composer.ts
@@ -14,12 +14,11 @@
  * limitations under the License.
  */
 
-import { GitHubFileContents } from '../github';
-
 import { checkpoint, CheckpointType } from '../util/checkpoint';
 import { Update, UpdateOptions } from './update';
+import { GitHubFileContents } from '../github';
 
-export class Version implements Update {
+export class RootComposer implements Update {
   path: string;
   changelogEntry: string;
   version: string;
@@ -33,10 +32,31 @@ export class Version implements Update {
     this.path = options.path;
     this.changelogEntry = options.changelogEntry;
     this.version = options.version;
+    this.versions = options.versions;
     this.packageName = options.packageName;
-    this.contents = options.contents;
   }
   updateContent(content: string): string {
-    return `${this.version}`;
+    if (!this.versions || Object.keys(this.versions).length === 0) {
+      checkpoint(
+        `no updates necessary for ${this.path}`,
+        CheckpointType.Failure
+      );
+      return content;
+    }
+    const parsed = JSON.parse(content);
+    Object.keys(this.versions).forEach((key: string) => {
+      if (this.versions) {
+        const version: string = this.versions[key]
+          ? this.versions[key]
+          : '1.0.0';
+        checkpoint(
+          `updating ${key} from ${parsed.replace[key]} to ${version}`,
+          CheckpointType.Success
+        );
+        parsed.replace[key] = version;
+      }
+    });
+
+    return JSON.stringify(parsed, null, 4) + '\n';
   }
 }

--- a/src/updaters/samples-package-json.ts
+++ b/src/updaters/samples-package-json.ts
@@ -22,6 +22,7 @@ export class SamplesPackageJson implements Update {
   path: string;
   changelogEntry: string;
   version: string;
+  versions?: { [key: string]: string };
   packageName: string;
   create: boolean;
   contents?: GitHubFileContents;

--- a/src/updaters/update.ts
+++ b/src/updaters/update.ts
@@ -21,6 +21,7 @@ export interface UpdateOptions {
   packageName: string;
   path: string;
   version: string;
+  versions?: { [key: string]: string };
   contents?: GitHubFileContents;
 }
 
@@ -30,6 +31,7 @@ export interface Update {
   path: string;
   packageName: string;
   version: string;
+  versions?: { [key: string]: string };
   contents?: GitHubFileContents;
   updateContent(content: string | undefined): string;
 }

--- a/test/fixtures/CHANGELOG-php-yoshi.md
+++ b/test/fixtures/CHANGELOG-php-yoshi.md
@@ -1,0 +1,65 @@
+# Changelog
+
+## 0.105.0
+
+<details><summary>google/cloud-bigquerydatatransfer 0.11.1</summary>
+
+
+
+### Bug Fixes
+
+* Fix BigQueryDataTransfer smoke test ([#2046](https://www.github.com/googleapis/google-cloud-php/issues/2046)) ([98c7c9e](https://www.github.com/googleapis/google-cloud-php/commit/98c7c9e))
+
+</details>
+
+<details><summary>google/cloud-dlp 0.20.0</summary>
+
+
+
+### Features
+
+* Add support for avro ([#2050](https://www.github.com/googleapis/google-cloud-php/issues/2050)) ([4137f3d](https://www.github.com/googleapis/google-cloud-php/commit/4137f3d))
+
+</details>
+
+<details><summary>google/cloud-kms 1.4.0</summary>
+
+
+
+### Features
+
+* Update KMS client. ([#2045](https://www.github.com/googleapis/google-cloud-php/issues/2045)) ([c96da32](https://www.github.com/googleapis/google-cloud-php/commit/c96da32))
+
+</details>
+
+## 0.104.0
+
+<details><summary>google/cloud-bigquerydatatransfer 0.10.1</summary>
+
+
+
+### Bug Fixes
+
+* Fix BigQueryDataTransfer smoke test ([#2046](https://www.github.com/googleapis/google-cloud-php/issues/2046)) ([98c7c9e](https://www.github.com/googleapis/google-cloud-php/commit/98c7c9e))
+
+</details>
+
+<details><summary>google/cloud-dlp 0.19.0</summary>
+
+
+
+### Features
+
+* Add support for avro ([#2050](https://www.github.com/googleapis/google-cloud-php/issues/2050)) ([4137f3d](https://www.github.com/googleapis/google-cloud-php/commit/4137f3d))
+
+</details>
+
+<details><summary>google/cloud-kms 1.3.0</summary>
+
+
+
+### Features
+
+* Update KMS client. ([#2045](https://www.github.com/googleapis/google-cloud-php/issues/2045)) ([c96da32](https://www.github.com/googleapis/google-cloud-php/commit/c96da32))
+
+</details>

--- a/test/github-release.ts
+++ b/test/github-release.ts
@@ -72,5 +72,19 @@ describe('GitHubRelease', () => {
       );
       snapshot(latestReleaseNotes);
     });
+
+    describe('php-yoshi', () => {
+      it('extracts appropriate release notes, when multiple packages updated', () => {
+        const changelogContent = readFileSync(
+          resolve(fixturesPath, './CHANGELOG-php-yoshi.md'),
+          'utf8'
+        ).replace(/\r\n/g, '\n');
+        const latestReleaseNotes = GitHubRelease.extractLatestReleaseNotes(
+          changelogContent,
+          'v0.105.0'
+        );
+        snapshot(latestReleaseNotes);
+      });
+    });
   });
 });

--- a/test/release-pr.ts
+++ b/test/release-pr.ts
@@ -78,9 +78,13 @@ describe('GitHub', () => {
           content: Buffer.from('1.8.3', 'utf8').toString('base64'),
           sha: 'abc123',
         })
-        .get('/repos/googleapis/release-please/contents/Datastore/composer.json')
+        .get(
+          '/repos/googleapis/release-please/contents/Datastore/composer.json'
+        )
         .reply(200, {
-          content: Buffer.from('{"name": "datastore"}', 'utf8').toString('base64'),
+          content: Buffer.from('{"name": "datastore"}', 'utf8').toString(
+            'base64'
+          ),
           sha: 'abc123',
         })
         .get('/repos/googleapis/release-please/contents/Datastore/VERSION')
@@ -108,9 +112,14 @@ describe('GitHub', () => {
           content: Buffer.from('1.0.0', 'utf8').toString('base64'),
           sha: 'abc123',
         })
-        .get('/repos/googleapis/release-please/contents/WebSecurityScanner/composer.json')
+        .get(
+          '/repos/googleapis/release-please/contents/WebSecurityScanner/composer.json'
+        )
         .reply(200, {
-          content: Buffer.from('{"name": "websecurityscanner"}', 'utf8').toString('base64'),
+          content: Buffer.from(
+            '{"name": "websecurityscanner"}',
+            'utf8'
+          ).toString('base64'),
           sha: 'abc123',
         })
         .get(
@@ -125,18 +134,28 @@ describe('GitHub', () => {
         // overarching meta-information files that need updating.
         .get('/repos/googleapis/release-please/contents/docs/VERSION')
         .reply(404)
-        .get('/repos/googleapis/release-please/contents/CHANGELOG.md?ref=refs%2Fheads%2Frelease-v0.21.0')
+        .get(
+          '/repos/googleapis/release-please/contents/CHANGELOG.md?ref=refs%2Fheads%2Frelease-v0.21.0'
+        )
         .reply(404)
-        .get('/repos/googleapis/release-please/contents/src/Version.php?ref=refs%2Fheads%2Frelease-v0.21.0')
+        .get(
+          '/repos/googleapis/release-please/contents/src/Version.php?ref=refs%2Fheads%2Frelease-v0.21.0'
+        )
         .reply(404)
-        .get('/repos/googleapis/release-please/contents/src/ServiceBuilder.php?ref=refs%2Fheads%2Frelease-v0.21.0')
+        .get(
+          '/repos/googleapis/release-please/contents/src/ServiceBuilder.php?ref=refs%2Fheads%2Frelease-v0.21.0'
+        )
         .reply(404)
-        .get('/repos/googleapis/release-please/contents/composer.json?ref=refs%2Fheads%2Frelease-v0.21.0')
+        .get(
+          '/repos/googleapis/release-please/contents/composer.json?ref=refs%2Fheads%2Frelease-v0.21.0'
+        )
         .reply(200, {
           content: Buffer.from('{"replace": {}}', 'utf8').toString('base64'),
           sha: 'abc123',
         })
-        .get('/repos/googleapis/release-please/contents/docs/manifest.json?ref=refs%2Fheads%2Frelease-v0.21.0')
+        .get(
+          '/repos/googleapis/release-please/contents/docs/manifest.json?ref=refs%2Fheads%2Frelease-v0.21.0'
+        )
         .reply(200, {
           content: Buffer.from('{"modules": []}', 'utf8').toString('base64'),
           sha: 'abc123',

--- a/test/release-pr.ts
+++ b/test/release-pr.ts
@@ -67,10 +67,20 @@ describe('GitHub', () => {
         .reply(200, {
           data: graphql,
         })
-        // fetch teh current version of each library.
+        // fetch the current version of each library.
+        .get('/repos/googleapis/release-please/contents/AutoMl/composer.json')
+        .reply(200, {
+          content: Buffer.from('{"name": "automl"}', 'utf8').toString('base64'),
+          sha: 'abc123',
+        })
         .get('/repos/googleapis/release-please/contents/AutoMl/VERSION')
         .reply(200, {
           content: Buffer.from('1.8.3', 'utf8').toString('base64'),
+          sha: 'abc123',
+        })
+        .get('/repos/googleapis/release-please/contents/Datastore/composer.json')
+        .reply(200, {
+          content: Buffer.from('{"name": "datastore"}', 'utf8').toString('base64'),
           sha: 'abc123',
         })
         .get('/repos/googleapis/release-please/contents/Datastore/VERSION')
@@ -78,14 +88,29 @@ describe('GitHub', () => {
           content: Buffer.from('2.0.0', 'utf8').toString('base64'),
           sha: 'abc123',
         })
+        .get('/repos/googleapis/release-please/contents/PubSub/composer.json')
+        .reply(200, {
+          content: Buffer.from('{"name": "pubsub"}', 'utf8').toString('base64'),
+          sha: 'abc123',
+        })
         .get('/repos/googleapis/release-please/contents/PubSub/VERSION')
         .reply(200, {
           content: Buffer.from('1.0.1', 'utf8').toString('base64'),
           sha: 'abc123',
         })
+        .get('/repos/googleapis/release-please/contents/Speech/composer.json')
+        .reply(200, {
+          content: Buffer.from('{"name": "speech"}', 'utf8').toString('base64'),
+          sha: 'abc123',
+        })
         .get('/repos/googleapis/release-please/contents/Speech/VERSION')
         .reply(200, {
           content: Buffer.from('1.0.0', 'utf8').toString('base64'),
+          sha: 'abc123',
+        })
+        .get('/repos/googleapis/release-please/contents/WebSecurityScanner/composer.json')
+        .reply(200, {
+          content: Buffer.from('{"name": "websecurityscanner"}', 'utf8').toString('base64'),
           sha: 'abc123',
         })
         .get(
@@ -95,8 +120,27 @@ describe('GitHub', () => {
           content: Buffer.from('0.8.0', 'utf8').toString('base64'),
           sha: 'abc123',
         })
+        // besides the composer.json and VERSION files that need to be
+        // processed for each individual module, there are several
+        // overarching meta-information files that need updating.
         .get('/repos/googleapis/release-please/contents/docs/VERSION')
         .reply(404)
+        .get('/repos/googleapis/release-please/contents/CHANGELOG.md?ref=refs%2Fheads%2Frelease-v0.21.0')
+        .reply(404)
+        .get('/repos/googleapis/release-please/contents/src/Version.php?ref=refs%2Fheads%2Frelease-v0.21.0')
+        .reply(404)
+        .get('/repos/googleapis/release-please/contents/src/ServiceBuilder.php?ref=refs%2Fheads%2Frelease-v0.21.0')
+        .reply(404)
+        .get('/repos/googleapis/release-please/contents/composer.json?ref=refs%2Fheads%2Frelease-v0.21.0')
+        .reply(200, {
+          content: Buffer.from('{"replace": {}}', 'utf8').toString('base64'),
+          sha: 'abc123',
+        })
+        .get('/repos/googleapis/release-please/contents/docs/manifest.json?ref=refs%2Fheads%2Frelease-v0.21.0')
+        .reply(200, {
+          content: Buffer.from('{"modules": []}', 'utf8').toString('base64'),
+          sha: 'abc123',
+        })
         // we're on the home stretch I promise ...
         // fetch prior refs, to determine whether this is an update
         // to an existing branch or new PR.
@@ -118,6 +162,12 @@ describe('GitHub', () => {
           '/repos/googleapis/release-please/contents/WebSecurityScanner/VERSION'
         )
         .reply(200)
+        .put('/repos/googleapis/release-please/contents/composer.json')
+        .reply(200, [])
+        .put('/repos/googleapis/release-please/contents/docs/manifest.json')
+        .reply(200, [])
+        .put('/repos/googleapis/release-please/contents/CHANGELOG.md')
+        .reply(200, [])
         // actually open the darn PR, this is the exciting step,
         // so we snapshot it:
         .post(


### PR DESCRIPTION
## Additional Updaters

* PHPClientVersion: updates the `const version` in client libraries.
* PHPManifest: adds new version to array in manifest.
* RootComposer: adds updated version to root composer file.

## TODO

- [x] tests need to be updated.