### PR TITLE
feat: adding support for google-auth-library-java

### DIFF
--- a/__snapshots__/graphql-to-commits.js
+++ b/__snapshots__/graphql-to-commits.js
@@ -532,3 +532,510 @@ exports['graphqlToCommits converts raw graphql response into Commits object 1'] 
     }
   ]
 }
+
+exports['graphqlToCommits uses label for conventional commit prefix, if no prefix provided 1'] = {
+  "endCursor": "fcd1c890dc1526f4d62ceedad561f498195c8939 99",
+  "hasNextPage": true,
+  "commits": [
+    {
+      "sha": "fcd1c890dc1526f4d62ceedad561f498195c8939",
+      "message": "Refactor shared IAM-based signing (#292)\n\n* Extract IAM signing into its own class\r\n\r\n* Refactor into IamUtils package private class\r\n\r\n* Remove unnecessary class\r\n\r\n* Remove unused code\r\n\r\n* Cleanup imports\r\n\r\n* Fill out javadoc for IamUtils\r\n\r\n* Failing tests for impersonated credentials\r\n\r\n* Fix credentials used for signing\r\n\r\n* Fix providing delegates to signing request\r\n\r\n* Disallow null additionalFields, remove jsr305 annotation\r\n\r\n* Remove usued imports",
+      "files": []
+    },
+    {
+      "sha": "1f9663cf08ab1cf3b68d95dee4dc99b7c4aac373",
+      "message": "Update allowed header format (#301)\n\n* Update copyright format  \r\n\r\n@chingor13\r\n\r\n* Update java.header\r\n\r\n* add legacy copyright\r\n\r\n* remove spurious $",
+      "files": []
+    },
+    {
+      "sha": "3006009a2b1b2cb4bd5108c0f469c410759f3a6a",
+      "message": "Upgrade Guava to 28.0-android (#300)",
+      "files": []
+    },
+    {
+      "sha": "35abf13fa8acb3988aa086f3eb23f5ce1483cc5d",
+      "message": "fix: Fix declared dependencies from merge issue (#291)",
+      "files": []
+    },
+    {
+      "sha": "9b14268e2901dd4e82e20d0bec6f87ef4c37cc10",
+      "message": "Log warnings and deprecate AppEngineCredentials.getApplicationDefault (#288)\n\n* Log warnings and deprecate AppEngineCredentials.getApplicationDefault\r\n\r\nUsers should use GoogleCredentials.getApplicationDefault() if they want\r\nADC.\r\n\r\nADC will never return com.google.auth.appengine.AppEngineCredentials.\r\n\r\n* Add test for warning message\r\n\r\n* Catch the IOException from default credentials",
+      "files": []
+    },
+    {
+      "sha": "09e415ad348ace1e2c8912f7af8868f6cf11e574",
+      "message": "Adds CI test for mvn dependency:analyze and fixes missing deps (#289)\n\n* Add CI test for dependency:analyze\r\n\r\n* Remove unused dependencies\r\n\r\n* Fix path in dependency test file\r\n\r\n* Fix typo",
+      "files": []
+    },
+    {
+      "sha": "70767e3758aaaf4db25e316e3fb689be415a897f",
+      "message": "feat!: Implement ServiceAccountSigner for ImpersonatedCredentials (#279)\n\n* Add Signer for impersonatied credentials\r\n\r\n* add lint fixes\r\n\r\n* back to the future\r\n\r\n* Update oauth2_http/java/com/google/auth/oauth2/ImpersonatedCredentials.java\r\n\r\nCo-Authored-By: Jeff Ching <chingor@google.com>",
+      "files": []
+    },
+    {
+      "sha": "fcbc42656b393351f6d29b341cdafde25d3f7087",
+      "message": "Update dependency org.apache.maven.plugins:maven-javadoc-plugin to v3.1.1 (#287)",
+      "files": []
+    },
+    {
+      "sha": "19a9ba57e40c9f627c9efc29d460b7181c099635",
+      "message": "Update instructions for google-auth-library-appengine artifact (#278)\n\n* Update instructions for google-auth-library-appengine artifact\r\n\r\n* Fix AppEngine -> App Engine and Java 10 -> 11\r\n\r\n* GoogleCredentials -> Credentials in README example",
+      "files": []
+    },
+    {
+      "sha": "f212149e99d45fedcda525f418d5eefd0e6d75f1",
+      "message": "Bump next snapshot (#285)",
+      "files": []
+    },
+    {
+      "sha": "59edf251df08008e1f412968bd9103c9b441e81a",
+      "message": "Release v0.16.2 (#284)",
+      "files": []
+    },
+    {
+      "sha": "bb7d80d4b5fc90f50e99c1db41863bcd212678da",
+      "message": "Autorelease should actually autorelease",
+      "files": []
+    },
+    {
+      "sha": "c166c13e41866435ef3e0072afb4f6b2a20cbc59",
+      "message": "Add metadata-flavor header to metadata server ping for compute engine (#283)",
+      "files": []
+    },
+    {
+      "sha": "0a5443ada6a440fd30c862b4b673b84ea66bc08d",
+      "message": "Group AppEngine packages for renovate",
+      "files": []
+    },
+    {
+      "sha": "f81f3daf60db334b564733b859ec4c0ac556bef8",
+      "message": "import http client bom for dependency management (#268)",
+      "files": []
+    },
+    {
+      "sha": "cccdfdb41cc2b9d50da6490b0e2cba3425d96a24",
+      "message": "README section for interop with google-http-client (#275)\n\nAdds an example using `HttpCredentialsAdapter`",
+      "files": []
+    },
+    {
+      "sha": "4701056d32d95fd1133910889bd7611ca5369587",
+      "message": "Autorelease will also auto publish (#271)\n\n* Autorelease will also auto publish\r\n\r\n* Remove debug echo",
+      "files": []
+    },
+    {
+      "sha": "0d2b93f90979ec56e13e327ba9cec33f65d0548e",
+      "message": "Bump next snapshot (#270)",
+      "files": []
+    },
+    {
+      "sha": "537e710cd3a5ec842229b1642715664efcdb766c",
+      "message": "Release v0.16.1 (#269)",
+      "files": []
+    },
+    {
+      "sha": "1091092283d9e223cf389d885abe416c76394423",
+      "message": "Add credentials for autorelease (#267)",
+      "files": []
+    },
+    {
+      "sha": "2cedd9a1f7a7d82f670398dba055b46ed24e3d60",
+      "message": "Update dependency com.google.http-client:google-http-client to v1.30.1 (#265)",
+      "files": []
+    },
+    {
+      "sha": "311950919858b75afcf9e06cd2306fad054bbf09",
+      "message": "Bump next snapshot (#264)",
+      "files": []
+    },
+    {
+      "sha": "81ff35215931b047cd21957b376efd14c8234320",
+      "message": "Add developers section to google-auth-library-bom pom.xml",
+      "files": []
+    },
+    {
+      "sha": "397a32ad4a63414d2cc7eae96550cabf4d21011a",
+      "message": "Release v0.16.0 (#263)",
+      "files": []
+    },
+    {
+      "sha": "e918fd90252653f16aaf8038518ffb71dbdbd494",
+      "message": "Update dependency com.google.http-client:google-http-client to v1.30.0 (#261)",
+      "files": []
+    },
+    {
+      "sha": "6c776ae6415bb347c9b87205867e7c517b6cf04f",
+      "message": "Update dependency com.google.http-client:google-http-client to v1.29.2 (#259)",
+      "files": []
+    },
+    {
+      "sha": "78c2b58e0e8efc20d53c4f9de56b971b199b534c",
+      "message": "Update dependency org.sonatype.plugins:nexus-staging-maven-plugin to v1.6.8 (#257)",
+      "files": []
+    },
+    {
+      "sha": "1f987babc52340982faaecbb6ac35dc3c3a263e0",
+      "message": "Update to latest app engine SDK version (#258)",
+      "files": []
+    },
+    {
+      "sha": "dfca2f600d7664562b30d0fe63fe734ddb9946e3",
+      "message": "Add google-auth-library-bom artifact (#256)",
+      "files": []
+    },
+    {
+      "sha": "124aea52cdd9aaf491b1df04ef9abd3e8b1ee198",
+      "message": "Update dependency org.apache.maven.plugins:maven-source-plugin to v3.1.0 (#254)",
+      "files": []
+    },
+    {
+      "sha": "8e4f3429dbec388ed91f5440549205fd2160cf40",
+      "message": "Update dependency org.jacoco:jacoco-maven-plugin to v0.8.4 (#255)",
+      "files": []
+    },
+    {
+      "sha": "559ef11b0755021b48211c7c7f1b6f4631ce7aac",
+      "message": "Update dependency org.apache.maven.plugins:maven-jar-plugin to v3.1.2 (#252)",
+      "files": []
+    },
+    {
+      "sha": "fcb1da38217301b01108ae07d10a444dc82ec625",
+      "message": "Update dependency org.apache.maven.plugins:maven-source-plugin to v2.4 (#253)",
+      "files": []
+    },
+    {
+      "sha": "bc047c10cad6ce031ec731c6577c58f85a9326fb",
+      "message": "Add renovate.json (#245)",
+      "files": []
+    },
+    {
+      "sha": "7c28e941dbdebf588b3a0fa4e06bb5d2a1f13c1f",
+      "message": "Javadoc publish kokoro job uses docpublisher (#243)\n\n* Javadoc publish kokoro job uses docpublisher\r\n\r\n* Fix config path\r\n\r\n* Fix site:stage config\r\n\r\n* Move config to reporting\r\n\r\n* Fix indent",
+      "files": []
+    },
+    {
+      "sha": "e336dd29ef7421dd24ffadd4c8abaa2132c5d270",
+      "message": "Bump next snapshot (#240)",
+      "files": []
+    },
+    {
+      "sha": "f4354c12c2400897e54fad45644dcb7b94c10afc",
+      "message": "Release v0.15.0 (#239)",
+      "files": []
+    },
+    {
+      "sha": "88b381079ad5d2a6dadfbbfa132a85cb3cd58fbc",
+      "message": "Add back in deprecated methods in ServiceAccountJwtAccessCredentials (#238)\n\n* Add back in deprecated methods in ServiceAccountJwtAccessCredentials\r\n\r\n* typo fix\r\n\r\n* change constructor to private\r\n\r\n* change constructor to private",
+      "files": []
+    },
+    {
+      "sha": "49b39ae6beb9a054b9739cafe76059b0978a3067",
+      "message": "Bump next snapshot (#237)",
+      "files": []
+    },
+    {
+      "sha": "6698b3f6b5ab6017e28f68971406ca765807e169",
+      "message": "createScoped: make overload call implementation (#229)\n\nCall `createScoped` implementation instead of endlessly recursing.",
+      "files": []
+    },
+    {
+      "sha": "6ad960441490636afd8d260e04a588a30efbba1a",
+      "message": "Release v0.14.0 (#236)",
+      "files": []
+    },
+    {
+      "sha": "135d4ff4ca085ffb4a861804dc8656f1b49d5a2b",
+      "message": "Upgrade http client to 1.29.0. (#235)",
+      "files": []
+    },
+    {
+      "sha": "4c8360ee81b81b8d235141ee1d791acc8e350019",
+      "message": "update default metadata url (#230)",
+      "files": []
+    },
+    {
+      "sha": "e1e1f044782c5f3624fd576e321ec21784c79f45",
+      "message": "Update README.md (#233)\n\nfixed typo.",
+      "files": []
+    },
+    {
+      "sha": "f1b1c73fa3fd31e4832fac29296f948a7472e4ff",
+      "message": "update deps (#234)",
+      "files": []
+    },
+    {
+      "sha": "5db77026fb0a2859fc6933b23623f0e97ea9f125",
+      "message": "Update Sign Blob API (#232)",
+      "files": []
+    },
+    {
+      "sha": "44a5d33f8a9554192af1302d58f1dcab47cd2568",
+      "message": "Remove deprecated methods (#190)\n\n* add App Engine API to pom.xml with test scope\r\n\r\n* remove deprecated methods\r\n\r\n* remove one more deprecated comment\r\n\r\n* 1.9.71 appngine api",
+      "files": []
+    },
+    {
+      "sha": "e8b569be8db680169057688ae45f29916406e47e",
+      "message": "Provide STAGING_REPOSITORY_ID as an environment variable (#226)",
+      "files": []
+    },
+    {
+      "sha": "999de3b11de320354a8ff80a8dc906723d708cf4",
+      "message": "Bump next snapshot (#225)",
+      "files": []
+    },
+    {
+      "sha": "ee78958511100ec71c123d634c84ba7c0554d480",
+      "message": "Release v0.13.0 (#224)",
+      "files": []
+    },
+    {
+      "sha": "1d44ecd1e55fb6470cf3e03ed3c7e318df204445",
+      "message": "Enable autorelease (#222)",
+      "files": []
+    },
+    {
+      "sha": "ee67b5de492aea70c9b41b22bd53d75a1ea190c8",
+      "message": "Update google-http-client version and maven surefire plugin (#221)",
+      "files": []
+    },
+    {
+      "sha": "af3ae7530ffba1d4a3f0614dce28ba98862f290a",
+      "message": "Use OutputStream directly instead of PrintWriter (#220)",
+      "files": []
+    },
+    {
+      "sha": "48faeab8c9432d121a171d00ac2997dec3afbbbf",
+      "message": "Tests: Enable a test that was missing the test annotation (#219)\n\n* Enable a test that was missing the test annotation\r\n\r\n* Remove debug statement",
+      "files": []
+    },
+    {
+      "sha": "9f40bc7d6dd1e101c9ce1eaef44658f12ed763c3",
+      "message": "Overload GoogleCredentials.createScoped with variadic arguments (#218)\n\n* Add variadic overload of GoogleCredentials.createScoped\r\n\r\n* Remove unused import",
+      "files": []
+    },
+    {
+      "sha": "a1bbc4f4b6e26f123c462aca0aad7b53cd37d930",
+      "message": "Add kokoro job for publishing javadoc to GCS (#217)\n\n* Add kokoro job for publishing javadoc to GCS\r\n\r\n* Use string for Kokoro env var and default LINK_LATEST to true",
+      "files": []
+    },
+    {
+      "sha": "e311be7adb496d1a2bdad104203528240d3fa7ae",
+      "message": "Improve log output when detecting GCE (#214)\n\nImproving the log output when unexpected exceptions occur while determining\r\nif the client is running on Google Compute Engine.\r\n\r\nMoving the stacktrace to be FINE output since stacktraces are alarming.\r\n\r\nMaking the INFO level log message occur only once instead of potentially many times.\r\n\r\nFurther improvements to #199 and #198",
+      "files": []
+    },
+    {
+      "sha": "24164bfefc3ab1fe7f66ed3a6c674e7789c7ac6f",
+      "message": "Bump next snapshot (#216)",
+      "files": []
+    },
+    {
+      "sha": "f3415decbda6a99730b3a479f6f76328362446de",
+      "message": "Release v0.12.0 (#213)",
+      "files": []
+    },
+    {
+      "sha": "8225b92f88cc33edddcd0d4643ca1d9096cb1855",
+      "message": "Cleanup ImpersonatedCredentials (#212)\n\n* Cleanup\r\n\r\n* Fix tests\r\n\r\n* No need for singular ERROR_PREFIX that doesn't provide extra information\r\n\r\n* Fix spelling error",
+      "files": []
+    },
+    {
+      "sha": "b037146c665029ca4b764fe21bd3d7452dbc0ea3",
+      "message": "Add ImpersonatedCredentials (#211)\n\n* Add impersonatedcredentials\r\n\r\n* constructors->private; handle errors as IOException",
+      "files": []
+    },
+    {
+      "sha": "1b5f8ac5c6e53d8c074d5a86f7055310956ba2c2",
+      "message": "Update google-http-java-client dependency to 1.27.0 (#208)",
+      "files": []
+    },
+    {
+      "sha": "415f91b1cc6e0cdae934a14aa41c4b4d1affb3a6",
+      "message": "Update README with instructions on installing the App Engine SDK and running the tests (#209)",
+      "files": []
+    },
+    {
+      "sha": "4598c3fbbb6b036f11381f09f83b2144eea26b8b",
+      "message": "Option to suppress end user credentials warning. (#207)\n\n* Option to suppress end user credentials warning.\r\n\r\nDefining a new environment variable SUPPRESS_GCLOUD_CREDS_WARNING.\r\nSetting this to true suppresses the end user credentials warning.\r\nFixes #193\r\n\r\n* reordering checks to respond to comment",
+      "files": []
+    },
+    {
+      "sha": "108df92031a42dd070b86464e5efa85a3bcf33e3",
+      "message": "Add note about NO_GCE_CHECK to Metadata 404 Error (#205)\n\nThis makes the workaround to issue #204 much easier to discover.",
+      "files": []
+    },
+    {
+      "sha": "cdcf5897b21bec9a49d4198ad27eb1682ceef7d0",
+      "message": "Show error message in case of problems with getting access token (#206)\n\nCurrently it's unclear what caused the problem with it",
+      "files": []
+    },
+    {
+      "sha": "eb7e8457f6f4d501a009bcd2eb560f8ad4cbdf23",
+      "message": "Kokoro release (#200)\n\n* Add publish and stage release Kokoro configs\r\n\r\n* Fix credentials\r\n\r\n* Use trampoline for releases\r\n\r\n* Make release scripts executable\r\n\r\n* Fix release directory\r\n\r\n* Fix pin-entry for gpg signing\r\n\r\n* temporarily bump version, fix artifact path\r\n\r\n* Try to get the nice artifact path",
+      "files": []
+    },
+    {
+      "sha": "e75322bcef3e835043b075749935be0d91fa2c99",
+      "message": "Enable releasetool (#202)\n\n* Enable releasetool versioning\r\n\r\n* Release notes\r\n\r\n* Fix type\r\n\r\n* remove extra declared versions",
+      "files": []
+    },
+    {
+      "sha": "9e9ddb1660ef7a627dd4341b539234f316ca41b5",
+      "message": "Add codecov (#201)\n\n* Add codecov\r\n\r\n* Get codecov credentials, run local codecov script\r\n\r\n* Add jacoco-maven-plugin for code coverage\r\n\r\n* Add java11 test config\r\n\r\n* Add codecov badge to README\r\n\r\n* Check that codecov creds are present, use gcs version\r\n\r\n* output format of test report\r\n\r\n* Remove codecov script, only use gcs version",
+      "files": []
+    },
+    {
+      "sha": "9ef4ab1563e84e0f5579747fa6e575a2e71fc736",
+      "message": "Add CODEOWNERS and issue/pr templates (#203)",
+      "files": []
+    },
+    {
+      "sha": "a6585aeb5a81961fddf5382740c22768c75759ed",
+      "message": "Fix snapshot version in pom files and fix urls after repo move (#196)\n\n* Fix snapshot version in pom files and fix urls after repo move\r\n\r\n* fix repo and link in update_javadoc.sh script",
+      "files": []
+    },
+    {
+      "sha": "248fdb2557354430b3a1811924878c9f8a224031",
+      "message": "Fix warnings (#199)\n\n* Fix javadoc warnings\r\n\r\n* Only output message for GCE detection failure at INFO level",
+      "files": []
+    },
+    {
+      "sha": "1a004a3a4a0a7c1623ce777db614c5b0812bdcc5",
+      "message": "Add Kokoro continuous job configs (#197)\n\n* Add continuous integration Kokoro configs\r\n\r\n* Add CI Status section to README",
+      "files": []
+    },
+    {
+      "sha": "f739f2f33256bdc93b2312521b38dc56780fc090",
+      "message": "README grammar fix (#192)\n\n* grammar fix\r\n\r\n* Update README.md",
+      "files": []
+    },
+    {
+      "sha": "169c4d70423e731a6c651065db9fbfaca284ade2",
+      "message": "Add unstable badge to README (#184)",
+      "files": []
+    },
+    {
+      "sha": "3101a0242394b9f9bda38263dedaa296f7c7afcc",
+      "message": "Add windows Kokoro test config (#181)\n\n* Add windows Kokoro test config\r\n\r\n* Fix location of build.bat\r\n\r\n* Fix windows working directory\r\n\r\n* Fix bath to build script\r\n\r\n* Use a tempfile for test files to avoid windows path issues\r\n\r\n* empty commit to trigger travis\r\n\r\n* Skip creating the temporary test json files.\r\n\r\nThe actual file is not necessary for the tests - we only need a valid\r\npath for the OS.\r\n\r\n* Fix joining of paths\r\n\r\n* Fix osx script",
+      "files": []
+    },
+    {
+      "sha": "42c9906bc3b93cdb9766c2ef4a379670dab6d9f8",
+      "message": "Fix assorted warnings (#186)\n\n* warnings\r\n\r\n* revert",
+      "files": []
+    },
+    {
+      "sha": "15601f48fac4ed2eb8662ad976e33e601e8849f9",
+      "message": "0.11.0 has been released (#182)",
+      "files": []
+    },
+    {
+      "sha": "b87c763c55f960374a7f439af675bad4549ff5e0",
+      "message": "Add Kokoro CI config (#180)\n\n* Add Kokoro CI config\r\n\r\n* Fix directory",
+      "files": []
+    },
+    {
+      "sha": "64435cf60583a802564e40b3914b46e23c00b282",
+      "message": "Release v0.11.0 (#179)",
+      "files": []
+    },
+    {
+      "sha": "f7fc855cdd9d34e57aaa501ffc66e5372c960f51",
+      "message": "Documentation for ComputeEngineCredential signing. (#176)\n\nAdding note about enabling the IAM API and requiring the\r\niam.serviceAccounts.signBlob permission.",
+      "files": []
+    },
+    {
+      "sha": "1b0f73404c064a82c5501c394b8fe922ea8b3cff",
+      "message": "Update new token urls (#174)",
+      "files": []
+    },
+    {
+      "sha": "df46fd3c67ceccc721878e8bd0a42c2906d36243",
+      "message": "Bumping google-http-client version (#171)\n\n* Bumping google-http-client version\r\n\r\n* Bumping checkstyle to fix mac build",
+      "files": []
+    },
+    {
+      "sha": "185658cff1927664dde487819f6dbaa7e7a98923",
+      "message": "update dependencies (#170)",
+      "files": []
+    },
+    {
+      "sha": "da0541304a994eb48f765b88b5b8911d3bdfc702",
+      "message": "fix link (#169)",
+      "files": []
+    },
+    {
+      "sha": "c357d9ddf87f06c8ad05ef41b09a9c7dae752900",
+      "message": "0.10.1-SNAPSHOT version bump (#168)",
+      "files": []
+    },
+    {
+      "sha": "cb13da113c4d907ee8aafeab712757867276a7ed",
+      "message": "Bump release to 0.10.0 (#167)",
+      "files": []
+    },
+    {
+      "sha": "8964e7cf71d311ee910f144db2f768149c577363",
+      "message": "Allows to use GCE service credentials to sign blobs (#150)\n\nFixes #141 \r\n\r\n* Allows to use GCE service credentials to sign blobs (#141)\r\n\r\n* Fix failing test (#141)\r\n\r\n* Improve error reporting (#141)\r\n\r\n* Fix issues for code review (#141)\r\n\r\n* Don't change ServiceAccountSigner method signatures\r\n* Use complete list of imports in ComputeEngineCredentials\r\n\r\n* Restore individual assert imports\r\n\r\n* No need for IAM_API_ROOT_URL constant\r\n\r\n* Add tests for failure cases",
+      "files": []
+    },
+    {
+      "sha": "13c2418a6c511765761de9e52a9f03016044dae8",
+      "message": "Log warning if default credentials yields a user token from gcloud sdk (#166)\n\n* Log warning if default credentials yields a user token from gcloud sdk\r\n\r\n* Address PR comments",
+      "files": []
+    },
+    {
+      "sha": "4c311eeec807e8cfd37f3cd0b14a088cdd9f1362",
+      "message": "Add documentation note that getAccessToken() returns cached value (#162)",
+      "files": []
+    },
+    {
+      "sha": "64b48cbfc5805c6c8f3c8645bf1885ecbc4f6198",
+      "message": "Add OAuth2Credentials#refreshIfExpired() (#163)\n\n* Add OAuth2Credentials#refreshIfExpired()\r\n\r\n* Update README with info on explicit credential loading/refreshing",
+      "files": []
+    },
+    {
+      "sha": "6cc107359226ab2c70c9b2d066ddf726e27a92b7",
+      "message": "Versionless docs (#164)\n\n* Copy docs release version to latest folder\r\n\r\n* Update link to documentation to latest",
+      "files": []
+    },
+    {
+      "sha": "cbc6c1062d5fe1920c6a641a4d63769b56267eb0",
+      "message": "Read token_uri from service account JSON. (#160)",
+      "files": []
+    },
+    {
+      "sha": "8658eb1b6a4e1e458de715a50e2d5e70b825dd87",
+      "message": "Prepare next version (0.9.2-SNAPSHOT) (#156)",
+      "files": []
+    },
+    {
+      "sha": "dfd7b6ddc8995bb25bc77382b32a99a54ef89a6d",
+      "message": "Merge pull request #155 from jadekler/bump_release_0.9.1\n\nbump release from 0.9.1-SNAPSHOT to 0.9.1",
+      "files": []
+    },
+    {
+      "sha": "c7f0153168d56fd8bdf081eda225c975efb4db68",
+      "message": "Merge branch 'master' into bump_release_0.9.1",
+      "files": []
+    },
+    {
+      "sha": "d0e42454cd674cedffbe7a9c0f6d837e9b233098",
+      "message": "bump release from 0.9.1-SNAPSHOT to 0.9.1\n\nAlso, fix a documentation problem in RELEASE.md (apparently, searching sonatype\nnow not only accepts periods but requires them).",
+      "files": []
+    },
+    {
+      "sha": "8b965c21a8f68e32a8661c17bfaddf681108dd5c",
+      "message": "Merge pull request #154 from jadekler/patch-1\n\nUpdate RELEASE.md",
+      "files": []
+    },
+    {
+      "sha": "c59f51dcf1eaf8a4a1bbc5ea06025d93fcb792f6",
+      "message": "Update RELEASE.md\n\nRelevant issue: https://github.com/resin-io/etcher/issues/1786",
+      "files": []
+    },
+    {
+      "sha": "664754ee1208fe17472e41d10aa752851f610e7e",
+      "message": "Add caching for JWT tokens (#151)\n\n* Add caching for JWT tokens\r\n\r\n* code style\r\n\r\n* Add tests\r\n\r\n* refresh token 5 minutes early",
+      "files": []
+    }
+  ]
+}

--- a/__snapshots__/java-auth-readme.js
+++ b/__snapshots__/java-auth-readme.js
@@ -1,0 +1,36 @@
+exports['JavaAuthReadme updateContent updates version examples in README.md 1'] = `
+## Quickstart
+
+If you are using Maven, add this to your pom.xml file (notice that you can replace
+\`google-auth-library-oauth2-http\` with any of \`google-auth-library-credentials\` and
+\`google-auth-library-appengine\`, depending on your application needs):
+
+[//]: # ({x-version-update-start:google-auth-library-oauth2-http:released})
+
+\`\`\`xml
+<dependency>
+  <groupId>com.google.auth</groupId>
+  <artifactId>google-auth-library-oauth2-http</artifactId>
+  <version>0.20.0</version>
+</dependency>
+\`\`\`
+[//]: # ({x-version-update-end})
+
+
+If you are using Gradle, add this to your dependencies
+
+[//]: # ({x-version-update-start:google-auth-library-oauth2-http:released})
+\`\`\`Groovy
+compile 'com.google.auth:google-auth-library-oauth2-http:0.20.0'
+\`\`\`
+[//]: # ({x-version-update-end})
+
+If you are using SBT, add this to your dependencies
+
+[//]: # ({x-version-update-start:google-auth-library-oauth2-http:released})
+\`\`\`Scala
+libraryDependencies += "com.google.auth" % "google-auth-library-oauth2-http" % "0.20.0"
+\`\`\`
+[//]: # ({x-version-update-end})
+
+`

--- a/__snapshots__/java-auth-versions.js
+++ b/__snapshots__/java-auth-versions.js
@@ -1,0 +1,25 @@
+exports['JavaAuthVersions updateContent updates versions.txt appropriately for non-SNAPSHOT release 1'] = `
+# Format:
+# module:released-version:current-version
+
+google-auth-library:0.25.0:0.25.0
+google-auth-library-bom:0.25.0:0.25.0
+google-auth-library-parent:0.25.0:0.25.0
+google-auth-library-appengine:0.25.0:0.25.0
+google-auth-library-credentials:0.25.0:0.25.0
+google-auth-library-oauth2-http:0.25.0:0.25.0
+
+`
+
+exports['JavaAuthVersions updateContent updates versions.txt appropriately for SNAPSHOT release 1'] = `
+# Format:
+# module:released-version:current-version
+
+google-auth-library:0.16.2:0.16.2-SNAPSHOT
+google-auth-library-bom:0.16.2:0.16.2-SNAPSHOT
+google-auth-library-parent:0.16.2:0.16.2-SNAPSHOT
+google-auth-library-appengine:0.16.2:0.16.2-SNAPSHOT
+google-auth-library-credentials:0.16.2:0.16.2-SNAPSHOT
+google-auth-library-oauth2-http:0.16.2:0.16.2-SNAPSHOT
+
+`

--- a/__snapshots__/pom-xml.js
+++ b/__snapshots__/pom-xml.js
@@ -1,0 +1,81 @@
+exports['PomXML updateContent updates version in pom.xml 1'] = `
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <parent>
+    <groupId>com.google.auth</groupId>
+    <artifactId>google-auth-library-parent</artifactId>
+    <version>0.19.0</version><!-- {x-version-update:google-auth-library-parent:current} -->
+    <relativePath>../pom.xml</relativePath>
+  </parent>
+
+  <artifactId>google-auth-library-appengine</artifactId>
+  <name>Google Auth Library for Java - Google App Engine</name>
+
+  <distributionManagement>
+    <snapshotRepository>
+      <id>ossrh</id>
+      <url>https://oss.sonatype.org/content/repositories/snapshots</url>
+    </snapshotRepository>
+  </distributionManagement>
+
+  <build>
+    <sourceDirectory>java</sourceDirectory>
+    <testSourceDirectory>javatests</testSourceDirectory>
+    <plugins>
+      <plugin>
+        <groupId>org.sonatype.plugins</groupId>
+        <artifactId>nexus-staging-maven-plugin</artifactId>
+      </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-source-plugin</artifactId>
+      </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-javadoc-plugin</artifactId>
+      </plugin>
+    </plugins>
+  </build>
+
+  <dependencies>
+    <dependency>
+      <groupId>com.google.auth</groupId>
+      <artifactId>google-auth-library-credentials</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>com.google.auth</groupId>
+      <artifactId>google-auth-library-oauth2-http</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>com.google.http-client</groupId>
+      <artifactId>google-http-client</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>com.google.http-client</groupId>
+      <artifactId>google-http-client-jackson2</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>com.google.appengine</groupId>
+      <artifactId>appengine-api-1.0-sdk</artifactId>
+      <scope>provided</scope>
+    </dependency>
+    <dependency>
+      <groupId>com.google.guava</groupId>
+      <artifactId>guava</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>junit</groupId>
+      <artifactId>junit</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>com.google.auth</groupId>
+      <artifactId>google-auth-library-oauth2-http</artifactId>
+      <type>test-jar</type>
+      <scope>test</scope>
+    </dependency>
+  </dependencies>
+</project>
+`

--- a/__snapshots__/pom-xml.js
+++ b/__snapshots__/pom-xml.js
@@ -4,6 +4,12 @@ exports['PomXML updateContent updates version in pom.xml 1'] = `
   <modelVersion>4.0.0</modelVersion>
 
   <parent>
+    <groupId>org.sonatype.oss</groupId>
+    <artifactId>oss-parent</artifactId>
+    <version>7</version>
+  </parent>
+
+  <parent>
     <groupId>com.google.auth</groupId>
     <artifactId>google-auth-library-parent</artifactId>
     <version>0.19.0</version><!-- {x-version-update:google-auth-library-parent:current} -->

--- a/src/bin/release-please.ts
+++ b/src/bin/release-please.ts
@@ -34,7 +34,8 @@ interface ErrorObject {
 interface YargsOptions {
   describe: string;
   demand?: boolean;
-  default?: string;
+  type?: string;
+  default?: string|boolean;
 }
 
 interface YargsOptionsBuilder {
@@ -58,6 +59,11 @@ const argv = yargs
         .option('label', {
           default: 'autorelease: pending,type: process',
           describe: 'label(s) to add to generated PR',
+        })
+        .option('snapshot', {
+          describe: 'is it a snapshot (or pre-release) being generated?',
+          type: 'boolean',
+          default: false
         });
     },
     (argv: ReleasePROptions) => {
@@ -147,7 +153,7 @@ action "github-release" {
   })
   .option('release-type', {
     describe: 'what type of repo is a release being created for?',
-    options: ['node', 'php-yoshi'],
+    choices: ['node', 'php-yoshi', 'java-auth-yoshi'],
     default: 'node',
   })
   .option('bump-minor-pre-major', {

--- a/src/bin/release-please.ts
+++ b/src/bin/release-please.ts
@@ -35,7 +35,7 @@ interface YargsOptions {
   describe: string;
   demand?: boolean;
   type?: string;
-  default?: string|boolean;
+  default?: string | boolean;
 }
 
 interface YargsOptionsBuilder {
@@ -63,7 +63,7 @@ const argv = yargs
         .option('snapshot', {
           describe: 'is it a snapshot (or pre-release) being generated?',
           type: 'boolean',
-          default: false
+          default: false,
         });
     },
     (argv: ReleasePROptions) => {

--- a/src/release-pr.ts
+++ b/src/release-pr.ts
@@ -389,7 +389,7 @@ export class ReleasePR {
           },
         ]
       : await this.commits(latestTag ? latestTag.sha : undefined, 100, true);
-    let prSHA = commits[0].sha
+    let prSHA = commits[0].sha;
 
     const cc = new ConventionalCommits({
       commits,
@@ -405,7 +405,7 @@ export class ReleasePR {
       currentTag: `v${candidate.version}`,
       previousTag: candidate.previousTag,
     });
-    
+
     // snapshot entries are special:
     // 1. they don't update the README or CHANGELOG.
     // 2. they always update a patch with the -SNAPSHOT suffix.
@@ -413,7 +413,8 @@ export class ReleasePR {
     if (this.snapshot) {
       prSHA = latestTag!.sha;
       candidate.version = `${candidate.version}-SNAPSHOT`;
-      changelogEntry = '### Updating meta-information for bleeding-edge SNAPSHOT release.';
+      changelogEntry =
+        '### Updating meta-information for bleeding-edge SNAPSHOT release.';
     }
 
     // don't create a release candidate until user facing changes

--- a/src/release-pr.ts
+++ b/src/release-pr.ts
@@ -411,10 +411,9 @@ export class ReleasePR {
     // 2. they always update a patch with the -SNAPSHOT suffix.
     // 3. they're haunted.
     if (this.snapshot) {
-      const lastCommit = (await this.commits(latestTag ? latestTag.sha : undefined, 1, true))[0];
-      prSHA = lastCommit.sha;
+      prSHA = latestTag!.sha;
       candidate.version = `${candidate.version}-SNAPSHOT`;
-      changelogEntry = '\nUpdating meta-information for bleeding-edge SNAPSHOT release.';
+      changelogEntry = '### Updating meta-information for bleeding-edge SNAPSHOT release.';
     }
 
     // don't create a release candidate until user facing changes

--- a/src/updaters/java-auth-readme.ts
+++ b/src/updaters/java-auth-readme.ts
@@ -1,0 +1,51 @@
+/**
+ * Copyright 2019 Google LLC. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { checkpoint, CheckpointType } from '../util/checkpoint';
+import { Update, UpdateOptions } from './update';
+import { GitHubFileContents } from '../github';
+
+export class JavaAuthReadme implements Update {
+  path: string;
+  changelogEntry: string;
+  version: string;
+  versions?: { [key: string]: string };
+  packageName: string;
+  create: boolean;
+  contents?: GitHubFileContents;
+
+  constructor(options: UpdateOptions) {
+    this.create = false;
+    this.path = options.path;
+    this.changelogEntry = options.changelogEntry;
+    this.version = options.version;
+    this.packageName = options.packageName;
+  }
+  updateContent(content: string): string {
+    content = content.replace(
+      /<version>.*<\/version>/,
+      `<version>${this.version}</version>`
+    );
+    content = content.replace(
+      /'com.google.auth:google-auth-library-oauth2-http:[^']+'/,
+      `'com.google.auth:google-auth-library-oauth2-http:${this.version}'`
+    );
+    return content.replace(
+      /"com.google.auth" % "google-auth-library-oauth2-http" % "[^"]+"/,
+      `"com.google.auth" % "google-auth-library-oauth2-http" % "${this.version}"`
+    );
+  }
+}

--- a/src/updaters/java-auth-versions.ts
+++ b/src/updaters/java-auth-versions.ts
@@ -37,7 +37,7 @@ export class JavaAuthVersions implements Update {
   updateContent(content: string): string {
     if (this.version.includes('SNAPSHOT')) {
       return content.replace(
-        /:[0-9]+\.[0-9]+\.[0-9]+(-SNAPSHOT)?\n/g,
+        /:[0-9]+\.[0-9]+\.[0-9]+(-SNAPSHOT)?[\r\n]/g,
         `:${this.version}\n`
       );
     } else {

--- a/src/updaters/java-auth-versions.ts
+++ b/src/updaters/java-auth-versions.ts
@@ -1,0 +1,50 @@
+/**
+ * Copyright 2019 Google LLC. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { checkpoint, CheckpointType } from '../util/checkpoint';
+import { Update, UpdateOptions } from './update';
+import { GitHubFileContents } from '../github';
+
+export class JavaAuthVersions implements Update {
+  path: string;
+  changelogEntry: string;
+  version: string;
+  versions?: { [key: string]: string };
+  packageName: string;
+  create: boolean;
+  contents?: GitHubFileContents;
+
+  constructor(options: UpdateOptions) {
+    this.create = false;
+    this.path = options.path;
+    this.changelogEntry = options.changelogEntry;
+    this.version = options.version;
+    this.packageName = options.packageName;
+  }
+  updateContent(content: string): string {
+    if (this.version.includes('SNAPSHOT')) {
+      return content.replace(
+        /:[0-9]+\.[0-9]+\.[0-9]+(-SNAPSHOT)?\n/g,
+        `:${this.version}\n`
+      );
+    } else {
+      return content.replace(
+        /:[0-9]+\.[0-9]+\.[0-9]+:[0-9]+\.[0-9]+\.[0-9]+(-SNAPSHOT)?/g,
+        `:${this.version}:${this.version}`
+      );  
+    }
+  }
+}

--- a/src/updaters/java-auth-versions.ts
+++ b/src/updaters/java-auth-versions.ts
@@ -37,12 +37,12 @@ export class JavaAuthVersions implements Update {
   updateContent(content: string): string {
     if (this.version.includes('SNAPSHOT')) {
       return content.replace(
-        /:[0-9]+\.[0-9]+\.[0-9]+(-SNAPSHOT)?[\r\n]/g,
+        /:[0-9]+\.[0-9]+\.[0-9]+(-\w+)?(-SNAPSHOT)?[\r\n]/g,
         `:${this.version}\n`
       );
     } else {
       return content.replace(
-        /:[0-9]+\.[0-9]+\.[0-9]+:[0-9]+\.[0-9]+\.[0-9]+(-SNAPSHOT)?/g,
+        /:[0-9]+\.[0-9]+\.[0-9]+:[0-9]+\.[0-9]+\.[0-9]+(-\w+)?(-SNAPSHOT)?/g,
         `:${this.version}:${this.version}`
       );
     }

--- a/src/updaters/java-auth-versions.ts
+++ b/src/updaters/java-auth-versions.ts
@@ -44,7 +44,7 @@ export class JavaAuthVersions implements Update {
       return content.replace(
         /:[0-9]+\.[0-9]+\.[0-9]+:[0-9]+\.[0-9]+\.[0-9]+(-SNAPSHOT)?/g,
         `:${this.version}:${this.version}`
-      );  
+      );
     }
   }
 }

--- a/src/updaters/pom-xml.ts
+++ b/src/updaters/pom-xml.ts
@@ -1,0 +1,43 @@
+/**
+ * Copyright 2019 Google LLC. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { checkpoint, CheckpointType } from '../util/checkpoint';
+import { Update, UpdateOptions } from './update';
+import { GitHubFileContents } from '../github';
+
+export class PomXML implements Update {
+  path: string;
+  changelogEntry: string;
+  version: string;
+  versions?: { [key: string]: string };
+  packageName: string;
+  create: boolean;
+  contents?: GitHubFileContents;
+
+  constructor(options: UpdateOptions) {
+    this.create = false;
+    this.path = options.path;
+    this.changelogEntry = options.changelogEntry;
+    this.version = options.version;
+    this.packageName = options.packageName;
+  }
+  updateContent(content: string): string {
+    return content.replace(
+      /<version>.*<\/version>/,
+      `<version>${this.version}</version>`
+    );
+  }
+}

--- a/src/updaters/pom-xml.ts
+++ b/src/updaters/pom-xml.ts
@@ -36,8 +36,8 @@ export class PomXML implements Update {
   }
   updateContent(content: string): string {
     return content.replace(
-      /<version>.*<\/version>/,
-      `<version>${this.version}</version>`
+      /<version>.*<\/version>(.*x-version-update.*)/,
+      `<version>${this.version}</version>$1`
     );
   }
 }

--- a/test/fixtures/commits-with-labels.json
+++ b/test/fixtures/commits-with-labels.json
@@ -1,0 +1,2274 @@
+{
+    "repository": {
+      "defaultBranchRef": {
+        "target": {
+          "history": {
+            "edges": [
+              {
+                "node": {
+                  "message": "Refactor shared IAM-based signing (#292)\n\n* Extract IAM signing into its own class\r\n\r\n* Refactor into IamUtils package private class\r\n\r\n* Remove unnecessary class\r\n\r\n* Remove unused code\r\n\r\n* Cleanup imports\r\n\r\n* Fill out javadoc for IamUtils\r\n\r\n* Failing tests for impersonated credentials\r\n\r\n* Fix credentials used for signing\r\n\r\n* Fix providing delegates to signing request\r\n\r\n* Disallow null additionalFields, remove jsr305 annotation\r\n\r\n* Remove usued imports",
+                  "oid": "fcd1c890dc1526f4d62ceedad561f498195c8939",
+                  "associatedPullRequests": {
+                    "edges": [
+                      {
+                        "node": {
+                          "number": 292,
+                          "labels": {
+                            "edges": [
+                              {
+                                "node": {
+                                  "name": "cla: yes"
+                                }
+                              }
+                            ]
+                          }
+                        }
+                      }
+                    ]
+                  }
+                }
+              },
+              {
+                "node": {
+                  "message": "Update allowed header format (#301)\n\n* Update copyright format  \r\n\r\n@chingor13\r\n\r\n* Update java.header\r\n\r\n* add legacy copyright\r\n\r\n* remove spurious $",
+                  "oid": "1f9663cf08ab1cf3b68d95dee4dc99b7c4aac373",
+                  "associatedPullRequests": {
+                    "edges": [
+                      {
+                        "node": {
+                          "number": 301,
+                          "labels": {
+                            "edges": [
+                              {
+                                "node": {
+                                  "name": "cla: yes"
+                                }
+                              }
+                            ]
+                          }
+                        }
+                      }
+                    ]
+                  }
+                }
+              },
+              {
+                "node": {
+                  "message": "Upgrade Guava to 28.0-android (#300)",
+                  "oid": "3006009a2b1b2cb4bd5108c0f469c410759f3a6a",
+                  "associatedPullRequests": {
+                    "edges": [
+                      {
+                        "node": {
+                          "number": 300,
+                          "labels": {
+                            "edges": [
+                              {
+                                "node": {
+                                  "name": "cla: yes"
+                                }
+                              }
+                            ]
+                          }
+                        }
+                      }
+                    ]
+                  }
+                }
+              },
+              {
+                "node": {
+                  "message": "Fix declared dependencies from merge issue (#291)",
+                  "oid": "35abf13fa8acb3988aa086f3eb23f5ce1483cc5d",
+                  "associatedPullRequests": {
+                    "edges": [
+                      {
+                        "node": {
+                          "number": 291,
+                          "labels": {
+                            "edges": [
+                              {
+                                "node": {
+                                  "name": "cla: yes"
+                                }
+                              },
+                              {
+                                "node": {
+                                  "name": "fix"
+                                }
+                              }
+                            ]
+                          }
+                        }
+                      }
+                    ]
+                  }
+                }
+              },
+              {
+                "node": {
+                  "message": "Log warnings and deprecate AppEngineCredentials.getApplicationDefault (#288)\n\n* Log warnings and deprecate AppEngineCredentials.getApplicationDefault\r\n\r\nUsers should use GoogleCredentials.getApplicationDefault() if they want\r\nADC.\r\n\r\nADC will never return com.google.auth.appengine.AppEngineCredentials.\r\n\r\n* Add test for warning message\r\n\r\n* Catch the IOException from default credentials",
+                  "oid": "9b14268e2901dd4e82e20d0bec6f87ef4c37cc10",
+                  "associatedPullRequests": {
+                    "edges": [
+                      {
+                        "node": {
+                          "number": 288,
+                          "labels": {
+                            "edges": [
+                              {
+                                "node": {
+                                  "name": "cla: yes"
+                                }
+                              }
+                            ]
+                          }
+                        }
+                      }
+                    ]
+                  }
+                }
+              },
+              {
+                "node": {
+                  "message": "Adds CI test for mvn dependency:analyze and fixes missing deps (#289)\n\n* Add CI test for dependency:analyze\r\n\r\n* Remove unused dependencies\r\n\r\n* Fix path in dependency test file\r\n\r\n* Fix typo",
+                  "oid": "09e415ad348ace1e2c8912f7af8868f6cf11e574",
+                  "associatedPullRequests": {
+                    "edges": [
+                      {
+                        "node": {
+                          "number": 289,
+                          "labels": {
+                            "edges": [
+                              {
+                                "node": {
+                                  "name": "cla: yes"
+                                }
+                              }
+                            ]
+                          }
+                        }
+                      }
+                    ]
+                  }
+                }
+              },
+              {
+                "node": {
+                  "message": "Implement ServiceAccountSigner for ImpersonatedCredentials (#279)\n\n* Add Signer for impersonatied credentials\r\n\r\n* add lint fixes\r\n\r\n* back to the future\r\n\r\n* Update oauth2_http/java/com/google/auth/oauth2/ImpersonatedCredentials.java\r\n\r\nCo-Authored-By: Jeff Ching <chingor@google.com>",
+                  "oid": "70767e3758aaaf4db25e316e3fb689be415a897f",
+                  "associatedPullRequests": {
+                    "edges": [
+                      {
+                        "node": {
+                          "number": 279,
+                          "labels": {
+                            "edges": [
+                              {
+                                "node": {
+                                  "name": "cla: yes"
+                                }
+                              },
+                              {
+                                "node": {
+                                  "name": "feature"
+                                }
+                              },
+                              {
+                                "node": {
+                                  "name": "semver: major"
+                                }
+                              }
+                            ]
+                          }
+                        }
+                      }
+                    ]
+                  }
+                }
+              },
+              {
+                "node": {
+                  "message": "Update dependency org.apache.maven.plugins:maven-javadoc-plugin to v3.1.1 (#287)",
+                  "oid": "fcbc42656b393351f6d29b341cdafde25d3f7087",
+                  "associatedPullRequests": {
+                    "edges": [
+                      {
+                        "node": {
+                          "number": 287,
+                          "labels": {
+                            "edges": [
+                              {
+                                "node": {
+                                  "name": "cla: yes"
+                                }
+                              }
+                            ]
+                          }
+                        }
+                      }
+                    ]
+                  }
+                }
+              },
+              {
+                "node": {
+                  "message": "Update instructions for google-auth-library-appengine artifact (#278)\n\n* Update instructions for google-auth-library-appengine artifact\r\n\r\n* Fix AppEngine -> App Engine and Java 10 -> 11\r\n\r\n* GoogleCredentials -> Credentials in README example",
+                  "oid": "19a9ba57e40c9f627c9efc29d460b7181c099635",
+                  "associatedPullRequests": {
+                    "edges": [
+                      {
+                        "node": {
+                          "number": 278,
+                          "labels": {
+                            "edges": [
+                              {
+                                "node": {
+                                  "name": "cla: yes"
+                                }
+                              }
+                            ]
+                          }
+                        }
+                      }
+                    ]
+                  }
+                }
+              },
+              {
+                "node": {
+                  "message": "Bump next snapshot (#285)",
+                  "oid": "f212149e99d45fedcda525f418d5eefd0e6d75f1",
+                  "associatedPullRequests": {
+                    "edges": [
+                      {
+                        "node": {
+                          "number": 285,
+                          "labels": {
+                            "edges": [
+                              {
+                                "node": {
+                                  "name": "cla: yes"
+                                }
+                              }
+                            ]
+                          }
+                        }
+                      }
+                    ]
+                  }
+                }
+              },
+              {
+                "node": {
+                  "message": "Release v0.16.2 (#284)",
+                  "oid": "59edf251df08008e1f412968bd9103c9b441e81a",
+                  "associatedPullRequests": {
+                    "edges": [
+                      {
+                        "node": {
+                          "number": 284,
+                          "labels": {
+                            "edges": [
+                              {
+                                "node": {
+                                  "name": "autorelease: published"
+                                }
+                              },
+                              {
+                                "node": {
+                                  "name": "cla: yes"
+                                }
+                              }
+                            ]
+                          }
+                        }
+                      }
+                    ]
+                  }
+                }
+              },
+              {
+                "node": {
+                  "message": "Autorelease should actually autorelease",
+                  "oid": "bb7d80d4b5fc90f50e99c1db41863bcd212678da",
+                  "associatedPullRequests": {
+                    "edges": []
+                  }
+                }
+              },
+              {
+                "node": {
+                  "message": "Add metadata-flavor header to metadata server ping for compute engine (#283)",
+                  "oid": "c166c13e41866435ef3e0072afb4f6b2a20cbc59",
+                  "associatedPullRequests": {
+                    "edges": [
+                      {
+                        "node": {
+                          "number": 283,
+                          "labels": {
+                            "edges": [
+                              {
+                                "node": {
+                                  "name": "cla: yes"
+                                }
+                              }
+                            ]
+                          }
+                        }
+                      }
+                    ]
+                  }
+                }
+              },
+              {
+                "node": {
+                  "message": "Group AppEngine packages for renovate",
+                  "oid": "0a5443ada6a440fd30c862b4b673b84ea66bc08d",
+                  "associatedPullRequests": {
+                    "edges": []
+                  }
+                }
+              },
+              {
+                "node": {
+                  "message": "import http client bom for dependency management (#268)",
+                  "oid": "f81f3daf60db334b564733b859ec4c0ac556bef8",
+                  "associatedPullRequests": {
+                    "edges": [
+                      {
+                        "node": {
+                          "number": 268,
+                          "labels": {
+                            "edges": [
+                              {
+                                "node": {
+                                  "name": ":rotating_light:"
+                                }
+                              },
+                              {
+                                "node": {
+                                  "name": "cla: yes"
+                                }
+                              }
+                            ]
+                          }
+                        }
+                      }
+                    ]
+                  }
+                }
+              },
+              {
+                "node": {
+                  "message": "README section for interop with google-http-client (#275)\n\nAdds an example using `HttpCredentialsAdapter`",
+                  "oid": "cccdfdb41cc2b9d50da6490b0e2cba3425d96a24",
+                  "associatedPullRequests": {
+                    "edges": [
+                      {
+                        "node": {
+                          "number": 275,
+                          "labels": {
+                            "edges": [
+                              {
+                                "node": {
+                                  "name": ":rotating_light:"
+                                }
+                              },
+                              {
+                                "node": {
+                                  "name": "cla: yes"
+                                }
+                              }
+                            ]
+                          }
+                        }
+                      }
+                    ]
+                  }
+                }
+              },
+              {
+                "node": {
+                  "message": "Autorelease will also auto publish (#271)\n\n* Autorelease will also auto publish\r\n\r\n* Remove debug echo",
+                  "oid": "4701056d32d95fd1133910889bd7611ca5369587",
+                  "associatedPullRequests": {
+                    "edges": [
+                      {
+                        "node": {
+                          "number": 271,
+                          "labels": {
+                            "edges": [
+                              {
+                                "node": {
+                                  "name": ":rotating_light:"
+                                }
+                              },
+                              {
+                                "node": {
+                                  "name": "cla: yes"
+                                }
+                              }
+                            ]
+                          }
+                        }
+                      }
+                    ]
+                  }
+                }
+              },
+              {
+                "node": {
+                  "message": "Bump next snapshot (#270)",
+                  "oid": "0d2b93f90979ec56e13e327ba9cec33f65d0548e",
+                  "associatedPullRequests": {
+                    "edges": [
+                      {
+                        "node": {
+                          "number": 270,
+                          "labels": {
+                            "edges": [
+                              {
+                                "node": {
+                                  "name": "cla: yes"
+                                }
+                              }
+                            ]
+                          }
+                        }
+                      }
+                    ]
+                  }
+                }
+              },
+              {
+                "node": {
+                  "message": "Release v0.16.1 (#269)",
+                  "oid": "537e710cd3a5ec842229b1642715664efcdb766c",
+                  "associatedPullRequests": {
+                    "edges": [
+                      {
+                        "node": {
+                          "number": 269,
+                          "labels": {
+                            "edges": [
+                              {
+                                "node": {
+                                  "name": "autorelease: tagged"
+                                }
+                              },
+                              {
+                                "node": {
+                                  "name": "cla: yes"
+                                }
+                              }
+                            ]
+                          }
+                        }
+                      }
+                    ]
+                  }
+                }
+              },
+              {
+                "node": {
+                  "message": "Add credentials for autorelease (#267)",
+                  "oid": "1091092283d9e223cf389d885abe416c76394423",
+                  "associatedPullRequests": {
+                    "edges": [
+                      {
+                        "node": {
+                          "number": 267,
+                          "labels": {
+                            "edges": [
+                              {
+                                "node": {
+                                  "name": "cla: yes"
+                                }
+                              }
+                            ]
+                          }
+                        }
+                      }
+                    ]
+                  }
+                }
+              },
+              {
+                "node": {
+                  "message": "Update dependency com.google.http-client:google-http-client to v1.30.1 (#265)",
+                  "oid": "2cedd9a1f7a7d82f670398dba055b46ed24e3d60",
+                  "associatedPullRequests": {
+                    "edges": [
+                      {
+                        "node": {
+                          "number": 265,
+                          "labels": {
+                            "edges": [
+                              {
+                                "node": {
+                                  "name": "cla: yes"
+                                }
+                              }
+                            ]
+                          }
+                        }
+                      }
+                    ]
+                  }
+                }
+              },
+              {
+                "node": {
+                  "message": "Bump next snapshot (#264)",
+                  "oid": "311950919858b75afcf9e06cd2306fad054bbf09",
+                  "associatedPullRequests": {
+                    "edges": [
+                      {
+                        "node": {
+                          "number": 264,
+                          "labels": {
+                            "edges": [
+                              {
+                                "node": {
+                                  "name": "cla: yes"
+                                }
+                              }
+                            ]
+                          }
+                        }
+                      }
+                    ]
+                  }
+                }
+              },
+              {
+                "node": {
+                  "message": "Add developers section to google-auth-library-bom pom.xml",
+                  "oid": "81ff35215931b047cd21957b376efd14c8234320",
+                  "associatedPullRequests": {
+                    "edges": []
+                  }
+                }
+              },
+              {
+                "node": {
+                  "message": "Release v0.16.0 (#263)",
+                  "oid": "397a32ad4a63414d2cc7eae96550cabf4d21011a",
+                  "associatedPullRequests": {
+                    "edges": [
+                      {
+                        "node": {
+                          "number": 263,
+                          "labels": {
+                            "edges": [
+                              {
+                                "node": {
+                                  "name": "cla: yes"
+                                }
+                              }
+                            ]
+                          }
+                        }
+                      }
+                    ]
+                  }
+                }
+              },
+              {
+                "node": {
+                  "message": "Update dependency com.google.http-client:google-http-client to v1.30.0 (#261)",
+                  "oid": "e918fd90252653f16aaf8038518ffb71dbdbd494",
+                  "associatedPullRequests": {
+                    "edges": [
+                      {
+                        "node": {
+                          "number": 261,
+                          "labels": {
+                            "edges": [
+                              {
+                                "node": {
+                                  "name": "cla: yes"
+                                }
+                              }
+                            ]
+                          }
+                        }
+                      }
+                    ]
+                  }
+                }
+              },
+              {
+                "node": {
+                  "message": "Update dependency com.google.http-client:google-http-client to v1.29.2 (#259)",
+                  "oid": "6c776ae6415bb347c9b87205867e7c517b6cf04f",
+                  "associatedPullRequests": {
+                    "edges": [
+                      {
+                        "node": {
+                          "number": 259,
+                          "labels": {
+                            "edges": [
+                              {
+                                "node": {
+                                  "name": "cla: yes"
+                                }
+                              }
+                            ]
+                          }
+                        }
+                      }
+                    ]
+                  }
+                }
+              },
+              {
+                "node": {
+                  "message": "Update dependency org.sonatype.plugins:nexus-staging-maven-plugin to v1.6.8 (#257)",
+                  "oid": "78c2b58e0e8efc20d53c4f9de56b971b199b534c",
+                  "associatedPullRequests": {
+                    "edges": [
+                      {
+                        "node": {
+                          "number": 257,
+                          "labels": {
+                            "edges": [
+                              {
+                                "node": {
+                                  "name": "cla: yes"
+                                }
+                              }
+                            ]
+                          }
+                        }
+                      }
+                    ]
+                  }
+                }
+              },
+              {
+                "node": {
+                  "message": "Update to latest app engine SDK version (#258)",
+                  "oid": "1f987babc52340982faaecbb6ac35dc3c3a263e0",
+                  "associatedPullRequests": {
+                    "edges": [
+                      {
+                        "node": {
+                          "number": 258,
+                          "labels": {
+                            "edges": [
+                              {
+                                "node": {
+                                  "name": "cla: yes"
+                                }
+                              }
+                            ]
+                          }
+                        }
+                      }
+                    ]
+                  }
+                }
+              },
+              {
+                "node": {
+                  "message": "Add google-auth-library-bom artifact (#256)",
+                  "oid": "dfca2f600d7664562b30d0fe63fe734ddb9946e3",
+                  "associatedPullRequests": {
+                    "edges": [
+                      {
+                        "node": {
+                          "number": 256,
+                          "labels": {
+                            "edges": [
+                              {
+                                "node": {
+                                  "name": "cla: yes"
+                                }
+                              }
+                            ]
+                          }
+                        }
+                      }
+                    ]
+                  }
+                }
+              },
+              {
+                "node": {
+                  "message": "Update dependency org.apache.maven.plugins:maven-source-plugin to v3.1.0 (#254)",
+                  "oid": "124aea52cdd9aaf491b1df04ef9abd3e8b1ee198",
+                  "associatedPullRequests": {
+                    "edges": [
+                      {
+                        "node": {
+                          "number": 254,
+                          "labels": {
+                            "edges": [
+                              {
+                                "node": {
+                                  "name": "cla: yes"
+                                }
+                              }
+                            ]
+                          }
+                        }
+                      }
+                    ]
+                  }
+                }
+              },
+              {
+                "node": {
+                  "message": "Update dependency org.jacoco:jacoco-maven-plugin to v0.8.4 (#255)",
+                  "oid": "8e4f3429dbec388ed91f5440549205fd2160cf40",
+                  "associatedPullRequests": {
+                    "edges": [
+                      {
+                        "node": {
+                          "number": 255,
+                          "labels": {
+                            "edges": [
+                              {
+                                "node": {
+                                  "name": "cla: yes"
+                                }
+                              }
+                            ]
+                          }
+                        }
+                      }
+                    ]
+                  }
+                }
+              },
+              {
+                "node": {
+                  "message": "Update dependency org.apache.maven.plugins:maven-jar-plugin to v3.1.2 (#252)",
+                  "oid": "559ef11b0755021b48211c7c7f1b6f4631ce7aac",
+                  "associatedPullRequests": {
+                    "edges": [
+                      {
+                        "node": {
+                          "number": 252,
+                          "labels": {
+                            "edges": [
+                              {
+                                "node": {
+                                  "name": "cla: yes"
+                                }
+                              }
+                            ]
+                          }
+                        }
+                      }
+                    ]
+                  }
+                }
+              },
+              {
+                "node": {
+                  "message": "Update dependency org.apache.maven.plugins:maven-source-plugin to v2.4 (#253)",
+                  "oid": "fcb1da38217301b01108ae07d10a444dc82ec625",
+                  "associatedPullRequests": {
+                    "edges": [
+                      {
+                        "node": {
+                          "number": 253,
+                          "labels": {
+                            "edges": [
+                              {
+                                "node": {
+                                  "name": "cla: yes"
+                                }
+                              }
+                            ]
+                          }
+                        }
+                      }
+                    ]
+                  }
+                }
+              },
+              {
+                "node": {
+                  "message": "Add renovate.json (#245)",
+                  "oid": "bc047c10cad6ce031ec731c6577c58f85a9326fb",
+                  "associatedPullRequests": {
+                    "edges": [
+                      {
+                        "node": {
+                          "number": 245,
+                          "labels": {
+                            "edges": [
+                              {
+                                "node": {
+                                  "name": "cla: yes"
+                                }
+                              }
+                            ]
+                          }
+                        }
+                      }
+                    ]
+                  }
+                }
+              },
+              {
+                "node": {
+                  "message": "Javadoc publish kokoro job uses docpublisher (#243)\n\n* Javadoc publish kokoro job uses docpublisher\r\n\r\n* Fix config path\r\n\r\n* Fix site:stage config\r\n\r\n* Move config to reporting\r\n\r\n* Fix indent",
+                  "oid": "7c28e941dbdebf588b3a0fa4e06bb5d2a1f13c1f",
+                  "associatedPullRequests": {
+                    "edges": [
+                      {
+                        "node": {
+                          "number": 243,
+                          "labels": {
+                            "edges": [
+                              {
+                                "node": {
+                                  "name": ":rotating_light:"
+                                }
+                              },
+                              {
+                                "node": {
+                                  "name": "cla: yes"
+                                }
+                              },
+                              {
+                                "node": {
+                                  "name": "type: docs"
+                                }
+                              }
+                            ]
+                          }
+                        }
+                      }
+                    ]
+                  }
+                }
+              },
+              {
+                "node": {
+                  "message": "Bump next snapshot (#240)",
+                  "oid": "e336dd29ef7421dd24ffadd4c8abaa2132c5d270",
+                  "associatedPullRequests": {
+                    "edges": [
+                      {
+                        "node": {
+                          "number": 240,
+                          "labels": {
+                            "edges": [
+                              {
+                                "node": {
+                                  "name": "cla: yes"
+                                }
+                              }
+                            ]
+                          }
+                        }
+                      }
+                    ]
+                  }
+                }
+              },
+              {
+                "node": {
+                  "message": "Release v0.15.0 (#239)",
+                  "oid": "f4354c12c2400897e54fad45644dcb7b94c10afc",
+                  "associatedPullRequests": {
+                    "edges": [
+                      {
+                        "node": {
+                          "number": 239,
+                          "labels": {
+                            "edges": [
+                              {
+                                "node": {
+                                  "name": "cla: yes"
+                                }
+                              }
+                            ]
+                          }
+                        }
+                      }
+                    ]
+                  }
+                }
+              },
+              {
+                "node": {
+                  "message": "Add back in deprecated methods in ServiceAccountJwtAccessCredentials (#238)\n\n* Add back in deprecated methods in ServiceAccountJwtAccessCredentials\r\n\r\n* typo fix\r\n\r\n* change constructor to private\r\n\r\n* change constructor to private",
+                  "oid": "88b381079ad5d2a6dadfbbfa132a85cb3cd58fbc",
+                  "associatedPullRequests": {
+                    "edges": [
+                      {
+                        "node": {
+                          "number": 238,
+                          "labels": {
+                            "edges": [
+                              {
+                                "node": {
+                                  "name": "cla: yes"
+                                }
+                              }
+                            ]
+                          }
+                        }
+                      }
+                    ]
+                  }
+                }
+              },
+              {
+                "node": {
+                  "message": "Bump next snapshot (#237)",
+                  "oid": "49b39ae6beb9a054b9739cafe76059b0978a3067",
+                  "associatedPullRequests": {
+                    "edges": [
+                      {
+                        "node": {
+                          "number": 237,
+                          "labels": {
+                            "edges": [
+                              {
+                                "node": {
+                                  "name": "cla: yes"
+                                }
+                              }
+                            ]
+                          }
+                        }
+                      }
+                    ]
+                  }
+                }
+              },
+              {
+                "node": {
+                  "message": "createScoped: make overload call implementation (#229)\n\nCall `createScoped` implementation instead of endlessly recursing.",
+                  "oid": "6698b3f6b5ab6017e28f68971406ca765807e169",
+                  "associatedPullRequests": {
+                    "edges": [
+                      {
+                        "node": {
+                          "number": 229,
+                          "labels": {
+                            "edges": [
+                              {
+                                "node": {
+                                  "name": ":rotating_light:"
+                                }
+                              },
+                              {
+                                "node": {
+                                  "name": "cla: yes"
+                                }
+                              }
+                            ]
+                          }
+                        }
+                      }
+                    ]
+                  }
+                }
+              },
+              {
+                "node": {
+                  "message": "Release v0.14.0 (#236)",
+                  "oid": "6ad960441490636afd8d260e04a588a30efbba1a",
+                  "associatedPullRequests": {
+                    "edges": [
+                      {
+                        "node": {
+                          "number": 236,
+                          "labels": {
+                            "edges": [
+                              {
+                                "node": {
+                                  "name": "cla: yes"
+                                }
+                              }
+                            ]
+                          }
+                        }
+                      }
+                    ]
+                  }
+                }
+              },
+              {
+                "node": {
+                  "message": "Upgrade http client to 1.29.0. (#235)",
+                  "oid": "135d4ff4ca085ffb4a861804dc8656f1b49d5a2b",
+                  "associatedPullRequests": {
+                    "edges": [
+                      {
+                        "node": {
+                          "number": 235,
+                          "labels": {
+                            "edges": [
+                              {
+                                "node": {
+                                  "name": "cla: yes"
+                                }
+                              }
+                            ]
+                          }
+                        }
+                      }
+                    ]
+                  }
+                }
+              },
+              {
+                "node": {
+                  "message": "update default metadata url (#230)",
+                  "oid": "4c8360ee81b81b8d235141ee1d791acc8e350019",
+                  "associatedPullRequests": {
+                    "edges": [
+                      {
+                        "node": {
+                          "number": 230,
+                          "labels": {
+                            "edges": [
+                              {
+                                "node": {
+                                  "name": ":rotating_light:"
+                                }
+                              },
+                              {
+                                "node": {
+                                  "name": "cla: yes"
+                                }
+                              }
+                            ]
+                          }
+                        }
+                      }
+                    ]
+                  }
+                }
+              },
+              {
+                "node": {
+                  "message": "Update README.md (#233)\n\nfixed typo.",
+                  "oid": "e1e1f044782c5f3624fd576e321ec21784c79f45",
+                  "associatedPullRequests": {
+                    "edges": [
+                      {
+                        "node": {
+                          "number": 233,
+                          "labels": {
+                            "edges": [
+                              {
+                                "node": {
+                                  "name": "cla: yes"
+                                }
+                              }
+                            ]
+                          }
+                        }
+                      }
+                    ]
+                  }
+                }
+              },
+              {
+                "node": {
+                  "message": "update deps (#234)",
+                  "oid": "f1b1c73fa3fd31e4832fac29296f948a7472e4ff",
+                  "associatedPullRequests": {
+                    "edges": [
+                      {
+                        "node": {
+                          "number": 234,
+                          "labels": {
+                            "edges": [
+                              {
+                                "node": {
+                                  "name": "cla: yes"
+                                }
+                              }
+                            ]
+                          }
+                        }
+                      }
+                    ]
+                  }
+                }
+              },
+              {
+                "node": {
+                  "message": "Update Sign Blob API (#232)",
+                  "oid": "5db77026fb0a2859fc6933b23623f0e97ea9f125",
+                  "associatedPullRequests": {
+                    "edges": [
+                      {
+                        "node": {
+                          "number": 232,
+                          "labels": {
+                            "edges": [
+                              {
+                                "node": {
+                                  "name": "cla: yes"
+                                }
+                              }
+                            ]
+                          }
+                        }
+                      }
+                    ]
+                  }
+                }
+              },
+              {
+                "node": {
+                  "message": "Remove deprecated methods (#190)\n\n* add App Engine API to pom.xml with test scope\r\n\r\n* remove deprecated methods\r\n\r\n* remove one more deprecated comment\r\n\r\n* 1.9.71 appngine api",
+                  "oid": "44a5d33f8a9554192af1302d58f1dcab47cd2568",
+                  "associatedPullRequests": {
+                    "edges": [
+                      {
+                        "node": {
+                          "number": 190,
+                          "labels": {
+                            "edges": [
+                              {
+                                "node": {
+                                  "name": ":rotating_light:"
+                                }
+                              },
+                              {
+                                "node": {
+                                  "name": "cla: yes"
+                                }
+                              }
+                            ]
+                          }
+                        }
+                      }
+                    ]
+                  }
+                }
+              },
+              {
+                "node": {
+                  "message": "Provide STAGING_REPOSITORY_ID as an environment variable (#226)",
+                  "oid": "e8b569be8db680169057688ae45f29916406e47e",
+                  "associatedPullRequests": {
+                    "edges": [
+                      {
+                        "node": {
+                          "number": 226,
+                          "labels": {
+                            "edges": [
+                              {
+                                "node": {
+                                  "name": "cla: yes"
+                                }
+                              }
+                            ]
+                          }
+                        }
+                      }
+                    ]
+                  }
+                }
+              },
+              {
+                "node": {
+                  "message": "Bump next snapshot (#225)",
+                  "oid": "999de3b11de320354a8ff80a8dc906723d708cf4",
+                  "associatedPullRequests": {
+                    "edges": [
+                      {
+                        "node": {
+                          "number": 225,
+                          "labels": {
+                            "edges": [
+                              {
+                                "node": {
+                                  "name": "cla: yes"
+                                }
+                              }
+                            ]
+                          }
+                        }
+                      }
+                    ]
+                  }
+                }
+              },
+              {
+                "node": {
+                  "message": "Release v0.13.0 (#224)",
+                  "oid": "ee78958511100ec71c123d634c84ba7c0554d480",
+                  "associatedPullRequests": {
+                    "edges": [
+                      {
+                        "node": {
+                          "number": 224,
+                          "labels": {
+                            "edges": [
+                              {
+                                "node": {
+                                  "name": "cla: yes"
+                                }
+                              }
+                            ]
+                          }
+                        }
+                      }
+                    ]
+                  }
+                }
+              },
+              {
+                "node": {
+                  "message": "Enable autorelease (#222)",
+                  "oid": "1d44ecd1e55fb6470cf3e03ed3c7e318df204445",
+                  "associatedPullRequests": {
+                    "edges": [
+                      {
+                        "node": {
+                          "number": 222,
+                          "labels": {
+                            "edges": [
+                              {
+                                "node": {
+                                  "name": "cla: yes"
+                                }
+                              }
+                            ]
+                          }
+                        }
+                      }
+                    ]
+                  }
+                }
+              },
+              {
+                "node": {
+                  "message": "Update google-http-client version and maven surefire plugin (#221)",
+                  "oid": "ee67b5de492aea70c9b41b22bd53d75a1ea190c8",
+                  "associatedPullRequests": {
+                    "edges": [
+                      {
+                        "node": {
+                          "number": 221,
+                          "labels": {
+                            "edges": [
+                              {
+                                "node": {
+                                  "name": "cla: yes"
+                                }
+                              }
+                            ]
+                          }
+                        }
+                      }
+                    ]
+                  }
+                }
+              },
+              {
+                "node": {
+                  "message": "Use OutputStream directly instead of PrintWriter (#220)",
+                  "oid": "af3ae7530ffba1d4a3f0614dce28ba98862f290a",
+                  "associatedPullRequests": {
+                    "edges": [
+                      {
+                        "node": {
+                          "number": 220,
+                          "labels": {
+                            "edges": [
+                              {
+                                "node": {
+                                  "name": "cla: yes"
+                                }
+                              }
+                            ]
+                          }
+                        }
+                      }
+                    ]
+                  }
+                }
+              },
+              {
+                "node": {
+                  "message": "Tests: Enable a test that was missing the test annotation (#219)\n\n* Enable a test that was missing the test annotation\r\n\r\n* Remove debug statement",
+                  "oid": "48faeab8c9432d121a171d00ac2997dec3afbbbf",
+                  "associatedPullRequests": {
+                    "edges": [
+                      {
+                        "node": {
+                          "number": 219,
+                          "labels": {
+                            "edges": [
+                              {
+                                "node": {
+                                  "name": "cla: yes"
+                                }
+                              }
+                            ]
+                          }
+                        }
+                      }
+                    ]
+                  }
+                }
+              },
+              {
+                "node": {
+                  "message": "Overload GoogleCredentials.createScoped with variadic arguments (#218)\n\n* Add variadic overload of GoogleCredentials.createScoped\r\n\r\n* Remove unused import",
+                  "oid": "9f40bc7d6dd1e101c9ce1eaef44658f12ed763c3",
+                  "associatedPullRequests": {
+                    "edges": [
+                      {
+                        "node": {
+                          "number": 218,
+                          "labels": {
+                            "edges": [
+                              {
+                                "node": {
+                                  "name": "cla: yes"
+                                }
+                              }
+                            ]
+                          }
+                        }
+                      }
+                    ]
+                  }
+                }
+              },
+              {
+                "node": {
+                  "message": "Add kokoro job for publishing javadoc to GCS (#217)\n\n* Add kokoro job for publishing javadoc to GCS\r\n\r\n* Use string for Kokoro env var and default LINK_LATEST to true",
+                  "oid": "a1bbc4f4b6e26f123c462aca0aad7b53cd37d930",
+                  "associatedPullRequests": {
+                    "edges": [
+                      {
+                        "node": {
+                          "number": 217,
+                          "labels": {
+                            "edges": [
+                              {
+                                "node": {
+                                  "name": "cla: yes"
+                                }
+                              }
+                            ]
+                          }
+                        }
+                      }
+                    ]
+                  }
+                }
+              },
+              {
+                "node": {
+                  "message": "Improve log output when detecting GCE (#214)\n\nImproving the log output when unexpected exceptions occur while determining\r\nif the client is running on Google Compute Engine.\r\n\r\nMoving the stacktrace to be FINE output since stacktraces are alarming.\r\n\r\nMaking the INFO level log message occur only once instead of potentially many times.\r\n\r\nFurther improvements to #199 and #198",
+                  "oid": "e311be7adb496d1a2bdad104203528240d3fa7ae",
+                  "associatedPullRequests": {
+                    "edges": [
+                      {
+                        "node": {
+                          "number": 214,
+                          "labels": {
+                            "edges": [
+                              {
+                                "node": {
+                                  "name": "cla: yes"
+                                }
+                              }
+                            ]
+                          }
+                        }
+                      }
+                    ]
+                  }
+                }
+              },
+              {
+                "node": {
+                  "message": "Bump next snapshot (#216)",
+                  "oid": "24164bfefc3ab1fe7f66ed3a6c674e7789c7ac6f",
+                  "associatedPullRequests": {
+                    "edges": [
+                      {
+                        "node": {
+                          "number": 216,
+                          "labels": {
+                            "edges": [
+                              {
+                                "node": {
+                                  "name": "cla: yes"
+                                }
+                              }
+                            ]
+                          }
+                        }
+                      }
+                    ]
+                  }
+                }
+              },
+              {
+                "node": {
+                  "message": "Release v0.12.0 (#213)",
+                  "oid": "f3415decbda6a99730b3a479f6f76328362446de",
+                  "associatedPullRequests": {
+                    "edges": [
+                      {
+                        "node": {
+                          "number": 213,
+                          "labels": {
+                            "edges": [
+                              {
+                                "node": {
+                                  "name": "cla: yes"
+                                }
+                              }
+                            ]
+                          }
+                        }
+                      }
+                    ]
+                  }
+                }
+              },
+              {
+                "node": {
+                  "message": "Cleanup ImpersonatedCredentials (#212)\n\n* Cleanup\r\n\r\n* Fix tests\r\n\r\n* No need for singular ERROR_PREFIX that doesn't provide extra information\r\n\r\n* Fix spelling error",
+                  "oid": "8225b92f88cc33edddcd0d4643ca1d9096cb1855",
+                  "associatedPullRequests": {
+                    "edges": [
+                      {
+                        "node": {
+                          "number": 212,
+                          "labels": {
+                            "edges": [
+                              {
+                                "node": {
+                                  "name": "cla: yes"
+                                }
+                              }
+                            ]
+                          }
+                        }
+                      }
+                    ]
+                  }
+                }
+              },
+              {
+                "node": {
+                  "message": "Add ImpersonatedCredentials (#211)\n\n* Add impersonatedcredentials\r\n\r\n* constructors->private; handle errors as IOException",
+                  "oid": "b037146c665029ca4b764fe21bd3d7452dbc0ea3",
+                  "associatedPullRequests": {
+                    "edges": [
+                      {
+                        "node": {
+                          "number": 211,
+                          "labels": {
+                            "edges": [
+                              {
+                                "node": {
+                                  "name": "cla: yes"
+                                }
+                              }
+                            ]
+                          }
+                        }
+                      }
+                    ]
+                  }
+                }
+              },
+              {
+                "node": {
+                  "message": "Update google-http-java-client dependency to 1.27.0 (#208)",
+                  "oid": "1b5f8ac5c6e53d8c074d5a86f7055310956ba2c2",
+                  "associatedPullRequests": {
+                    "edges": [
+                      {
+                        "node": {
+                          "number": 208,
+                          "labels": {
+                            "edges": [
+                              {
+                                "node": {
+                                  "name": "cla: yes"
+                                }
+                              }
+                            ]
+                          }
+                        }
+                      }
+                    ]
+                  }
+                }
+              },
+              {
+                "node": {
+                  "message": "Update README with instructions on installing the App Engine SDK and running the tests (#209)",
+                  "oid": "415f91b1cc6e0cdae934a14aa41c4b4d1affb3a6",
+                  "associatedPullRequests": {
+                    "edges": [
+                      {
+                        "node": {
+                          "number": 209,
+                          "labels": {
+                            "edges": [
+                              {
+                                "node": {
+                                  "name": "cla: yes"
+                                }
+                              }
+                            ]
+                          }
+                        }
+                      }
+                    ]
+                  }
+                }
+              },
+              {
+                "node": {
+                  "message": "Option to suppress end user credentials warning. (#207)\n\n* Option to suppress end user credentials warning.\r\n\r\nDefining a new environment variable SUPPRESS_GCLOUD_CREDS_WARNING.\r\nSetting this to true suppresses the end user credentials warning.\r\nFixes #193\r\n\r\n* reordering checks to respond to comment",
+                  "oid": "4598c3fbbb6b036f11381f09f83b2144eea26b8b",
+                  "associatedPullRequests": {
+                    "edges": [
+                      {
+                        "node": {
+                          "number": 207,
+                          "labels": {
+                            "edges": [
+                              {
+                                "node": {
+                                  "name": "cla: yes"
+                                }
+                              }
+                            ]
+                          }
+                        }
+                      }
+                    ]
+                  }
+                }
+              },
+              {
+                "node": {
+                  "message": "Add note about NO_GCE_CHECK to Metadata 404 Error (#205)\n\nThis makes the workaround to issue #204 much easier to discover.",
+                  "oid": "108df92031a42dd070b86464e5efa85a3bcf33e3",
+                  "associatedPullRequests": {
+                    "edges": [
+                      {
+                        "node": {
+                          "number": 205,
+                          "labels": {
+                            "edges": [
+                              {
+                                "node": {
+                                  "name": "cla: yes"
+                                }
+                              }
+                            ]
+                          }
+                        }
+                      }
+                    ]
+                  }
+                }
+              },
+              {
+                "node": {
+                  "message": "Show error message in case of problems with getting access token (#206)\n\nCurrently it's unclear what caused the problem with it",
+                  "oid": "cdcf5897b21bec9a49d4198ad27eb1682ceef7d0",
+                  "associatedPullRequests": {
+                    "edges": [
+                      {
+                        "node": {
+                          "number": 206,
+                          "labels": {
+                            "edges": [
+                              {
+                                "node": {
+                                  "name": "cla: yes"
+                                }
+                              }
+                            ]
+                          }
+                        }
+                      }
+                    ]
+                  }
+                }
+              },
+              {
+                "node": {
+                  "message": "Kokoro release (#200)\n\n* Add publish and stage release Kokoro configs\r\n\r\n* Fix credentials\r\n\r\n* Use trampoline for releases\r\n\r\n* Make release scripts executable\r\n\r\n* Fix release directory\r\n\r\n* Fix pin-entry for gpg signing\r\n\r\n* temporarily bump version, fix artifact path\r\n\r\n* Try to get the nice artifact path",
+                  "oid": "eb7e8457f6f4d501a009bcd2eb560f8ad4cbdf23",
+                  "associatedPullRequests": {
+                    "edges": [
+                      {
+                        "node": {
+                          "number": 200,
+                          "labels": {
+                            "edges": [
+                              {
+                                "node": {
+                                  "name": "cla: yes"
+                                }
+                              }
+                            ]
+                          }
+                        }
+                      }
+                    ]
+                  }
+                }
+              },
+              {
+                "node": {
+                  "message": "Enable releasetool (#202)\n\n* Enable releasetool versioning\r\n\r\n* Release notes\r\n\r\n* Fix type\r\n\r\n* remove extra declared versions",
+                  "oid": "e75322bcef3e835043b075749935be0d91fa2c99",
+                  "associatedPullRequests": {
+                    "edges": [
+                      {
+                        "node": {
+                          "number": 202,
+                          "labels": {
+                            "edges": [
+                              {
+                                "node": {
+                                  "name": "cla: yes"
+                                }
+                              }
+                            ]
+                          }
+                        }
+                      }
+                    ]
+                  }
+                }
+              },
+              {
+                "node": {
+                  "message": "Add codecov (#201)\n\n* Add codecov\r\n\r\n* Get codecov credentials, run local codecov script\r\n\r\n* Add jacoco-maven-plugin for code coverage\r\n\r\n* Add java11 test config\r\n\r\n* Add codecov badge to README\r\n\r\n* Check that codecov creds are present, use gcs version\r\n\r\n* output format of test report\r\n\r\n* Remove codecov script, only use gcs version",
+                  "oid": "9e9ddb1660ef7a627dd4341b539234f316ca41b5",
+                  "associatedPullRequests": {
+                    "edges": [
+                      {
+                        "node": {
+                          "number": 201,
+                          "labels": {
+                            "edges": [
+                              {
+                                "node": {
+                                  "name": "cla: yes"
+                                }
+                              }
+                            ]
+                          }
+                        }
+                      }
+                    ]
+                  }
+                }
+              },
+              {
+                "node": {
+                  "message": "Add CODEOWNERS and issue/pr templates (#203)",
+                  "oid": "9ef4ab1563e84e0f5579747fa6e575a2e71fc736",
+                  "associatedPullRequests": {
+                    "edges": [
+                      {
+                        "node": {
+                          "number": 203,
+                          "labels": {
+                            "edges": [
+                              {
+                                "node": {
+                                  "name": "cla: yes"
+                                }
+                              }
+                            ]
+                          }
+                        }
+                      }
+                    ]
+                  }
+                }
+              },
+              {
+                "node": {
+                  "message": "Fix snapshot version in pom files and fix urls after repo move (#196)\n\n* Fix snapshot version in pom files and fix urls after repo move\r\n\r\n* fix repo and link in update_javadoc.sh script",
+                  "oid": "a6585aeb5a81961fddf5382740c22768c75759ed",
+                  "associatedPullRequests": {
+                    "edges": [
+                      {
+                        "node": {
+                          "number": 196,
+                          "labels": {
+                            "edges": [
+                              {
+                                "node": {
+                                  "name": "cla: yes"
+                                }
+                              }
+                            ]
+                          }
+                        }
+                      }
+                    ]
+                  }
+                }
+              },
+              {
+                "node": {
+                  "message": "Fix warnings (#199)\n\n* Fix javadoc warnings\r\n\r\n* Only output message for GCE detection failure at INFO level",
+                  "oid": "248fdb2557354430b3a1811924878c9f8a224031",
+                  "associatedPullRequests": {
+                    "edges": [
+                      {
+                        "node": {
+                          "number": 199,
+                          "labels": {
+                            "edges": [
+                              {
+                                "node": {
+                                  "name": "cla: yes"
+                                }
+                              }
+                            ]
+                          }
+                        }
+                      }
+                    ]
+                  }
+                }
+              },
+              {
+                "node": {
+                  "message": "Add Kokoro continuous job configs (#197)\n\n* Add continuous integration Kokoro configs\r\n\r\n* Add CI Status section to README",
+                  "oid": "1a004a3a4a0a7c1623ce777db614c5b0812bdcc5",
+                  "associatedPullRequests": {
+                    "edges": [
+                      {
+                        "node": {
+                          "number": 197,
+                          "labels": {
+                            "edges": [
+                              {
+                                "node": {
+                                  "name": "cla: yes"
+                                }
+                              }
+                            ]
+                          }
+                        }
+                      }
+                    ]
+                  }
+                }
+              },
+              {
+                "node": {
+                  "message": "README grammar fix (#192)\n\n* grammar fix\r\n\r\n* Update README.md",
+                  "oid": "f739f2f33256bdc93b2312521b38dc56780fc090",
+                  "associatedPullRequests": {
+                    "edges": [
+                      {
+                        "node": {
+                          "number": 192,
+                          "labels": {
+                            "edges": []
+                          }
+                        }
+                      }
+                    ]
+                  }
+                }
+              },
+              {
+                "node": {
+                  "message": "Add unstable badge to README (#184)",
+                  "oid": "169c4d70423e731a6c651065db9fbfaca284ade2",
+                  "associatedPullRequests": {
+                    "edges": [
+                      {
+                        "node": {
+                          "number": 184,
+                          "labels": {
+                            "edges": []
+                          }
+                        }
+                      }
+                    ]
+                  }
+                }
+              },
+              {
+                "node": {
+                  "message": "Add windows Kokoro test config (#181)\n\n* Add windows Kokoro test config\r\n\r\n* Fix location of build.bat\r\n\r\n* Fix windows working directory\r\n\r\n* Fix bath to build script\r\n\r\n* Use a tempfile for test files to avoid windows path issues\r\n\r\n* empty commit to trigger travis\r\n\r\n* Skip creating the temporary test json files.\r\n\r\nThe actual file is not necessary for the tests - we only need a valid\r\npath for the OS.\r\n\r\n* Fix joining of paths\r\n\r\n* Fix osx script",
+                  "oid": "3101a0242394b9f9bda38263dedaa296f7c7afcc",
+                  "associatedPullRequests": {
+                    "edges": [
+                      {
+                        "node": {
+                          "number": 181,
+                          "labels": {
+                            "edges": []
+                          }
+                        }
+                      }
+                    ]
+                  }
+                }
+              },
+              {
+                "node": {
+                  "message": "Fix assorted warnings (#186)\n\n* warnings\r\n\r\n* revert",
+                  "oid": "42c9906bc3b93cdb9766c2ef4a379670dab6d9f8",
+                  "associatedPullRequests": {
+                    "edges": [
+                      {
+                        "node": {
+                          "number": 186,
+                          "labels": {
+                            "edges": []
+                          }
+                        }
+                      }
+                    ]
+                  }
+                }
+              },
+              {
+                "node": {
+                  "message": "0.11.0 has been released (#182)",
+                  "oid": "15601f48fac4ed2eb8662ad976e33e601e8849f9",
+                  "associatedPullRequests": {
+                    "edges": [
+                      {
+                        "node": {
+                          "number": 182,
+                          "labels": {
+                            "edges": []
+                          }
+                        }
+                      }
+                    ]
+                  }
+                }
+              },
+              {
+                "node": {
+                  "message": "Add Kokoro CI config (#180)\n\n* Add Kokoro CI config\r\n\r\n* Fix directory",
+                  "oid": "b87c763c55f960374a7f439af675bad4549ff5e0",
+                  "associatedPullRequests": {
+                    "edges": [
+                      {
+                        "node": {
+                          "number": 180,
+                          "labels": {
+                            "edges": []
+                          }
+                        }
+                      }
+                    ]
+                  }
+                }
+              },
+              {
+                "node": {
+                  "message": "Release v0.11.0 (#179)",
+                  "oid": "64435cf60583a802564e40b3914b46e23c00b282",
+                  "associatedPullRequests": {
+                    "edges": [
+                      {
+                        "node": {
+                          "number": 179,
+                          "labels": {
+                            "edges": []
+                          }
+                        }
+                      }
+                    ]
+                  }
+                }
+              },
+              {
+                "node": {
+                  "message": "Documentation for ComputeEngineCredential signing. (#176)\n\nAdding note about enabling the IAM API and requiring the\r\niam.serviceAccounts.signBlob permission.",
+                  "oid": "f7fc855cdd9d34e57aaa501ffc66e5372c960f51",
+                  "associatedPullRequests": {
+                    "edges": [
+                      {
+                        "node": {
+                          "number": 176,
+                          "labels": {
+                            "edges": []
+                          }
+                        }
+                      }
+                    ]
+                  }
+                }
+              },
+              {
+                "node": {
+                  "message": "Update new token urls (#174)",
+                  "oid": "1b0f73404c064a82c5501c394b8fe922ea8b3cff",
+                  "associatedPullRequests": {
+                    "edges": [
+                      {
+                        "node": {
+                          "number": 174,
+                          "labels": {
+                            "edges": []
+                          }
+                        }
+                      }
+                    ]
+                  }
+                }
+              },
+              {
+                "node": {
+                  "message": "Bumping google-http-client version (#171)\n\n* Bumping google-http-client version\r\n\r\n* Bumping checkstyle to fix mac build",
+                  "oid": "df46fd3c67ceccc721878e8bd0a42c2906d36243",
+                  "associatedPullRequests": {
+                    "edges": [
+                      {
+                        "node": {
+                          "number": 171,
+                          "labels": {
+                            "edges": []
+                          }
+                        }
+                      }
+                    ]
+                  }
+                }
+              },
+              {
+                "node": {
+                  "message": "update dependencies (#170)",
+                  "oid": "185658cff1927664dde487819f6dbaa7e7a98923",
+                  "associatedPullRequests": {
+                    "edges": [
+                      {
+                        "node": {
+                          "number": 170,
+                          "labels": {
+                            "edges": []
+                          }
+                        }
+                      }
+                    ]
+                  }
+                }
+              },
+              {
+                "node": {
+                  "message": "fix link (#169)",
+                  "oid": "da0541304a994eb48f765b88b5b8911d3bdfc702",
+                  "associatedPullRequests": {
+                    "edges": [
+                      {
+                        "node": {
+                          "number": 169,
+                          "labels": {
+                            "edges": []
+                          }
+                        }
+                      }
+                    ]
+                  }
+                }
+              },
+              {
+                "node": {
+                  "message": "0.10.1-SNAPSHOT version bump (#168)",
+                  "oid": "c357d9ddf87f06c8ad05ef41b09a9c7dae752900",
+                  "associatedPullRequests": {
+                    "edges": [
+                      {
+                        "node": {
+                          "number": 168,
+                          "labels": {
+                            "edges": []
+                          }
+                        }
+                      }
+                    ]
+                  }
+                }
+              },
+              {
+                "node": {
+                  "message": "Bump release to 0.10.0 (#167)",
+                  "oid": "cb13da113c4d907ee8aafeab712757867276a7ed",
+                  "associatedPullRequests": {
+                    "edges": [
+                      {
+                        "node": {
+                          "number": 167,
+                          "labels": {
+                            "edges": []
+                          }
+                        }
+                      }
+                    ]
+                  }
+                }
+              },
+              {
+                "node": {
+                  "message": "Allows to use GCE service credentials to sign blobs (#150)\n\nFixes #141 \r\n\r\n* Allows to use GCE service credentials to sign blobs (#141)\r\n\r\n* Fix failing test (#141)\r\n\r\n* Improve error reporting (#141)\r\n\r\n* Fix issues for code review (#141)\r\n\r\n* Don't change ServiceAccountSigner method signatures\r\n* Use complete list of imports in ComputeEngineCredentials\r\n\r\n* Restore individual assert imports\r\n\r\n* No need for IAM_API_ROOT_URL constant\r\n\r\n* Add tests for failure cases",
+                  "oid": "8964e7cf71d311ee910f144db2f768149c577363",
+                  "associatedPullRequests": {
+                    "edges": [
+                      {
+                        "node": {
+                          "number": 150,
+                          "labels": {
+                            "edges": []
+                          }
+                        }
+                      }
+                    ]
+                  }
+                }
+              },
+              {
+                "node": {
+                  "message": "Log warning if default credentials yields a user token from gcloud sdk (#166)\n\n* Log warning if default credentials yields a user token from gcloud sdk\r\n\r\n* Address PR comments",
+                  "oid": "13c2418a6c511765761de9e52a9f03016044dae8",
+                  "associatedPullRequests": {
+                    "edges": [
+                      {
+                        "node": {
+                          "number": 166,
+                          "labels": {
+                            "edges": []
+                          }
+                        }
+                      }
+                    ]
+                  }
+                }
+              },
+              {
+                "node": {
+                  "message": "Add documentation note that getAccessToken() returns cached value (#162)",
+                  "oid": "4c311eeec807e8cfd37f3cd0b14a088cdd9f1362",
+                  "associatedPullRequests": {
+                    "edges": [
+                      {
+                        "node": {
+                          "number": 162,
+                          "labels": {
+                            "edges": []
+                          }
+                        }
+                      }
+                    ]
+                  }
+                }
+              },
+              {
+                "node": {
+                  "message": "Add OAuth2Credentials#refreshIfExpired() (#163)\n\n* Add OAuth2Credentials#refreshIfExpired()\r\n\r\n* Update README with info on explicit credential loading/refreshing",
+                  "oid": "64b48cbfc5805c6c8f3c8645bf1885ecbc4f6198",
+                  "associatedPullRequests": {
+                    "edges": [
+                      {
+                        "node": {
+                          "number": 163,
+                          "labels": {
+                            "edges": []
+                          }
+                        }
+                      }
+                    ]
+                  }
+                }
+              },
+              {
+                "node": {
+                  "message": "Versionless docs (#164)\n\n* Copy docs release version to latest folder\r\n\r\n* Update link to documentation to latest",
+                  "oid": "6cc107359226ab2c70c9b2d066ddf726e27a92b7",
+                  "associatedPullRequests": {
+                    "edges": [
+                      {
+                        "node": {
+                          "number": 164,
+                          "labels": {
+                            "edges": []
+                          }
+                        }
+                      }
+                    ]
+                  }
+                }
+              },
+              {
+                "node": {
+                  "message": "Read token_uri from service account JSON. (#160)",
+                  "oid": "cbc6c1062d5fe1920c6a641a4d63769b56267eb0",
+                  "associatedPullRequests": {
+                    "edges": [
+                      {
+                        "node": {
+                          "number": 160,
+                          "labels": {
+                            "edges": []
+                          }
+                        }
+                      }
+                    ]
+                  }
+                }
+              },
+              {
+                "node": {
+                  "message": "Prepare next version (0.9.2-SNAPSHOT) (#156)",
+                  "oid": "8658eb1b6a4e1e458de715a50e2d5e70b825dd87",
+                  "associatedPullRequests": {
+                    "edges": [
+                      {
+                        "node": {
+                          "number": 156,
+                          "labels": {
+                            "edges": []
+                          }
+                        }
+                      }
+                    ]
+                  }
+                }
+              },
+              {
+                "node": {
+                  "message": "Merge pull request #155 from jadekler/bump_release_0.9.1\n\nbump release from 0.9.1-SNAPSHOT to 0.9.1",
+                  "oid": "dfd7b6ddc8995bb25bc77382b32a99a54ef89a6d",
+                  "associatedPullRequests": {
+                    "edges": [
+                      {
+                        "node": {
+                          "number": 155,
+                          "labels": {
+                            "edges": []
+                          }
+                        }
+                      }
+                    ]
+                  }
+                }
+              },
+              {
+                "node": {
+                  "message": "Merge branch 'master' into bump_release_0.9.1",
+                  "oid": "c7f0153168d56fd8bdf081eda225c975efb4db68",
+                  "associatedPullRequests": {
+                    "edges": [
+                      {
+                        "node": {
+                          "number": 155,
+                          "labels": {
+                            "edges": []
+                          }
+                        }
+                      }
+                    ]
+                  }
+                }
+              },
+              {
+                "node": {
+                  "message": "bump release from 0.9.1-SNAPSHOT to 0.9.1\n\nAlso, fix a documentation problem in RELEASE.md (apparently, searching sonatype\nnow not only accepts periods but requires them).",
+                  "oid": "d0e42454cd674cedffbe7a9c0f6d837e9b233098",
+                  "associatedPullRequests": {
+                    "edges": [
+                      {
+                        "node": {
+                          "number": 155,
+                          "labels": {
+                            "edges": []
+                          }
+                        }
+                      }
+                    ]
+                  }
+                }
+              },
+              {
+                "node": {
+                  "message": "Merge pull request #154 from jadekler/patch-1\n\nUpdate RELEASE.md",
+                  "oid": "8b965c21a8f68e32a8661c17bfaddf681108dd5c",
+                  "associatedPullRequests": {
+                    "edges": [
+                      {
+                        "node": {
+                          "number": 154,
+                          "labels": {
+                            "edges": []
+                          }
+                        }
+                      }
+                    ]
+                  }
+                }
+              },
+              {
+                "node": {
+                  "message": "Update RELEASE.md\n\nRelevant issue: https://github.com/resin-io/etcher/issues/1786",
+                  "oid": "c59f51dcf1eaf8a4a1bbc5ea06025d93fcb792f6",
+                  "associatedPullRequests": {
+                    "edges": [
+                      {
+                        "node": {
+                          "number": 154,
+                          "labels": {
+                            "edges": []
+                          }
+                        }
+                      }
+                    ]
+                  }
+                }
+              },
+              {
+                "node": {
+                  "message": "Add caching for JWT tokens (#151)\n\n* Add caching for JWT tokens\r\n\r\n* code style\r\n\r\n* Add tests\r\n\r\n* refresh token 5 minutes early",
+                  "oid": "664754ee1208fe17472e41d10aa752851f610e7e",
+                  "associatedPullRequests": {
+                    "edges": [
+                      {
+                        "node": {
+                          "number": 151,
+                          "labels": {
+                            "edges": []
+                          }
+                        }
+                      }
+                    ]
+                  }
+                }
+              }
+            ],
+            "pageInfo": {
+              "endCursor": "fcd1c890dc1526f4d62ceedad561f498195c8939 99",
+              "hasNextPage": true
+            }
+          }
+        }
+      }
+    }
+  }

--- a/test/graphql-to-commits.ts
+++ b/test/graphql-to-commits.ts
@@ -36,4 +36,12 @@ describe('graphqlToCommits', () => {
     const commits = await graphqlToCommits(github, graphql);
     snapshot(commits);
   });
+
+  it('uses label for conventional commit prefix, if no prefix provided', async () => {
+    const graphql = JSON.parse(
+      readFileSync(resolve(fixturesPath, 'commits-with-labels.json'), 'utf8')
+    );
+    const commits = await graphqlToCommits(github, graphql);
+    snapshot(commits);
+  });
 });

--- a/test/updaters/fixtures/java-auth-readme.md
+++ b/test/updaters/fixtures/java-auth-readme.md
@@ -1,0 +1,33 @@
+## Quickstart
+
+If you are using Maven, add this to your pom.xml file (notice that you can replace
+`google-auth-library-oauth2-http` with any of `google-auth-library-credentials` and
+`google-auth-library-appengine`, depending on your application needs):
+
+[//]: # ({x-version-update-start:google-auth-library-oauth2-http:released})
+
+```xml
+<dependency>
+  <groupId>com.google.auth</groupId>
+  <artifactId>google-auth-library-oauth2-http</artifactId>
+  <version>0.16.2</version>
+</dependency>
+```
+[//]: # ({x-version-update-end})
+
+
+If you are using Gradle, add this to your dependencies
+
+[//]: # ({x-version-update-start:google-auth-library-oauth2-http:released})
+```Groovy
+compile 'com.google.auth:google-auth-library-oauth2-http:0.16.2'
+```
+[//]: # ({x-version-update-end})
+
+If you are using SBT, add this to your dependencies
+
+[//]: # ({x-version-update-start:google-auth-library-oauth2-http:released})
+```Scala
+libraryDependencies += "com.google.auth" % "google-auth-library-oauth2-http" % "0.16.2"
+```
+[//]: # ({x-version-update-end})

--- a/test/updaters/fixtures/java-auth-versions.txt
+++ b/test/updaters/fixtures/java-auth-versions.txt
@@ -1,0 +1,9 @@
+# Format:
+# module:released-version:current-version
+
+google-auth-library:0.16.2:0.16.2
+google-auth-library-bom:0.16.2:0.16.2
+google-auth-library-parent:0.16.2:0.16.2
+google-auth-library-appengine:0.16.2:0.16.2
+google-auth-library-credentials:0.16.2:0.16.2
+google-auth-library-oauth2-http:0.16.2:0.16.2

--- a/test/updaters/fixtures/java-auth-versions.txt
+++ b/test/updaters/fixtures/java-auth-versions.txt
@@ -1,9 +1,9 @@
 # Format:
 # module:released-version:current-version
 
-google-auth-library:0.16.2:0.16.2
-google-auth-library-bom:0.16.2:0.16.2
-google-auth-library-parent:0.16.2:0.16.2
+google-auth-library:0.16.2:0.16.2-SNAPSHOT
+google-auth-library-bom:0.16.2:0.16.2-99-SNAPSHOT
+google-auth-library-parent:0.16.2:0.16.2-alpha-SNAPSHOT
 google-auth-library-appengine:0.16.2:0.16.2
 google-auth-library-credentials:0.16.2:0.16.2
 google-auth-library-oauth2-http:0.16.2:0.16.2

--- a/test/updaters/fixtures/pom.xml
+++ b/test/updaters/fixtures/pom.xml
@@ -1,0 +1,79 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <parent>
+    <groupId>com.google.auth</groupId>
+    <artifactId>google-auth-library-parent</artifactId>
+    <version>0.16.2</version><!-- {x-version-update:google-auth-library-parent:current} -->
+    <relativePath>../pom.xml</relativePath>
+  </parent>
+
+  <artifactId>google-auth-library-appengine</artifactId>
+  <name>Google Auth Library for Java - Google App Engine</name>
+
+  <distributionManagement>
+    <snapshotRepository>
+      <id>ossrh</id>
+      <url>https://oss.sonatype.org/content/repositories/snapshots</url>
+    </snapshotRepository>
+  </distributionManagement>
+
+  <build>
+    <sourceDirectory>java</sourceDirectory>
+    <testSourceDirectory>javatests</testSourceDirectory>
+    <plugins>
+      <plugin>
+        <groupId>org.sonatype.plugins</groupId>
+        <artifactId>nexus-staging-maven-plugin</artifactId>
+      </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-source-plugin</artifactId>
+      </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-javadoc-plugin</artifactId>
+      </plugin>
+    </plugins>
+  </build>
+
+  <dependencies>
+    <dependency>
+      <groupId>com.google.auth</groupId>
+      <artifactId>google-auth-library-credentials</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>com.google.auth</groupId>
+      <artifactId>google-auth-library-oauth2-http</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>com.google.http-client</groupId>
+      <artifactId>google-http-client</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>com.google.http-client</groupId>
+      <artifactId>google-http-client-jackson2</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>com.google.appengine</groupId>
+      <artifactId>appengine-api-1.0-sdk</artifactId>
+      <scope>provided</scope>
+    </dependency>
+    <dependency>
+      <groupId>com.google.guava</groupId>
+      <artifactId>guava</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>junit</groupId>
+      <artifactId>junit</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>com.google.auth</groupId>
+      <artifactId>google-auth-library-oauth2-http</artifactId>
+      <type>test-jar</type>
+      <scope>test</scope>
+    </dependency>
+  </dependencies>
+</project>

--- a/test/updaters/fixtures/pom.xml
+++ b/test/updaters/fixtures/pom.xml
@@ -3,6 +3,12 @@
   <modelVersion>4.0.0</modelVersion>
 
   <parent>
+    <groupId>org.sonatype.oss</groupId>
+    <artifactId>oss-parent</artifactId>
+    <version>7</version>
+  </parent>
+
+  <parent>
     <groupId>com.google.auth</groupId>
     <artifactId>google-auth-library-parent</artifactId>
     <version>0.16.2</version><!-- {x-version-update:google-auth-library-parent:current} -->

--- a/test/updaters/java-auth-readme.ts
+++ b/test/updaters/java-auth-readme.ts
@@ -1,0 +1,43 @@
+/**
+ * Copyright 2019 Google LLC. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { readFileSync } from 'fs';
+import { basename, resolve } from 'path';
+import * as snapshot from 'snap-shot-it';
+
+import { JavaAuthReadme } from '../../src/updaters/java-auth-readme';
+import { UpdateOptions } from '../../src/updaters/update';
+
+const fixturesPath = './test/updaters/fixtures';
+
+describe('JavaAuthReadme', () => {
+  describe('updateContent', () => {
+    it('updates version examples in README.md', async () => {
+      const oldContent = readFileSync(
+        resolve(fixturesPath, './java-auth-readme.md'),
+        'utf8'
+      );
+      const javaAuthReadme = new JavaAuthReadme({
+        path: 'README.md',
+        changelogEntry: '',
+        version: '0.20.0',
+        packageName: 'google-auth-library-java',
+      });
+      const newContent = javaAuthReadme.updateContent(oldContent);
+      snapshot(newContent);
+    });
+  });
+});

--- a/test/updaters/java-auth-readme.ts
+++ b/test/updaters/java-auth-readme.ts
@@ -29,7 +29,7 @@ describe('JavaAuthReadme', () => {
       const oldContent = readFileSync(
         resolve(fixturesPath, './java-auth-readme.md'),
         'utf8'
-      );
+      ).replace(/\r\n/g, '\n');
       const javaAuthReadme = new JavaAuthReadme({
         path: 'README.md',
         changelogEntry: '',

--- a/test/updaters/java-auth-versions.ts
+++ b/test/updaters/java-auth-versions.ts
@@ -29,7 +29,7 @@ describe('JavaAuthVersions', () => {
       const oldContent = readFileSync(
         resolve(fixturesPath, './java-auth-versions.txt'),
         'utf8'
-      );
+      ).replace(/\r\n/g, '\n');
       const javaAuthVersions = new JavaAuthVersions({
         path: 'versions.txt',
         changelogEntry: '',
@@ -44,7 +44,7 @@ describe('JavaAuthVersions', () => {
       const oldContent = readFileSync(
         resolve(fixturesPath, './java-auth-versions.txt'),
         'utf8'
-      );
+      ).replace(/\r\n/g, '\n');
       const javaAuthVersions = new JavaAuthVersions({
         path: 'versions.txt',
         changelogEntry: '',

--- a/test/updaters/java-auth-versions.ts
+++ b/test/updaters/java-auth-versions.ts
@@ -1,0 +1,58 @@
+/**
+ * Copyright 2019 Google LLC. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { readFileSync } from 'fs';
+import { basename, resolve } from 'path';
+import * as snapshot from 'snap-shot-it';
+
+import { JavaAuthVersions } from '../../src/updaters/java-auth-versions';
+import { UpdateOptions } from '../../src/updaters/update';
+
+const fixturesPath = './test/updaters/fixtures';
+
+describe('JavaAuthVersions', () => {
+  describe('updateContent', () => {
+    it('updates versions.txt appropriately for non-SNAPSHOT release', async () => {
+      const oldContent = readFileSync(
+        resolve(fixturesPath, './java-auth-versions.txt'),
+        'utf8'
+      );
+      const javaAuthVersions = new JavaAuthVersions({
+        path: 'versions.txt',
+        changelogEntry: '',
+        version: '0.25.0',
+        packageName: 'google-auth-library-java',
+      });
+      const newContent = javaAuthVersions.updateContent(oldContent);
+      snapshot(newContent);
+    });
+
+    it('updates versions.txt appropriately for SNAPSHOT release', async () => {
+      const oldContent = readFileSync(
+        resolve(fixturesPath, './java-auth-versions.txt'),
+        'utf8'
+      );
+      const javaAuthVersions = new JavaAuthVersions({
+        path: 'versions.txt',
+        changelogEntry: '',
+        version: '0.16.2-SNAPSHOT',
+        packageName: 'google-auth-library-java',
+      });
+      const newContent = javaAuthVersions.updateContent(oldContent);
+      snapshot(newContent);
+    });
+  });
+});

--- a/test/updaters/pom-xml.ts
+++ b/test/updaters/pom-xml.ts
@@ -1,0 +1,43 @@
+/**
+ * Copyright 2019 Google LLC. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { readFileSync } from 'fs';
+import { basename, resolve } from 'path';
+import * as snapshot from 'snap-shot-it';
+
+import { PomXML } from '../../src/updaters/pom-xml';
+import { UpdateOptions } from '../../src/updaters/update';
+
+const fixturesPath = './test/updaters/fixtures';
+
+describe('PomXML', () => {
+  describe('updateContent', () => {
+    it('updates version in pom.xml', async () => {
+      const oldContent = readFileSync(
+        resolve(fixturesPath, './pom.xml'),
+        'utf8'
+      );
+      const pomXML = new PomXML({
+        path: 'pom.xml',
+        changelogEntry: '',
+        version: '0.19.0',
+        packageName: 'google-auth-library-java',
+      });
+      const newContent = pomXML.updateContent(oldContent);
+      snapshot(newContent);
+    });
+  });
+});

--- a/test/updaters/pom-xml.ts
+++ b/test/updaters/pom-xml.ts
@@ -29,7 +29,7 @@ describe('PomXML', () => {
       const oldContent = readFileSync(
         resolve(fixturesPath, './pom.xml'),
         'utf8'
-      );
+      ).replace(/\r\n/g, '\n');
       const pomXML = new PomXML({
         path: 'pom.xml',
         changelogEntry: '',


### PR DESCRIPTION
Adds support for the files that should be updated during a release of `google-auth-library-java` (_this represents a good prototype of what things will look like once the repo split happens for Java_).

New updaters added:

* `versions.txt`: for normal releases updates all entries to `version:version`, for snapshot releases updates entries to `previous-release:snapshot-release`.
* `pom.xml`: update to `<version>newVersion</version>`.
* `README.md`: update examples of Java, Scala, and Groovy imports.

@chingor13 please take a look and let me know if the logic looks right, tomorrow I'll actually integrate it with the CLI and we can play around.