### PR TITLE
fix: increase PRs checked during release to 100

### DIFF
--- a/src/github.ts
+++ b/src/github.ts
@@ -475,9 +475,7 @@ export class GitHub {
         // pull-request body.
         if (openReleasePR && openReleasePR.body === options.body) {
           checkpoint(
-            `PR https://github.com/${this.owner}/${this.repo}/pull/${
-              openReleasePR.number
-            } remained the same`,
+            `PR https://github.com/${this.owner}/${this.repo}/pull/${openReleasePR.number} remained the same`,
             CheckpointType.Failure
           );
           return -1;

--- a/src/github.ts
+++ b/src/github.ts
@@ -276,7 +276,7 @@ export class GitHub {
 
   async findMergedReleasePR(
     labels: string[],
-    perPage = 25
+    perPage = 100
   ): Promise<GitHubReleasePR | undefined> {
     const pullsResponse = (await this.request(
       `GET /repos/:owner/:repo/pulls?state=closed&per_page=${perPage}${

--- a/test/release-pr.ts
+++ b/test/release-pr.ts
@@ -48,7 +48,7 @@ describe('GitHub', () => {
       const req = nock('https://api.github.com')
         // check to see if this PR was already landed and we're
         // just waiting on the autorelease.
-        .get('/repos/googleapis/release-please/pulls?state=closed&per_page=25')
+        .get('/repos/googleapis/release-please/pulls?state=closed&per_page=100')
         .reply(200, undefined)
         // fetch semver tags, this will be used to determine
         // the delta since the last release.


### PR DESCRIPTION
hadn't planned on a mono-repo which might keep the PR open long enough for it to float down below 25 recent commits (our release PR was the 27th or so most recent commit).

I believe pulling this out to 100 would have covered us pretty well.