### PR TITLE
fix: don't print full error in --debug mode

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ system-test/fixtures/gh/*
 .coverage
 __pycache__
 package-lock.json
+debug.sh

--- a/src/bin/release-please.ts
+++ b/src/bin/release-please.ts
@@ -29,6 +29,7 @@ interface ErrorObject {
   body?: object;
   status?: number;
   message: string;
+  stack: string;
 }
 
 interface YargsOptions {
@@ -198,7 +199,7 @@ function handleError(err: ErrorObject) {
   );
   if (argv.debug) {
     console.error('---------');
-    console.error(err);
+    console.error(err.stack);
   }
   process.exitCode = 1;
 }

--- a/src/updaters/samples-package-json.ts
+++ b/src/updaters/samples-package-json.ts
@@ -45,7 +45,9 @@ export class SamplesPackageJson implements Update {
       } to ^${this.version}`,
       CheckpointType.Success
     );
-    parsed.dependencies[this.packageName] = `^${this.version}`;
+    if (parsed.dependencies[this.packageName]) {
+      parsed.dependencies[this.packageName] = `^${this.version}`;
+    }
     return JSON.stringify(parsed, null, 2) + '\n';
   }
 }

--- a/src/updaters/samples-package-json.ts
+++ b/src/updaters/samples-package-json.ts
@@ -45,9 +45,7 @@ export class SamplesPackageJson implements Update {
       } to ^${this.version}`,
       CheckpointType.Success
     );
-    if (parsed.dependencies[this.packageName]) {
-      parsed.dependencies[this.packageName] = `^${this.version}`;
-    }
+    parsed.dependencies[this.packageName] = `^${this.version}`;
     return JSON.stringify(parsed, null, 2) + '\n';
   }
 }

--- a/test/updaters/samples-package-json.ts
+++ b/test/updaters/samples-package-json.ts
@@ -44,7 +44,7 @@ describe('SamplesPackageJson', () => {
       const oldContent = readFileSync(
         resolve(fixturesPath, './samples-package-json-no-dep.json'),
         'utf8'
-      );
+      ).replace(/\r\n/g, '\n');
       const samplesPackageJson = new SamplesPackageJson({
         path: 'samples/package.json',
         changelogEntry: '',


### PR DESCRIPTION
oktokit includes auth headers and URL in the error object, this makes printing the error object a security concern.