### PR TITLE
fix: reflect yoshi's use of minor version bumps

### DIFF
--- a/__snapshots__/commit-split.js
+++ b/__snapshots__/commit-split.js
@@ -478,7 +478,7 @@ exports['CommitSplit partitions commits based on path from root directory by def
     },
     {
       "sha": "8db7f3b19c46c873897d79c89ce35b8492e5fe60",
-      "message": "feat!: move speech from alpha -> beta (#1962)",
+      "message": "feat: move speech from alpha -> beta (#1962)",
       "files": [
         "README.md",
         "Speech/README.md"

--- a/__snapshots__/github.js
+++ b/__snapshots__/github.js
@@ -145,7 +145,7 @@ exports['GitHub commitsSinceSha returns commits immediately before sha 1'] = [
   },
   {
     "sha": "8db7f3b19c46c873897d79c89ce35b8492e5fe60",
-    "message": "feat!: move speech from alpha -> beta (#1962)",
+    "message": "feat: move speech from alpha -> beta (#1962)",
     "files": [
       "README.md",
       "Speech/README.md"

--- a/__snapshots__/graphql-to-commits.js
+++ b/__snapshots__/graphql-to-commits.js
@@ -148,7 +148,7 @@ exports['graphqlToCommits converts raw graphql response into Commits object 1'] 
     },
     {
       "sha": "8db7f3b19c46c873897d79c89ce35b8492e5fe60",
-      "message": "feat!: move speech from alpha -> beta (#1962)",
+      "message": "feat: move speech from alpha -> beta (#1962)",
       "files": [
         "README.md",
         "Speech/README.md"

--- a/__snapshots__/release-pr.js
+++ b/__snapshots__/release-pr.js
@@ -53,13 +53,9 @@ exports['GitHub Yoshi PHP Mono-Repo generates CHANGELOG and aborts if duplicate 
 
 </details>
 
-<details><summary>speech 2.0.0</summary>
+<details><summary>speech 1.1.0</summary>
 
 
-
-### ⚠ BREAKING CHANGES
-
-* move speech from alpha -> beta (#1962)
 
 ### Features
 

--- a/src/conventional-commits.ts
+++ b/src/conventional-commits.ts
@@ -147,7 +147,10 @@ export class ConventionalCommits {
 
             // we have slightly different logic than the default of conventional commits,
             // the minor should be bumped when features are introduced for pre 1.x.x libs:
-            if (result.reason.indexOf(' 0 features') === -1 && result.releaseType === 'patch') {
+            if (
+              result.reason.indexOf(' 0 features') === -1 &&
+              result.releaseType === 'patch'
+            ) {
               result.releaseType = 'minor';
             }
 

--- a/src/conventional-commits.ts
+++ b/src/conventional-commits.ts
@@ -145,6 +145,12 @@ export class ConventionalCommits {
               result = {};
             }
 
+            // we have slightly different logic than the default of conventional commits,
+            // the minor should be bumped when features are introduced for pre 1.x.x libs:
+            if (result.reason.indexOf(' 0 features') === -1 && result.releaseType === 'patch') {
+              result.releaseType = 'minor';
+            }
+
             return resolve(result);
           })
         );

--- a/test/fixtures/commits-yoshi-php-monorepo.json
+++ b/test/fixtures/commits-yoshi-php-monorepo.json
@@ -698,7 +698,7 @@
             },
             {
               "node": {
-                "message": "feat!: move speech from alpha -> beta (#1962)",
+                "message": "feat: move speech from alpha -> beta (#1962)",
                 "oid": "8db7f3b19c46c873897d79c89ce35b8492e5fe60",
                 "associatedPullRequests": {
                   "edges": [


### PR DESCRIPTION
Our PHP team expects that the minor version would be bumped for new features pre 1.x.x, seems reasonable to me.