### PR TITLE
fix: address bugs found during first run on Ruby

### DIFF
--- a/src/conventional-commits.ts
+++ b/src/conventional-commits.ts
@@ -42,8 +42,8 @@ interface ConventionalCommitsOptions {
 }
 
 interface ChangelogSection {
-  type: string,
-  section: string,
+  type: string;
+  section: string;
   hidden?: boolean;
 }
 
@@ -130,7 +130,7 @@ export class ConventionalCommits {
 
     // allows the sections displayed in the CHANGELOG to be configured
     // as an example, Ruby displays docs:
-    let config: {[key: string]:ChangelogSection[]} = {};
+    const config: { [key: string]: ChangelogSection[] } = {};
     if (this.changelogSections) {
       config.types = this.changelogSections;
     }

--- a/src/conventional-commits.ts
+++ b/src/conventional-commits.ts
@@ -38,6 +38,13 @@ interface ConventionalCommitsOptions {
   commitPartial?: string;
   headerPartial?: string;
   mainTemplate?: string;
+  changelogSections?: ChangelogSection[];
+}
+
+interface ChangelogSection {
+  type: string,
+  section: string,
+  hidden?: boolean;
 }
 
 interface ChangelogEntryOptions {
@@ -77,6 +84,7 @@ export class ConventionalCommits {
   commitPartial?: string;
   headerPartial?: string;
   mainTemplate?: string;
+  changelogSections?: ChangelogSection[];
 
   constructor(options: ConventionalCommitsOptions) {
     const parsedGithubRepoUrl = parseGithubRepoUrl(options.githubRepoUrl);
@@ -92,6 +100,7 @@ export class ConventionalCommits {
     this.commitPartial = options.commitPartial;
     this.headerPartial = options.headerPartial;
     this.mainTemplate = options.mainTemplate;
+    this.changelogSections = options.changelogSections;
   }
   async suggestBump(version: string): Promise<BumpSuggestion> {
     const preMajor = this.bumpMinorPreMajor
@@ -119,7 +128,14 @@ export class ConventionalCommits {
       linkCompare: !!options.previousTag,
     };
 
-    const preset = await presetFactory({});
+    // allows the sections displayed in the CHANGELOG to be configured
+    // as an example, Ruby displays docs:
+    let config: {[key: string]:ChangelogSection[]} = {};
+    if (this.changelogSections) {
+      config.types = this.changelogSections;
+    }
+
+    const preset = await presetFactory(config);
     preset.writerOpts.commitPartial =
       this.commitPartial || preset.writerOpts.commitPartial;
     preset.writerOpts.headerPartial =

--- a/src/github.ts
+++ b/src/github.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright 2019 Google LLC. All Rights Reserved.
+ * Copyright 2019 Google LLC.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/github.ts
+++ b/src/github.ts
@@ -467,7 +467,7 @@ export class GitHub {
 
   async findOpenReleasePRs(
     labels: string[],
-    perPage = 25
+    perPage = 100
   ): Promise<PullsListResponseItem[]> {
     const openReleasePRs: PullsListResponseItem[] = [];
     const pullsResponse = (await this.request(

--- a/src/releasers/ruby-yoshi.ts
+++ b/src/releasers/ruby-yoshi.ts
@@ -78,7 +78,7 @@ export class RubyYoshi extends ReleasePR {
           resolve(__dirname, '../../../templates/template.hbs'),
           'utf8'
         ),
-        changelogSections: CHANGELOG_SECTIONS
+        changelogSections: CHANGELOG_SECTIONS,
       });
       const candidate: ReleaseCandidate = await this.coerceReleaseCandidate(
         cc,
@@ -119,9 +119,10 @@ export class RubyYoshi extends ReleasePR {
 
       updates.push(
         new VersionRB({
-          path: `${
-            this.packageName
-          }/lib/${this.packageName.replace(/-/g, '/')}/version.rb`,
+          path: `${this.packageName}/lib/${this.packageName.replace(
+            /-/g,
+            '/'
+          )}/version.rb`,
           changelogEntry,
           version: candidate.version,
           packageName: this.packageName,

--- a/test/release-pr.ts
+++ b/test/release-pr.ts
@@ -215,7 +215,7 @@ describe('GitHub', () => {
         )
         .reply(200, { number: 1 })
         // this step tries to close any existing PRs; just return an empty list.
-        .get('/repos/googleapis/release-please/pulls?state=open&per_page=25')
+        .get('/repos/googleapis/release-please/pulls?state=open&per_page=100')
         .reply(200, []);
 
       const releasePR = new PHPYoshi({


### PR DESCRIPTION
1. we now check the last 100 PRs, when deciding whether to close stale PRs.
2. we now show a "Documentation" section in changelog: only with one entry for all docs, only if at least one docs change exists.
3. our logic for updating `version.rb` was slightly off (it needed to replace `-` with `/`).