### PR TITLE
fix: address a couple more bugs with Ruby libraries

### DIFF
--- a/src/release-pr.ts
+++ b/src/release-pr.ts
@@ -118,7 +118,7 @@ export class ReleasePR {
       if (pr.number !== currentPRNumber) {
         // on mono repos that maintain multiple open release PRs, we use the
         // pull request title to differentiate between PRs:
-        if (includePackageName && !pr.title.includes(this.packageName)) {
+        if (includePackageName && !pr.title.includes(` ${this.packageName} `)) {
           continue;
         }
         checkpoint(`closing pull #${pr.number}`, CheckpointType.Failure);

--- a/src/releasers/ruby-yoshi.ts
+++ b/src/releasers/ruby-yoshi.ts
@@ -129,6 +129,16 @@ export class RubyYoshi extends ReleasePR {
         })
       );
 
+      // edge cases like grafeas-client, where there is no client folder:
+      updates.push(
+        new VersionRB({
+          path: `${this.packageName}/lib/${this.packageName.split('-')[0]}/version.rb`,
+          changelogEntry,
+          version: candidate.version,
+          packageName: this.packageName,
+        })
+      );
+
       await this.openPR(
         commits[0].sha!,
         `${changelogEntry}\n---\n${this.summarizeCommits(


### PR DESCRIPTION
* if one library contained the name of another library we would potentially close the PR for the related library (fixed this by making sure there are spaces surrounding library names when looking for PRs to close).
* grafeas had a slightly different naming convention `lib/grafeas` not `lib/grafeas-client`, we should be mindful of any other libraries that are edge cases.