### PR TITLE
feat: java-specific version bumping

### DIFF
--- a/__snapshots__/java-yoshi.js
+++ b/__snapshots__/java-yoshi.js
@@ -1,0 +1,14 @@
+exports['JavaYoshi creates a release PR 1'] = `
+:robot: I have created a release \\*beep\\* \\*boop\\* 
+---
+### [0.20.4](https://www.github.com/googleapis/java-trace/compare/v0.20.3...v0.20.4) 
+
+
+### Bug Fixes
+
+* Fix declared dependencies from merge issue ([#291](https://www.github.com/googleapis/java-trace/issues/291)) ([35abf13](https://www.github.com/googleapis/java-trace/commit/35abf13))
+---
+
+
+This PR was generated with [Release Please](https://github.com/googleapis/release-please).
+`

--- a/__snapshots__/java-yoshi.js
+++ b/__snapshots__/java-yoshi.js
@@ -1,4 +1,387 @@
 exports['JavaYoshi creates a release PR 1'] = `
+# Changelog
+
+### [0.20.4](https://www.github.com/googleapis/java-trace/compare/v0.20.3...v0.20.4) (2019-09-13)
+
+
+### Bug Fixes
+
+* Fix declared dependencies from merge issue ([#291](https://www.github.com/googleapis/java-trace/issues/291)) ([35abf13](https://www.github.com/googleapis/java-trace/commit/35abf13))
+
+`
+
+exports['JavaYoshi creates a release PR 2'] = `
+� �ॢ�Ij���'���+J֜����ӭ�%�ډب��bq�bz{_���i��+ޭ:�q�-i��+ޯ�kiǌj����i���!��]�*?��ޟ���ڗ��r����%y�h��࢈%{�%��~���z����i���!��]�*?��ޟ���ڗ��r����%y�h��࢈%{�%��~���z�����v�-�.���jب���q﩮�nrߝ��>
+X����n���:�g���b�{kiǾrX��ߥ�����\r�ד�+�'��+��)��� ��,jwfk*q�"�v��)����rL��>�w(�����^r����'$�֫�������*'��]j׾�֫�
+(�W�rZ.w�kiǫzW���H*.j���)�1�ޝ�]�������h��~)^�i]z��u���
+躒r����%y�h��஋�!֫�'�r��� ������q�ڮ؟i�Hv���*'�]<��޵��z�"��z��u��ȇ��z�"��i�^i�m�+-�*.�שzw^�Ȟ�j����jb��(�
+(�W������ ������q�5��>m�Z!����޺ȧ� Si�m�+-�*.�שzw^�Ȟ�'��bn���7�zw^�Ȟ�
+`
+
+exports['JavaYoshi creates a release PR 3'] = `
+# Format:
+# module:released-version:current-version
+
+google-cloud-trace:0.108.1-beta:0.108.1-beta
+grpc-google-cloud-trace-v1:0.73.1:0.73.1
+grpc-google-cloud-trace-v2:0.73.1:0.73.1
+proto-google-cloud-trace-v1:0.73.1:0.73.1
+proto-google-cloud-trace-v2:0.73.1:0.73.1
+`
+
+exports['JavaYoshi creates a release PR 4'] = `
+<?xml version='1.0' encoding='UTF-8'?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+  <groupId>com.google.cloud</groupId>
+  <artifactId>google-cloud-trace-parent</artifactId>
+  <packaging>pom</packaging>
+  <version>0.108.1-beta</version><!-- {x-version-update:google-cloud-trace:current} -->
+  <name>Google Cloud Trace Parent</name>
+  <url>https://github.com/googleapis/java-core</url>
+  <description>
+    Java idiomatic client for Google Cloud Platform services.
+  </description>
+
+  <parent>
+    <groupId>com.google.cloud</groupId>
+    <artifactId>google-cloud-shared-config</artifactId>
+    <version>0.1.1</version>
+  </parent>
+
+  <developers>
+    <developer>
+      <id>garrettjonesgoogle</id>
+      <name>Garrett Jones</name>
+      <email>garrettjones@google.com</email>
+      <organization>Google</organization>
+      <roles>
+        <role>Developer</role>
+      </roles>
+    </developer>
+    <developer>
+      <id>pongad</id>
+      <name>Michael Darakananda</name>
+      <email>pongad@google.com</email>
+      <organization>Google</organization>
+      <roles>
+        <role>Developer</role>
+      </roles>
+    </developer>
+    <developer>
+      <id>shinfan</id>
+      <name>Shin Fan</name>
+      <email>shinfan@google.com</email>
+      <organization>Google</organization>
+      <roles>
+        <role>Developer</role>
+      </roles>
+    </developer>
+    <developer>
+      <id>michaelbausor</id>
+      <name>Micheal Bausor</name>
+      <email>michaelbausor@google.com</email>
+      <organization>Google</organization>
+      <roles>
+        <role>Developer</role>
+      </roles>
+    </developer>
+    <developer>
+      <id>vam-google</id>
+      <name>Vadym Matsishevskyi</name>
+      <email>vam@google.com</email>
+      <organization>Google</organization>
+      <roles>
+        <role>Developer</role>
+      </roles>
+    </developer>
+    <developer>
+      <id>tswast</id>
+      <name>Tim Swast</name>
+      <email>tswast@google.com</email>
+      <organization>Google</organization>
+      <roles>
+        <role>Developer</role>
+      </roles>
+    </developer>
+    <developer>
+      <id>neozwu</id>
+      <name>Neo Wu</name>
+      <email>neowu@google.com</email>
+      <organization>Google</organization>
+      <roles>
+        <role>Developer</role>
+      </roles>
+    </developer>
+    <developer>
+      <id>lesv</id>
+      <name>Les Vogel</name>
+      <email>lesv@google.com</email>
+      <organization>Google</organization>
+      <roles>
+        <role>Developer</role>
+      </roles>
+    </developer>
+    <developer>
+      <id>schmidt_sebastian</id>
+      <name>Sebastian Schmidt</name>
+      <email>mrschmidt@google.com</email>
+      <organization>Google</organization>
+      <roles>
+        <role>Developer</role>
+      </roles>
+    </developer>
+    <developer>
+      <id>andreamlin</id>
+      <name>Andrea Lin</name>
+      <email>andrealin@google.com</email>
+      <roles>
+        <role>Developer</role>
+      </roles>
+    </developer>
+    <developer>
+      <id>hzyi-google</id>
+      <name>Hanzhen Yi</name>
+      <email>hzyi@google.com</email>
+      <roles>
+        <role>Developer</role>
+      </roles>
+    </developer>
+  </developers>
+  <organization>
+    <name>Google LLC</name>
+  </organization>
+  <scm>
+    <connection>scm:git:git@github.com:googleapis/java-core.git</connection>
+    <developerConnection>scm:git:git@github.com:googleapis/java-core.git</developerConnection>
+    <url>https://github.com/googleapis/java-core</url>
+    <tag>HEAD</tag>
+  </scm>
+  <issueManagement>
+    <url>https://github.com/googleapis/java-core/issues</url>
+    <system>GitHub Issues</system>
+  </issueManagement>
+  <distributionManagement>
+    <snapshotRepository>
+      <id>sonatype-nexus-snapshots</id>
+      <url>https://oss.sonatype.org/content/repositories/snapshots</url>
+    </snapshotRepository>
+    <repository>
+      <id>sonatype-nexus-staging</id>
+      <url>https://oss.sonatype.org/service/local/staging/deploy/maven2/</url>
+    </repository>
+  </distributionManagement>
+  <licenses>
+    <license>
+      <name>Apache-2.0</name>
+      <url>https://www.apache.org/licenses/LICENSE-2.0.txt</url>
+    </license>
+  </licenses>
+
+  <properties>
+    <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+    <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
+    <github.global.server>github</github.global.server>
+    <site.installationModule>google-cloud-trace-parent</site.installationModule>
+    <google.core.version>1.90.0</google.core.version>
+    <google.api-common.version>1.8.1</google.api-common.version>
+    <google.common-protos.version>1.16.0</google.common-protos.version>
+    <gax.version>1.48.1</gax.version>
+    <grpc.version>1.23.0</grpc.version>
+    <protobuf.version>3.9.1</protobuf.version>
+    <junit.version>4.12</junit.version>
+    <guava.version>28.0-android</guava.version>
+    <threeten.version>1.4.0</threeten.version>
+    <javax.annotations.version>1.3.2</javax.annotations.version>
+  </properties>
+
+  <dependencyManagement>
+    <dependencies>
+      <dependency>
+        <groupId>com.google.api.grpc</groupId>
+        <artifactId>proto-google-cloud-trace-v1</artifactId>
+        <version>0.73.1</version><!-- {x-version-update:proto-google-cloud-trace-v1:current} -->
+      </dependency>
+      <dependency>
+        <groupId>com.google.api.grpc</groupId>
+        <artifactId>proto-google-cloud-trace-v2</artifactId>
+        <version>0.73.1</version><!-- {x-version-update:proto-google-cloud-trace-v2:current} -->
+      </dependency>
+      <dependency>
+        <groupId>com.google.api.grpc</groupId>
+        <artifactId>grpc-google-cloud-trace-v1</artifactId>
+        <version>0.73.1</version><!-- {x-version-update:grpc-google-cloud-trace-v1:current} -->
+      </dependency>
+      <dependency>
+        <groupId>com.google.api.grpc</groupId>
+        <artifactId>grpc-google-cloud-trace-v2</artifactId>
+        <version>0.73.1</version><!-- {x-version-update:grpc-google-cloud-trace-v2:current} -->
+      </dependency>
+
+      <dependency>
+        <groupId>io.grpc</groupId>
+        <artifactId>grpc-bom</artifactId>
+        <version>\${grpc.version}</version>
+        <type>pom</type>
+        <scope>import</scope>
+      </dependency>
+      <dependency>
+        <groupId>com.google.api</groupId>
+        <artifactId>gax-bom</artifactId>
+        <version>\${gax.version}</version>
+        <type>pom</type>
+        <scope>import</scope>
+      </dependency>
+      <dependency>
+        <groupId>com.google.guava</groupId>
+        <artifactId>guava-bom</artifactId>
+        <version>\${guava.version}</version>
+        <type>pom</type>
+        <scope>import</scope>
+      </dependency>
+
+      <dependency>
+        <groupId>com.google.cloud</groupId>
+        <artifactId>google-cloud-core-grpc</artifactId>
+        <version>\${google.core.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>com.google.protobuf</groupId>
+        <artifactId>protobuf-java</artifactId>
+        <version>\${protobuf.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>com.google.api</groupId>
+        <artifactId>api-common</artifactId>
+        <version>\${google.api-common.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>com.google.api.grpc</groupId>
+        <artifactId>proto-google-common-protos</artifactId>
+        <version>\${google.common-protos.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.threeten</groupId>
+        <artifactId>threetenbp</artifactId>
+        <version>\${threeten.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>javax.annotation</groupId>
+        <artifactId>javax.annotation-api</artifactId>
+        <version>\${javax.annotations.version}</version>
+      </dependency>
+
+      <dependency>
+        <groupId>junit</groupId>
+        <artifactId>junit</artifactId>
+        <version>\${junit.version}</version>
+        <scope>test</scope>
+      </dependency>
+      <dependency>
+        <groupId>com.google.api</groupId>
+        <artifactId>gax-grpc</artifactId>
+        <version>\${gax.version}</version>
+        <classifier>testlib</classifier>
+        <scope>test</scope>
+      </dependency>
+    </dependencies>
+  </dependencyManagement>
+
+  <build>
+    <pluginManagement>
+      <plugins>
+        <plugin>
+          <groupId>org.apache.maven.plugins</groupId>
+          <artifactId>maven-dependency-plugin</artifactId>
+          <configuration>
+            <ignoredUnusedDeclaredDependencies>org.objenesis:objenesis</ignoredUnusedDeclaredDependencies>
+          </configuration>
+        </plugin>
+      </plugins>
+    </pluginManagement>
+  </build>
+
+  <modules>
+    <module>proto-google-cloud-trace-v1</module>
+    <module>proto-google-cloud-trace-v2</module>
+    <module>grpc-google-cloud-trace-v1</module>
+    <module>grpc-google-cloud-trace-v2</module>
+    <module>google-cloud-trace</module>
+  </modules>
+
+  <reporting>
+    <plugins>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-project-info-reports-plugin</artifactId>
+        <version>3.0.0</version>
+        <reportSets>
+          <reportSet>
+            <reports>
+              <report>index</report>
+              <report>dependency-info</report>
+              <report>team</report>
+              <report>ci-management</report>
+              <report>issue-management</report>
+              <report>licenses</report>
+              <report>scm</report>
+              <report>dependency-management</report>
+              <report>distribution-management</report>
+              <report>summary</report>
+              <report>modules</report>
+            </reports>
+          </reportSet>
+        </reportSets>
+        <configuration>
+          <dependencyDetailsEnabled>true</dependencyDetailsEnabled>
+          <artifactId>\${site.installationModule}</artifactId>
+          <packaging>jar</packaging>
+        </configuration>
+      </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-javadoc-plugin</artifactId>
+        <version>3.1.1</version>
+        <reportSets>
+          <reportSet>
+            <id>html</id>
+            <reports>
+              <report>aggregate</report>
+              <report>javadoc</report>
+            </reports>
+          </reportSet>
+        </reportSets>
+        <configuration>
+          <doclint>none</doclint>
+          <show>protected</show>
+          <nohelp>true</nohelp>
+          <outputDirectory>\${project.build.directory}/javadoc</outputDirectory>
+          <groups>
+            <group>
+              <title>Test helpers packages</title>
+              <packages>com.google.cloud.testing</packages>
+            </group>
+            <group>
+              <title>SPI packages</title>
+              <packages>com.google.cloud.spi*</packages>
+            </group>
+          </groups>
+
+          <links>
+            <link>https://grpc.io/grpc-java/javadoc/</link>
+            <link>https://developers.google.com/protocol-buffers/docs/reference/java/</link>
+            <link>https://googleapis.dev/java/google-auth-library/latest/</link>
+            <link>https://googleapis.dev/java/gax/latest/</link>
+            <link>https://googleapis.github.io/api-common-java/\${google.api-common.version}/apidocs/</link>
+          </links>
+        </configuration>
+      </plugin>
+    </plugins>
+  </reporting>
+</project>
+`
+
+exports['JavaYoshi creates a release PR 5'] = `
 :robot: I have created a release \\*beep\\* \\*boop\\* 
 ---
 ### [0.20.4](https://www.github.com/googleapis/java-trace/compare/v0.20.3...v0.20.4) 

--- a/__snapshots__/java-yoshi.js
+++ b/__snapshots__/java-yoshi.js
@@ -1,7 +1,7 @@
 exports['CHANGELOG'] = `
 # Changelog
 
-### [0.20.4](https://www.github.com/googleapis/java-trace/compare/v0.20.3...v0.20.4) (2019-09-13)
+### [0.20.4](https://www.github.com/googleapis/java-trace/compare/v0.20.3...v0.20.4) 
 
 
 ### Bug Fixes

--- a/__snapshots__/java-yoshi.js
+++ b/__snapshots__/java-yoshi.js
@@ -1,4 +1,4 @@
-exports['JavaYoshi creates a release PR 1'] = `
+exports['CHANGELOG'] = `
 # Changelog
 
 ### [0.20.4](https://www.github.com/googleapis/java-trace/compare/v0.20.3...v0.20.4) (2019-09-13)
@@ -10,7 +10,7 @@ exports['JavaYoshi creates a release PR 1'] = `
 
 `
 
-exports['JavaYoshi creates a release PR 2'] = `
+exports['README'] = `
 � �ॢ�Ij���'���+J֜����ӭ�%�ډب��bq�bz{_���i��+ޭ:�q�-i��+ޯ�kiǌj����i���!��]�*?��ޟ���ڗ��r����%y�h��࢈%{�%��~���z����i���!��]�*?��ޟ���ڗ��r����%y�h��࢈%{�%��~���z�����v�-�.���jب���q﩮�nrߝ��>
 X����n���:�g���b�{kiǾrX��ߥ�����\r�ד�+�'��+��)��� ��,jwfk*q�"�v��)����rL��>�w(�����^r����'$�֫�������*'��]j׾�֫�
 (�W�rZ.w�kiǫzW���H*.j���)�1�ޝ�]�������h��~)^�i]z��u���
@@ -18,7 +18,7 @@ X����n���:�g���b�{kiǾrX��ߥ�����\r�ד�
 (�W������ ������q�5��>m�Z!����޺ȧ� Si�m�+-�*.�שzw^�Ȟ�'��bn���7�zw^�Ȟ�
 `
 
-exports['JavaYoshi creates a release PR 3'] = `
+exports['versions'] = `
 # Format:
 # module:released-version:current-version
 
@@ -29,7 +29,7 @@ proto-google-cloud-trace-v1:0.73.1:0.73.1
 proto-google-cloud-trace-v2:0.73.1:0.73.1
 `
 
-exports['JavaYoshi creates a release PR 4'] = `
+exports['pom'] = `
 <?xml version='1.0' encoding='UTF-8'?>
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
@@ -381,7 +381,7 @@ exports['JavaYoshi creates a release PR 4'] = `
 </project>
 `
 
-exports['JavaYoshi creates a release PR 5'] = `
+exports['PR body'] = `
 :robot: I have created a release \\*beep\\* \\*boop\\* 
 ---
 ### [0.20.4](https://www.github.com/googleapis/java-trace/compare/v0.20.3...v0.20.4) 

--- a/__snapshots__/java-yoshi.js
+++ b/__snapshots__/java-yoshi.js
@@ -11,11 +11,106 @@ exports['CHANGELOG'] = `
 `
 
 exports['README'] = `
-� �ॢ�Ij���'���+J֜����ӭ�%�ډب��bq�bz{_���i��+ޭ:�q�-i��+ޯ�kiǌj����i���!��]�*?��ޟ���ڗ��r����%y�h��࢈%{�%��~���z����i���!��]�*?��ޟ���ڗ��r����%y�h��࢈%{�%��~���z�����v�-�.���jب���q﩮�nrߝ��>
-X����n���:�g���b�{kiǾrX��ߥ�����\r�ד�+�'��+��)��� ��,jwfk*q�"�v��)����rL��>�w(�����^r����'$�֫�������*'��]j׾�֫�
-(�W�rZ.w�kiǫzW���H*.j���)�1�ޝ�]�������h��~)^�i]z��u���
-躒r����%y�h��஋�!֫�'�r��� ������q�ڮ؟i�Hv���*'�]<��޵��z�"��z��u��ȇ��z�"��i�^i�m�+-�*.�שzw^�Ȟ�j����jb��(�
-(�W������ ������q�5��>m�Z!����޺ȧ� Si�m�+-�*.�שzw^�Ȟ�'��bn���7�zw^�Ȟ�
+# Google Cloud Java Client for Stackdriver Trace
+
+Java idiomatic client for [Stackdriver Trace][stackdriver-trace].
+
+[![Maven](https://img.shields.io/maven-central/v/com.google.cloud/google-cloud-trace.svg)](https://img.shields.io/maven-central/v/com.google.cloud/google-cloud-trace.svg)
+
+- [Product Documentation][trace-product-docs]
+- [Client Library Documentation][trace-client-lib-docs]
+
+> Note: This client is a work-in-progress, and may occasionally
+> make backwards-incompatible changes.
+
+## Quickstart
+
+[//]: # ({x-version-update-start:google-cloud-trace:released})
+If you are using Maven, add this to your pom.xml file
+\`\`\`xml
+<dependency>
+  <groupId>com.google.cloud</groupId>
+  <artifactId>google-cloud-trace</artifactId>
+  <version>0.108.1-beta</version>
+</dependency>
+\`\`\`
+If you are using Gradle, add this to your dependencies
+\`\`\`Groovy
+compile 'com.google.cloud:google-cloud-trace:0.108.1-beta'
+\`\`\`
+If you are using SBT, add this to your dependencies
+\`\`\`Scala
+libraryDependencies += "com.google.cloud" % "google-cloud-trace" % "0.108.1-beta"
+\`\`\`
+[//]: # ({x-version-update-end})
+
+## Authentication
+
+See the [Authentication](https://github.com/googleapis/google-cloud-java#authentication) section in the base directory's README.
+
+## About Stackdriver Trace
+
+[Stackdriver Trace][stackdriver-trace] is a distributed tracing system that collects latency data from your applications and displays it in the Google Cloud Platform Console. You can track how requests propagate through your application and receive detailed near real-time performance insights.
+
+See the [Trace client library docs][trace-client-lib-docs] to learn how to use this client library.
+
+## Getting Started
+
+### Prerequisites
+
+You will need a [Google Developers Console](https://console.developers.google.com/) project with the Stackdriver Trace API enabled. [Follow these instructions](https://cloud.google.com/resource-manager/docs/creating-managing-projects) to get your project set up. You will also need to set up the local development environment by [installing the Google Cloud SDK](https://cloud.google.com/sdk/) and running the following commands in command line: \`gcloud auth login\` and \`gcloud config set project [YOUR PROJECT ID]\`.
+
+### Installation and setup
+
+You'll need to obtain the \`google-cloud-trace\` library.  See the [Quickstart](#quickstart) section to add \`google-cloud-trace\` as a dependency in your code.
+
+## Troubleshooting
+
+To get help, follow the instructions in the [shared Troubleshooting document](https://github.com/googleapis/google-cloud-common/blob/master/troubleshooting/readme.md#troubleshooting).
+
+## Transport
+
+Trace uses gRPC for the transport layer.
+
+## Java Versions
+
+Java 7 or above is required for using this client.
+
+## Versioning
+
+This library follows [Semantic Versioning](http://semver.org/).
+
+It is currently in major version zero (\`\`0.y.z\`\`), which means that anything may change at any time and the public API should not be considered stable.
+
+## Contributing
+
+Contributions to this library are always welcome and highly encouraged.
+
+See \`google-cloud\`'s [CONTRIBUTING] documentation and the [shared documentation](https://github.com/googleapis/google-cloud-common/blob/master/contributing/readme.md#how-to-contribute-to-gcloud) for more information on how to get started.
+
+Please note that this project is released with a Contributor Code of Conduct. By participating in this project you agree to abide by its terms. See [Code of Conduct][code-of-conduct] for more information.
+
+## License
+
+Apache 2.0 - See [LICENSE] for more information.
+
+## CI Status
+
+Java Version | Status
+------------ | ------
+Java 7 | [![Kokoro CI](https://storage.googleapis.com/cloud-devrel-public/java/badges/java-trace/java7.svg)](https://storage.googleapis.com/cloud-devrel-public/java/badges/java-trace/java7.html)
+Java 8 | [![Kokoro CI](https://storage.googleapis.com/cloud-devrel-public/java/badges/java-trace/java8.svg)](https://storage.googleapis.com/cloud-devrel-public/java/badges/java-trace/java8.html)
+Java 11 | [![Kokoro CI](https://storage.googleapis.com/cloud-devrel-public/java/badges/java-trace/java11.svg)](https://storage.googleapis.com/cloud-devrel-public/java/badges/java-trace/java11.html)
+
+
+[CONTRIBUTING]:https://github.com/googleapis/google-cloud-java/blob/master/CONTRIBUTING.md
+[code-of-conduct]:https://github.com/googleapis/google-cloud-java/blob/master/CODE_OF_CONDUCT.md#contributor-code-of-conduct
+[LICENSE]: https://github.com/googleapis/google-cloud-java/blob/master/LICENSE
+[cloud-platform]: https://cloud.google.com/
+[stackdriver-trace]: https://cloud.google.com/trace/
+[trace-product-docs]: https://cloud.google.com/trace/docs/
+[trace-client-lib-docs]: https://googleapis.dev/java/google-cloud-clients/latest/index.html?com/google/cloud/trace/v1/package-summary.html
+
 `
 
 exports['versions'] = `

--- a/src/github.ts
+++ b/src/github.ts
@@ -743,7 +743,6 @@ export class GitHub {
         ? Buffer.from(content.data.content, 'base64').toString('utf8')
         : undefined;
       const updatedContent = update.updateContent(contentText);
-      console.log(updatedContent);
 
       if (content) {
         await this.request(

--- a/src/github.ts
+++ b/src/github.ts
@@ -743,6 +743,7 @@ export class GitHub {
         ? Buffer.from(content.data.content, 'base64').toString('utf8')
         : undefined;
       const updatedContent = update.updateContent(contentText);
+      console.log(updatedContent);
 
       if (content) {
         await this.request(

--- a/src/releasers/java-yoshi.ts
+++ b/src/releasers/java-yoshi.ts
@@ -113,8 +113,6 @@ export class Version {
         this.patch += 1;
         this.snapshot = true;
         break;
-      default:
-        throw Error(`unsupported bump type: ${bumpType}`);
     }
   }
 

--- a/src/releasers/java-yoshi.ts
+++ b/src/releasers/java-yoshi.ts
@@ -55,7 +55,13 @@ export class Version {
   extra: string;
   snapshot: boolean;
 
-  constructor(major: number, minor: number, patch: number, extra: string, snapshot: boolean) {
+  constructor(
+    major: number,
+    minor: number,
+    patch: number,
+    extra: string,
+    snapshot: boolean
+  ) {
     this.major = major;
     this.minor = minor;
     this.patch = patch;
@@ -87,7 +93,7 @@ export class Version {
   }
 
   bump(bumpType: BumpType) {
-    switch(bumpType) {
+    switch (bumpType) {
       case 'major':
         this.major += 1;
         this.minor = 0;
@@ -113,7 +119,9 @@ export class Version {
   }
 
   toString(): string {
-    return `${this.major}.${this.minor}.${this.patch}${this.extra}${this.snapshot ? '-SNAPSHOT' : ''}`
+    return `${this.major}.${this.minor}.${this.patch}${this.extra}${
+      this.snapshot ? '-SNAPSHOT' : ''
+    }`;
   }
 }
 
@@ -267,7 +275,7 @@ export class JavaYoshi extends ReleasePR {
     if (this.snapshot) {
       return 'snapshot';
     }
-    switch(releaseType) {
+    switch (releaseType) {
       case 'major':
       case 'minor':
       case 'patch':

--- a/src/releasers/java-yoshi.ts
+++ b/src/releasers/java-yoshi.ts
@@ -30,6 +30,8 @@ import { PomXML } from '../updaters/java/pom-xml';
 import { VersionsManifest } from '../updaters/java/versions-manifest';
 import { Readme } from '../updaters/java/readme';
 
+type BumpType = 'major' | 'minor' | 'patch' | 'snapshot';
+
 const CHANGELOG_SECTIONS = [
   { type: 'feat', section: 'Features' },
   { type: 'fix', section: 'Bug Fixes' },
@@ -44,6 +46,76 @@ const CHANGELOG_SECTIONS = [
   { type: 'build', section: 'Build System', hidden: true },
   { type: 'ci', section: 'Continuous Integration', hidden: true },
 ];
+
+const VERSION_REGEX = /(\d+)\.(\d+)\.(\d+)(-\w+)?(-SNAPSHOT)?/;
+export class Version {
+  major: number;
+  minor: number;
+  patch: number;
+  extra: string;
+  snapshot: boolean;
+
+  constructor(major: number, minor: number, patch: number, extra: string, snapshot: boolean) {
+    this.major = major;
+    this.minor = minor;
+    this.patch = patch;
+    this.extra = extra;
+    this.snapshot = snapshot;
+  }
+
+  static parse(version: string): Version {
+    const match = version.match(VERSION_REGEX);
+    if (!match) {
+      throw Error(`unable to parse version string: ${version}`);
+    }
+    const major = Number(match[1]);
+    const minor = Number(match[2]);
+    const patch = Number(match[3]);
+    let extra = '';
+    let snapshot = false;
+    if (match[5]) {
+      extra = match[4];
+      snapshot = match[5] === '-SNAPSHOT';
+    } else if (match[4]) {
+      if (match[4] === '-SNAPSHOT') {
+        snapshot = true;
+      } else {
+        extra = match[4];
+      }
+    }
+    return new Version(major, minor, patch, extra, snapshot);
+  }
+
+  bump(bumpType: BumpType) {
+    switch(bumpType) {
+      case 'major':
+        this.major += 1;
+        this.minor = 0;
+        this.patch = 0;
+        this.snapshot = false;
+        break;
+      case 'minor':
+        this.minor += 1;
+        this.patch = 0;
+        this.snapshot = false;
+        break;
+      case 'patch':
+        this.patch += 1;
+        this.snapshot = false;
+        break;
+      case 'snapshot':
+        this.patch += 1;
+        this.snapshot = true;
+        break;
+      default:
+        throw Error(`unsupported bump type: ${bumpType}`);
+    }
+  }
+
+  toString(): string {
+    return `${this.major}.${this.minor}.${this.patch}${this.extra}${this.snapshot ? '-SNAPSHOT' : ''}`
+  }
+}
 
 export class JavaYoshi extends ReleasePR {
   constructor(options: ReleasePROptions) {
@@ -184,13 +256,24 @@ export class JavaYoshi extends ReleasePR {
     const newVersions: VersionsMap = new Map<string, string>();
     for (const [k, version] of currentVersions) {
       const bump = await cc.suggestBump(version);
-      const candidate: string | null = semver.inc(version, bump.releaseType);
-      if (candidate) {
-        newVersions.set(k, candidate);
-      } else {
-        throw Error(`failed to increment ${k} @ ${version}`);
-      }
+      const newVersion = Version.parse(version);
+      newVersion.bump(this.coerceBumpType(bump.releaseType));
+      newVersions.set(k, newVersion.toString());
     }
     return newVersions;
+  }
+
+  private coerceBumpType(releaseType: semver.ReleaseType): BumpType {
+    if (this.snapshot) {
+      return 'snapshot';
+    }
+    switch(releaseType) {
+      case 'major':
+      case 'minor':
+      case 'patch':
+        return releaseType;
+      default:
+        throw Error(`unsupported release type ${releaseType}`);
+    }
   }
 }

--- a/src/releasers/java-yoshi.ts
+++ b/src/releasers/java-yoshi.ts
@@ -113,6 +113,8 @@ export class Version {
         this.patch += 1;
         this.snapshot = true;
         break;
+      default:
+        throw Error(`unsupported bump type: ${bumpType}`);
     }
   }
 

--- a/src/updaters/java/versions-manifest.ts
+++ b/src/updaters/java/versions-manifest.ts
@@ -30,23 +30,27 @@ export class VersionsManifest extends JavaUpdate {
     packageName: string,
     version: string
   ): string {
-    if (version.includes('SNAPSHOT')) {
-      return content.replace(
-        new RegExp(
-          `${packageName}:(.*):[0-9]+\\.[0-9]+\\.[0-9]+(-\\w+)?(-SNAPSHOT)?`,
-          'g'
-        ),
-        `${packageName}:$1:${version}`
-      );
-    } else {
-      return content.replace(
-        new RegExp(
-          `${packageName}:[0-9]+\\.[0-9]+\\.[0-9]+(-\\w+)?:[0-9]+\\.[0-9]+\\.[0-9]+(-\\w+)?(-SNAPSHOT)?`,
-          'g'
-        ),
-        `${packageName}:${version}:${version}`
-      );
-    }
+    const newLines: string[] = [];
+    content.split(/\r?\n/).forEach(line => {
+      if (version.includes('SNAPSHOT')) {
+        newLines.push(line.replace(
+          new RegExp(
+            `${packageName}:(.*):[0-9]+\\.[0-9]+\\.[0-9]+(-\\w+)?(-SNAPSHOT)?`,
+            'g'
+          ),
+          `${packageName}:$1:${version}`
+        ));
+      } else {
+        newLines.push(line.replace(
+          new RegExp(
+            `${packageName}:[0-9]+\\.[0-9]+\\.[0-9]+(-\\w+)?:[0-9]+\\.[0-9]+\\.[0-9]+(-\\w+)?(-SNAPSHOT)?`,
+            'g'
+          ),
+          `${packageName}:${version}:${version}`
+        ));
+      }
+    });
+    return newLines.join("\n");
   }
 
   static parseVersions(content: string): VersionsMap {

--- a/src/updaters/java/versions-manifest.ts
+++ b/src/updaters/java/versions-manifest.ts
@@ -33,24 +33,28 @@ export class VersionsManifest extends JavaUpdate {
     const newLines: string[] = [];
     content.split(/\r?\n/).forEach(line => {
       if (version.includes('SNAPSHOT')) {
-        newLines.push(line.replace(
-          new RegExp(
-            `${packageName}:(.*):[0-9]+\\.[0-9]+\\.[0-9]+(-\\w+)?(-SNAPSHOT)?`,
-            'g'
-          ),
-          `${packageName}:$1:${version}`
-        ));
+        newLines.push(
+          line.replace(
+            new RegExp(
+              `${packageName}:(.*):[0-9]+\\.[0-9]+\\.[0-9]+(-\\w+)?(-SNAPSHOT)?`,
+              'g'
+            ),
+            `${packageName}:$1:${version}`
+          )
+        );
       } else {
-        newLines.push(line.replace(
-          new RegExp(
-            `${packageName}:[0-9]+\\.[0-9]+\\.[0-9]+(-\\w+)?:[0-9]+\\.[0-9]+\\.[0-9]+(-\\w+)?(-SNAPSHOT)?`,
-            'g'
-          ),
-          `${packageName}:${version}:${version}`
-        ));
+        newLines.push(
+          line.replace(
+            new RegExp(
+              `${packageName}:[0-9]+\\.[0-9]+\\.[0-9]+(-\\w+)?:[0-9]+\\.[0-9]+\\.[0-9]+(-\\w+)?(-SNAPSHOT)?`,
+              'g'
+            ),
+            `${packageName}:${version}:${version}`
+          )
+        );
       }
     });
-    return newLines.join("\n");
+    return newLines.join('\n');
   }
 
   static parseVersions(content: string): VersionsMap {

--- a/src/updaters/java/versions-manifest.ts
+++ b/src/updaters/java/versions-manifest.ts
@@ -33,7 +33,7 @@ export class VersionsManifest extends JavaUpdate {
     if (version.includes('SNAPSHOT')) {
       return content.replace(
         new RegExp(
-          `${packageName}:(.*):[0-9]+\\.[0-9]+\\.[0-9]+(-\\w+)?(-SNAPSHOT)?[\\r\\n]`,
+          `${packageName}:(.*):[0-9]+\\.[0-9]+\\.[0-9]+(-\\w+)?(-SNAPSHOT)?\\r?\\n`,
           'g'
         ),
         `${packageName}:$1:${version}\n`
@@ -41,10 +41,10 @@ export class VersionsManifest extends JavaUpdate {
     } else {
       return content.replace(
         new RegExp(
-          `${packageName}:[0-9]+\\.[0-9]+\\.[0-9]+(-\\w+)?:[0-9]+\\.[0-9]+\\.[0-9]+(-\\w+)?(-SNAPSHOT)?`,
+          `${packageName}:[0-9]+\\.[0-9]+\\.[0-9]+(-\\w+)?:[0-9]+\\.[0-9]+\\.[0-9]+(-\\w+)?(-SNAPSHOT)?\\r?\\n`,
           'g'
         ),
-        `${packageName}:${version}:${version}`
+        `${packageName}:${version}:${version}\n`
       );
     }
   }

--- a/src/updaters/java/versions-manifest.ts
+++ b/src/updaters/java/versions-manifest.ts
@@ -33,18 +33,18 @@ export class VersionsManifest extends JavaUpdate {
     if (version.includes('SNAPSHOT')) {
       return content.replace(
         new RegExp(
-          `${packageName}:(.*):[0-9]+\\.[0-9]+\\.[0-9]+(-\\w+)?(-SNAPSHOT)?\\r?\\n`,
+          `${packageName}:(.*):[0-9]+\\.[0-9]+\\.[0-9]+(-\\w+)?(-SNAPSHOT)?`,
           'g'
         ),
-        `${packageName}:$1:${version}\n`
+        `${packageName}:$1:${version}`
       );
     } else {
       return content.replace(
         new RegExp(
-          `${packageName}:[0-9]+\\.[0-9]+\\.[0-9]+(-\\w+)?:[0-9]+\\.[0-9]+\\.[0-9]+(-\\w+)?(-SNAPSHOT)?\\r?\\n`,
+          `${packageName}:[0-9]+\\.[0-9]+\\.[0-9]+(-\\w+)?:[0-9]+\\.[0-9]+\\.[0-9]+(-\\w+)?(-SNAPSHOT)?`,
           'g'
         ),
-        `${packageName}:${version}:${version}\n`
+        `${packageName}:${version}:${version}`
       );
     }
   }

--- a/test/releasers/fixtures/README.md
+++ b/test/releasers/fixtures/README.md
@@ -1,0 +1,99 @@
+# Google Cloud Java Client for Stackdriver Trace
+
+Java idiomatic client for [Stackdriver Trace][stackdriver-trace].
+
+[![Maven](https://img.shields.io/maven-central/v/com.google.cloud/google-cloud-trace.svg)](https://img.shields.io/maven-central/v/com.google.cloud/google-cloud-trace.svg)
+
+- [Product Documentation][trace-product-docs]
+- [Client Library Documentation][trace-client-lib-docs]
+
+> Note: This client is a work-in-progress, and may occasionally
+> make backwards-incompatible changes.
+
+## Quickstart
+
+[//]: # ({x-version-update-start:google-cloud-trace:released})
+If you are using Maven, add this to your pom.xml file
+```xml
+<dependency>
+  <groupId>com.google.cloud</groupId>
+  <artifactId>google-cloud-trace</artifactId>
+  <version>0.108.0-beta</version>
+</dependency>
+```
+If you are using Gradle, add this to your dependencies
+```Groovy
+compile 'com.google.cloud:google-cloud-trace:0.108.0-beta'
+```
+If you are using SBT, add this to your dependencies
+```Scala
+libraryDependencies += "com.google.cloud" % "google-cloud-trace" % "0.108.0-beta"
+```
+[//]: # ({x-version-update-end})
+
+## Authentication
+
+See the [Authentication](https://github.com/googleapis/google-cloud-java#authentication) section in the base directory's README.
+
+## About Stackdriver Trace
+
+[Stackdriver Trace][stackdriver-trace] is a distributed tracing system that collects latency data from your applications and displays it in the Google Cloud Platform Console. You can track how requests propagate through your application and receive detailed near real-time performance insights.
+
+See the [Trace client library docs][trace-client-lib-docs] to learn how to use this client library.
+
+## Getting Started
+
+### Prerequisites
+
+You will need a [Google Developers Console](https://console.developers.google.com/) project with the Stackdriver Trace API enabled. [Follow these instructions](https://cloud.google.com/resource-manager/docs/creating-managing-projects) to get your project set up. You will also need to set up the local development environment by [installing the Google Cloud SDK](https://cloud.google.com/sdk/) and running the following commands in command line: `gcloud auth login` and `gcloud config set project [YOUR PROJECT ID]`.
+
+### Installation and setup
+
+You'll need to obtain the `google-cloud-trace` library.  See the [Quickstart](#quickstart) section to add `google-cloud-trace` as a dependency in your code.
+
+## Troubleshooting
+
+To get help, follow the instructions in the [shared Troubleshooting document](https://github.com/googleapis/google-cloud-common/blob/master/troubleshooting/readme.md#troubleshooting).
+
+## Transport
+
+Trace uses gRPC for the transport layer.
+
+## Java Versions
+
+Java 7 or above is required for using this client.
+
+## Versioning
+
+This library follows [Semantic Versioning](http://semver.org/).
+
+It is currently in major version zero (``0.y.z``), which means that anything may change at any time and the public API should not be considered stable.
+
+## Contributing
+
+Contributions to this library are always welcome and highly encouraged.
+
+See `google-cloud`'s [CONTRIBUTING] documentation and the [shared documentation](https://github.com/googleapis/google-cloud-common/blob/master/contributing/readme.md#how-to-contribute-to-gcloud) for more information on how to get started.
+
+Please note that this project is released with a Contributor Code of Conduct. By participating in this project you agree to abide by its terms. See [Code of Conduct][code-of-conduct] for more information.
+
+## License
+
+Apache 2.0 - See [LICENSE] for more information.
+
+## CI Status
+
+Java Version | Status
+------------ | ------
+Java 7 | [![Kokoro CI](https://storage.googleapis.com/cloud-devrel-public/java/badges/java-trace/java7.svg)](https://storage.googleapis.com/cloud-devrel-public/java/badges/java-trace/java7.html)
+Java 8 | [![Kokoro CI](https://storage.googleapis.com/cloud-devrel-public/java/badges/java-trace/java8.svg)](https://storage.googleapis.com/cloud-devrel-public/java/badges/java-trace/java8.html)
+Java 11 | [![Kokoro CI](https://storage.googleapis.com/cloud-devrel-public/java/badges/java-trace/java11.svg)](https://storage.googleapis.com/cloud-devrel-public/java/badges/java-trace/java11.html)
+
+
+[CONTRIBUTING]:https://github.com/googleapis/google-cloud-java/blob/master/CONTRIBUTING.md
+[code-of-conduct]:https://github.com/googleapis/google-cloud-java/blob/master/CODE_OF_CONDUCT.md#contributor-code-of-conduct
+[LICENSE]: https://github.com/googleapis/google-cloud-java/blob/master/LICENSE
+[cloud-platform]: https://cloud.google.com/
+[stackdriver-trace]: https://cloud.google.com/trace/
+[trace-product-docs]: https://cloud.google.com/trace/docs/
+[trace-client-lib-docs]: https://googleapis.dev/java/google-cloud-clients/latest/index.html?com/google/cloud/trace/v1/package-summary.html

--- a/test/releasers/fixtures/commits-yoshi-java.json
+++ b/test/releasers/fixtures/commits-yoshi-java.json
@@ -1,0 +1,121 @@
+{
+  "repository": {
+    "defaultBranchRef": {
+      "target": {
+        "history": {
+          "edges": [
+            {
+              "node": {
+                "message": "Refactor shared IAM-based signing (#292)\n\n* Extract IAM signing into its own class\r\n\r\n* Refactor into IamUtils package private class\r\n\r\n* Remove unnecessary class\r\n\r\n* Remove unused code\r\n\r\n* Cleanup imports\r\n\r\n* Fill out javadoc for IamUtils\r\n\r\n* Failing tests for impersonated credentials\r\n\r\n* Fix credentials used for signing\r\n\r\n* Fix providing delegates to signing request\r\n\r\n* Disallow null additionalFields, remove jsr305 annotation\r\n\r\n* Remove usued imports",
+                "oid": "fcd1c890dc1526f4d62ceedad561f498195c8939",
+                "associatedPullRequests": {
+                  "edges": [
+                    {
+                      "node": {
+                        "mergeCommit": {"oid": "fcd1c890dc1526f4d62ceedad561f498195c8939"},
+                        "number": 292,
+                        "labels": {
+                          "edges": [
+                            {
+                              "node": {
+                                "name": "cla: yes"
+                              }
+                            }
+                          ]
+                        }
+                      }
+                    }
+                  ]
+                }
+              }
+            },
+            {
+              "node": {
+                "message": "Update allowed header format (#301)\n\n* Update copyright format  \r\n\r\n@chingor13\r\n\r\n* Update java.header\r\n\r\n* add legacy copyright\r\n\r\n* remove spurious $",
+                "oid": "1f9663cf08ab1cf3b68d95dee4dc99b7c4aac373",
+                "associatedPullRequests": {
+                  "edges": [
+                    {
+                      "node": {
+                        "mergeCommit": {"oid": "1f9663cf08ab1cf3b68d95dee4dc99b7c4aac373"},
+                        "number": 301,
+                        "labels": {
+                          "edges": [
+                            {
+                              "node": {
+                                "name": "cla: yes"
+                              }
+                            }
+                          ]
+                        }
+                      }
+                    }
+                  ]
+                }
+              }
+            },
+            {
+              "node": {
+                "message": "Upgrade Guava to 28.0-android (#300)",
+                "oid": "3006009a2b1b2cb4bd5108c0f469c410759f3a6a",
+                "associatedPullRequests": {
+                  "edges": [
+                    {
+                      "node": {
+                        "mergeCommit": {"oid": "3006009a2b1b2cb4bd5108c0f469c410759f3a6a"},
+                        "number": 300,
+                        "labels": {
+                          "edges": [
+                            {
+                              "node": {
+                                "name": "cla: yes"
+                              }
+                            }
+                          ]
+                        }
+                      }
+                    }
+                  ]
+                }
+              }
+            },
+            {
+              "node": {
+                "message": "Fix declared dependencies from merge issue (#291)",
+                "oid": "35abf13fa8acb3988aa086f3eb23f5ce1483cc5d",
+                "associatedPullRequests": {
+                  "edges": [
+                    {
+                      "node": {
+                        "mergeCommit": {"oid": "35abf13fa8acb3988aa086f3eb23f5ce1483cc5d"},
+                        "number": 291,
+                        "labels": {
+                          "edges": [
+                            {
+                              "node": {
+                                "name": "cla: yes"
+                              }
+                            },
+                            {
+                              "node": {
+                                "name": "fix"
+                              }
+                            }
+                          ]
+                        }
+                      }
+                    }
+                  ]
+                }
+              }
+            }
+          ],
+          "pageInfo": {
+            "endCursor": "fcd1c890dc1526f4d62ceedad561f498195c8939 99",
+            "hasNextPage": false
+          }
+        }
+      }
+    }
+  }
+}

--- a/test/releasers/fixtures/pom.xml
+++ b/test/releasers/fixtures/pom.xml
@@ -1,0 +1,349 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+  <groupId>com.google.cloud</groupId>
+  <artifactId>google-cloud-trace-parent</artifactId>
+  <packaging>pom</packaging>
+  <version>0.108.1-beta-SNAPSHOT</version><!-- {x-version-update:google-cloud-trace:current} -->
+  <name>Google Cloud Trace Parent</name>
+  <url>https://github.com/googleapis/java-core</url>
+  <description>
+    Java idiomatic client for Google Cloud Platform services.
+  </description>
+
+  <parent>
+    <groupId>com.google.cloud</groupId>
+    <artifactId>google-cloud-shared-config</artifactId>
+    <version>0.1.1</version>
+  </parent>
+
+  <developers>
+    <developer>
+      <id>garrettjonesgoogle</id>
+      <name>Garrett Jones</name>
+      <email>garrettjones@google.com</email>
+      <organization>Google</organization>
+      <roles>
+        <role>Developer</role>
+      </roles>
+    </developer>
+    <developer>
+      <id>pongad</id>
+      <name>Michael Darakananda</name>
+      <email>pongad@google.com</email>
+      <organization>Google</organization>
+      <roles>
+        <role>Developer</role>
+      </roles>
+    </developer>
+    <developer>
+      <id>shinfan</id>
+      <name>Shin Fan</name>
+      <email>shinfan@google.com</email>
+      <organization>Google</organization>
+      <roles>
+        <role>Developer</role>
+      </roles>
+    </developer>
+    <developer>
+      <id>michaelbausor</id>
+      <name>Micheal Bausor</name>
+      <email>michaelbausor@google.com</email>
+      <organization>Google</organization>
+      <roles>
+        <role>Developer</role>
+      </roles>
+    </developer>
+    <developer>
+      <id>vam-google</id>
+      <name>Vadym Matsishevskyi</name>
+      <email>vam@google.com</email>
+      <organization>Google</organization>
+      <roles>
+        <role>Developer</role>
+      </roles>
+    </developer>
+    <developer>
+      <id>tswast</id>
+      <name>Tim Swast</name>
+      <email>tswast@google.com</email>
+      <organization>Google</organization>
+      <roles>
+        <role>Developer</role>
+      </roles>
+    </developer>
+    <developer>
+      <id>neozwu</id>
+      <name>Neo Wu</name>
+      <email>neowu@google.com</email>
+      <organization>Google</organization>
+      <roles>
+        <role>Developer</role>
+      </roles>
+    </developer>
+    <developer>
+      <id>lesv</id>
+      <name>Les Vogel</name>
+      <email>lesv@google.com</email>
+      <organization>Google</organization>
+      <roles>
+        <role>Developer</role>
+      </roles>
+    </developer>
+    <developer>
+      <id>schmidt_sebastian</id>
+      <name>Sebastian Schmidt</name>
+      <email>mrschmidt@google.com</email>
+      <organization>Google</organization>
+      <roles>
+        <role>Developer</role>
+      </roles>
+    </developer>
+    <developer>
+      <id>andreamlin</id>
+      <name>Andrea Lin</name>
+      <email>andrealin@google.com</email>
+      <roles>
+        <role>Developer</role>
+      </roles>
+    </developer>
+    <developer>
+      <id>hzyi-google</id>
+      <name>Hanzhen Yi</name>
+      <email>hzyi@google.com</email>
+      <roles>
+        <role>Developer</role>
+      </roles>
+    </developer>
+  </developers>
+  <organization>
+    <name>Google LLC</name>
+  </organization>
+  <scm>
+    <connection>scm:git:git@github.com:googleapis/java-core.git</connection>
+    <developerConnection>scm:git:git@github.com:googleapis/java-core.git</developerConnection>
+    <url>https://github.com/googleapis/java-core</url>
+    <tag>HEAD</tag>
+  </scm>
+  <issueManagement>
+    <url>https://github.com/googleapis/java-core/issues</url>
+    <system>GitHub Issues</system>
+  </issueManagement>
+  <distributionManagement>
+    <snapshotRepository>
+      <id>sonatype-nexus-snapshots</id>
+      <url>https://oss.sonatype.org/content/repositories/snapshots</url>
+    </snapshotRepository>
+    <repository>
+      <id>sonatype-nexus-staging</id>
+      <url>https://oss.sonatype.org/service/local/staging/deploy/maven2/</url>
+    </repository>
+  </distributionManagement>
+  <licenses>
+    <license>
+      <name>Apache-2.0</name>
+      <url>https://www.apache.org/licenses/LICENSE-2.0.txt</url>
+    </license>
+  </licenses>
+
+  <properties>
+    <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+    <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
+    <github.global.server>github</github.global.server>
+    <site.installationModule>google-cloud-trace-parent</site.installationModule>
+    <google.core.version>1.90.0</google.core.version>
+    <google.api-common.version>1.8.1</google.api-common.version>
+    <google.common-protos.version>1.16.0</google.common-protos.version>
+    <gax.version>1.48.1</gax.version>
+    <grpc.version>1.23.0</grpc.version>
+    <protobuf.version>3.9.1</protobuf.version>
+    <junit.version>4.12</junit.version>
+    <guava.version>28.0-android</guava.version>
+    <threeten.version>1.4.0</threeten.version>
+    <javax.annotations.version>1.3.2</javax.annotations.version>
+  </properties>
+
+  <dependencyManagement>
+    <dependencies>
+      <dependency>
+        <groupId>com.google.api.grpc</groupId>
+        <artifactId>proto-google-cloud-trace-v1</artifactId>
+        <version>0.73.1-SNAPSHOT</version><!-- {x-version-update:proto-google-cloud-trace-v1:current} -->
+      </dependency>
+      <dependency>
+        <groupId>com.google.api.grpc</groupId>
+        <artifactId>proto-google-cloud-trace-v2</artifactId>
+        <version>0.73.1-SNAPSHOT</version><!-- {x-version-update:proto-google-cloud-trace-v2:current} -->
+      </dependency>
+      <dependency>
+        <groupId>com.google.api.grpc</groupId>
+        <artifactId>grpc-google-cloud-trace-v1</artifactId>
+        <version>0.73.1-SNAPSHOT</version><!-- {x-version-update:grpc-google-cloud-trace-v1:current} -->
+      </dependency>
+      <dependency>
+        <groupId>com.google.api.grpc</groupId>
+        <artifactId>grpc-google-cloud-trace-v2</artifactId>
+        <version>0.73.1-SNAPSHOT</version><!-- {x-version-update:grpc-google-cloud-trace-v2:current} -->
+      </dependency>
+
+      <dependency>
+        <groupId>io.grpc</groupId>
+        <artifactId>grpc-bom</artifactId>
+        <version>${grpc.version}</version>
+        <type>pom</type>
+        <scope>import</scope>
+      </dependency>
+      <dependency>
+        <groupId>com.google.api</groupId>
+        <artifactId>gax-bom</artifactId>
+        <version>${gax.version}</version>
+        <type>pom</type>
+        <scope>import</scope>
+      </dependency>
+      <dependency>
+        <groupId>com.google.guava</groupId>
+        <artifactId>guava-bom</artifactId>
+        <version>${guava.version}</version>
+        <type>pom</type>
+        <scope>import</scope>
+      </dependency>
+
+      <dependency>
+        <groupId>com.google.cloud</groupId>
+        <artifactId>google-cloud-core-grpc</artifactId>
+        <version>${google.core.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>com.google.protobuf</groupId>
+        <artifactId>protobuf-java</artifactId>
+        <version>${protobuf.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>com.google.api</groupId>
+        <artifactId>api-common</artifactId>
+        <version>${google.api-common.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>com.google.api.grpc</groupId>
+        <artifactId>proto-google-common-protos</artifactId>
+        <version>${google.common-protos.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.threeten</groupId>
+        <artifactId>threetenbp</artifactId>
+        <version>${threeten.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>javax.annotation</groupId>
+        <artifactId>javax.annotation-api</artifactId>
+        <version>${javax.annotations.version}</version>
+      </dependency>
+
+      <dependency>
+        <groupId>junit</groupId>
+        <artifactId>junit</artifactId>
+        <version>${junit.version}</version>
+        <scope>test</scope>
+      </dependency>
+      <dependency>
+        <groupId>com.google.api</groupId>
+        <artifactId>gax-grpc</artifactId>
+        <version>${gax.version}</version>
+        <classifier>testlib</classifier>
+        <scope>test</scope>
+      </dependency>
+    </dependencies>
+  </dependencyManagement>
+
+  <build>
+    <pluginManagement>
+      <plugins>
+        <plugin>
+          <groupId>org.apache.maven.plugins</groupId>
+          <artifactId>maven-dependency-plugin</artifactId>
+          <configuration>
+            <ignoredUnusedDeclaredDependencies>org.objenesis:objenesis</ignoredUnusedDeclaredDependencies>
+          </configuration>
+        </plugin>
+      </plugins>
+    </pluginManagement>
+  </build>
+
+  <modules>
+    <module>proto-google-cloud-trace-v1</module>
+    <module>proto-google-cloud-trace-v2</module>
+    <module>grpc-google-cloud-trace-v1</module>
+    <module>grpc-google-cloud-trace-v2</module>
+    <module>google-cloud-trace</module>
+  </modules>
+
+  <reporting>
+    <plugins>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-project-info-reports-plugin</artifactId>
+        <version>3.0.0</version>
+        <reportSets>
+          <reportSet>
+            <reports>
+              <report>index</report>
+              <report>dependency-info</report>
+              <report>team</report>
+              <report>ci-management</report>
+              <report>issue-management</report>
+              <report>licenses</report>
+              <report>scm</report>
+              <report>dependency-management</report>
+              <report>distribution-management</report>
+              <report>summary</report>
+              <report>modules</report>
+            </reports>
+          </reportSet>
+        </reportSets>
+        <configuration>
+          <dependencyDetailsEnabled>true</dependencyDetailsEnabled>
+          <artifactId>${site.installationModule}</artifactId>
+          <packaging>jar</packaging>
+        </configuration>
+      </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-javadoc-plugin</artifactId>
+        <version>3.1.1</version>
+        <reportSets>
+          <reportSet>
+            <id>html</id>
+            <reports>
+              <report>aggregate</report>
+              <report>javadoc</report>
+            </reports>
+          </reportSet>
+        </reportSets>
+        <configuration>
+          <doclint>none</doclint>
+          <show>protected</show>
+          <nohelp>true</nohelp>
+          <outputDirectory>${project.build.directory}/javadoc</outputDirectory>
+          <groups>
+            <group>
+              <title>Test helpers packages</title>
+              <packages>com.google.cloud.testing</packages>
+            </group>
+            <group>
+              <title>SPI packages</title>
+              <packages>com.google.cloud.spi*</packages>
+            </group>
+          </groups>
+
+          <links>
+            <link>https://grpc.io/grpc-java/javadoc/</link>
+            <link>https://developers.google.com/protocol-buffers/docs/reference/java/</link>
+            <link>https://googleapis.dev/java/google-auth-library/latest/</link>
+            <link>https://googleapis.dev/java/gax/latest/</link>
+            <link>https://googleapis.github.io/api-common-java/${google.api-common.version}/apidocs/</link>
+          </links>
+        </configuration>
+      </plugin>
+    </plugins>
+  </reporting>
+</project>

--- a/test/releasers/fixtures/versions.txt
+++ b/test/releasers/fixtures/versions.txt
@@ -1,0 +1,8 @@
+# Format:
+# module:released-version:current-version
+
+google-cloud-trace:0.108.0-beta:0.108.1-beta-SNAPSHOT
+grpc-google-cloud-trace-v1:0.73.0:0.73.1-SNAPSHOT
+grpc-google-cloud-trace-v2:0.73.0:0.73.1-SNAPSHOT
+proto-google-cloud-trace-v1:0.73.0:0.73.1-SNAPSHOT
+proto-google-cloud-trace-v2:0.73.0:0.73.1-SNAPSHOT

--- a/test/releasers/java-yoshi.ts
+++ b/test/releasers/java-yoshi.ts
@@ -108,7 +108,9 @@ describe('JavaYoshi', () => {
       .get(
         '/repos/googleapis/java-trace/contents/README.md?ref=refs%2Fheads%2Frelease-v0.20.4'
       )
-      .reply(200, { content: Buffer.from(readmeContent, 'utf8').toString('base64') })
+      .reply(200, {
+        content: Buffer.from(readmeContent, 'utf8').toString('base64'),
+      })
       .put(
         '/repos/googleapis/java-trace/contents/README.md',
         (req: { [key: string]: string }) => {

--- a/test/releasers/java-yoshi.ts
+++ b/test/releasers/java-yoshi.ts
@@ -94,7 +94,7 @@ describe('JavaYoshi', () => {
       .put(
         '/repos/googleapis/java-trace/contents/CHANGELOG.md',
         (req: { [key: string]: string }) => {
-          snapshot('CHANGELOG', Buffer.from(req.content, 'base64').toString('utf8'));
+          snapshot('CHANGELOG', Buffer.from(req.content, 'base64').toString('utf8').replace(/\([0-9]{4}-[0-9]{2}-[0-9]{2}\)/g, ''));
           return true;
         }
       )

--- a/test/releasers/java-yoshi.ts
+++ b/test/releasers/java-yoshi.ts
@@ -108,7 +108,7 @@ describe('JavaYoshi', () => {
       .get(
         '/repos/googleapis/java-trace/contents/README.md?ref=refs%2Fheads%2Frelease-v0.20.4'
       )
-      .reply(200, { content: Buffer.from(readmeContent).toString('utf8') })
+      .reply(200, { content: Buffer.from(readmeContent, 'utf8').toString('base64') })
       .put(
         '/repos/googleapis/java-trace/contents/README.md',
         (req: { [key: string]: string }) => {

--- a/test/releasers/java-yoshi.ts
+++ b/test/releasers/java-yoshi.ts
@@ -94,7 +94,7 @@ describe('JavaYoshi', () => {
       .put(
         '/repos/googleapis/java-trace/contents/CHANGELOG.md',
         (req: { [key: string]: string }) => {
-          snapshot(Buffer.from(req.content, 'base64').toString('utf8'));
+          snapshot('CHANGELOG', Buffer.from(req.content, 'base64').toString('utf8'));
           return true;
         }
       )
@@ -107,7 +107,7 @@ describe('JavaYoshi', () => {
       .put(
         '/repos/googleapis/java-trace/contents/README.md',
         (req: { [key: string]: string }) => {
-          snapshot(Buffer.from(req.content, 'base64').toString('utf8'));
+          snapshot('README', Buffer.from(req.content, 'base64').toString('utf8'));
           return true;
         }
       )
@@ -123,7 +123,7 @@ describe('JavaYoshi', () => {
       .put(
         '/repos/googleapis/java-trace/contents/versions.txt',
         (req: { [key: string]: string }) => {
-          snapshot(Buffer.from(req.content, 'base64').toString('utf8'));
+          snapshot('versions', Buffer.from(req.content, 'base64').toString('utf8'));
           return true;
         }
       )
@@ -139,7 +139,7 @@ describe('JavaYoshi', () => {
       .put(
         '/repos/googleapis/java-trace/contents/pom.xml',
         (req: { [key: string]: string }) => {
-          snapshot(Buffer.from(req.content, 'base64').toString('utf8'));
+          snapshot('pom', Buffer.from(req.content, 'base64').toString('utf8'));
           return true;
         }
       )
@@ -149,7 +149,7 @@ describe('JavaYoshi', () => {
         '/repos/googleapis/java-trace/pulls',
         (req: { [key: string]: string }) => {
           const body = req.body.replace(/\([0-9]{4}-[0-9]{2}-[0-9]{2}\)/g, '');
-          snapshot(body);
+          snapshot('PR body', body);
           return true;
         }
       )

--- a/test/releasers/java-yoshi.ts
+++ b/test/releasers/java-yoshi.ts
@@ -1,0 +1,140 @@
+/**
+ * Copyright 2019 Google LLC. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { Version } from '../../src/releasers/java-yoshi';
+import { expect } from 'chai';
+
+describe('JavaYoshi', () => {
+});
+
+describe('Version', () => {
+  describe('parse', () => {
+    it('can read a plain semver', async () => {
+      const input = '1.23.45';
+      const version = Version.parse(input);
+      expect(version.major).to.equal(1);
+      expect(version.minor).to.equal(23);
+      expect(version.patch).to.equal(45);
+      expect(version.extra).to.equal('');
+      expect(version.snapshot).to.equal(false);
+    });
+    it('can read a SNAPSHOT version', async () => {
+      const input = '1.23.45-SNAPSHOT';
+      const version = Version.parse(input);
+      expect(version.major).to.equal(1);
+      expect(version.minor).to.equal(23);
+      expect(version.patch).to.equal(45);
+      expect(version.extra).to.equal('');
+      expect(version.snapshot).to.equal(true);
+    });
+    it('can read a beta version', async () => {
+      const input = '1.23.45-beta';
+      const version = Version.parse(input);
+      expect(version.major).to.equal(1);
+      expect(version.minor).to.equal(23);
+      expect(version.patch).to.equal(45);
+      expect(version.extra).to.equal('-beta');
+      expect(version.snapshot).to.equal(false);
+    });
+    it('can read a beta SNAPSHOT version', async () => {
+      const input = '1.23.45-beta-SNAPSHOT';
+      const version = Version.parse(input);
+      expect(version.major).to.equal(1);
+      expect(version.minor).to.equal(23);
+      expect(version.patch).to.equal(45);
+      expect(version.extra).to.equal('-beta');
+      expect(version.snapshot).to.equal(true);
+    });
+  });
+
+  describe('bump', () => {
+    let version: Version;
+    describe('for snapshot version', () => {
+      beforeEach(() => {
+        version = Version.parse('1.23.45-beta-SNAPSHOT');
+      });
+      it('should handle major bumps', async () => {
+        version.bump('major');
+        expect(version.major).to.equal(2);
+        expect(version.minor).to.equal(0);
+        expect(version.patch).to.equal(0);
+        expect(version.extra).to.equal('-beta');
+        expect(version.snapshot).to.equal(false);
+      });
+      it('should handle minor bumps', async () => {
+        version.bump('minor');
+        expect(version.major).to.equal(1);
+        expect(version.minor).to.equal(24);
+        expect(version.patch).to.equal(0);
+        expect(version.extra).to.equal('-beta');
+        expect(version.snapshot).to.equal(false);
+      });
+      it('should handle patch bumps', async () => {
+        version.bump('patch');
+        expect(version.major).to.equal(1);
+        expect(version.minor).to.equal(23);
+        expect(version.patch).to.equal(46);
+        expect(version.extra).to.equal('-beta');
+        expect(version.snapshot).to.equal(false);
+      });
+      it('should handle snapshot bumps', async () => {
+        version.bump('snapshot');
+        expect(version.major).to.equal(1);
+        expect(version.minor).to.equal(23);
+        expect(version.patch).to.equal(46);
+        expect(version.extra).to.equal('-beta');
+        expect(version.snapshot).to.equal(true);
+      });
+    });
+    describe('for non-snapshot version', () => {
+      beforeEach(() => {
+        version = Version.parse('1.23.45-beta');
+      });
+      it('should handle major bumps', async () => {
+        version.bump('major');
+        expect(version.major).to.equal(2);
+        expect(version.minor).to.equal(0);
+        expect(version.patch).to.equal(0);
+        expect(version.extra).to.equal('-beta');
+        expect(version.snapshot).to.equal(false);
+      });
+      it('should handle minor bumps', async () => {
+        version.bump('minor');
+        expect(version.major).to.equal(1);
+        expect(version.minor).to.equal(24);
+        expect(version.patch).to.equal(0);
+        expect(version.extra).to.equal('-beta');
+        expect(version.snapshot).to.equal(false);
+      });
+      it('should handle patch bumps', async () => {
+        version.bump('patch');
+        expect(version.major).to.equal(1);
+        expect(version.minor).to.equal(23);
+        expect(version.patch).to.equal(46);
+        expect(version.extra).to.equal('-beta');
+        expect(version.snapshot).to.equal(false);
+      });
+      it('should handle snapshot bumps', async () => {
+        version.bump('snapshot');
+        expect(version.major).to.equal(1);
+        expect(version.minor).to.equal(23);
+        expect(version.patch).to.equal(46);
+        expect(version.extra).to.equal('-beta');
+        expect(version.snapshot).to.equal(true);
+      });
+    });
+  });
+});

--- a/test/releasers/java-yoshi.ts
+++ b/test/releasers/java-yoshi.ts
@@ -14,10 +14,114 @@
  * limitations under the License.
  */
 
-import { Version } from '../../src/releasers/java-yoshi';
-import { expect } from 'chai';
+const nock = require('nock');
+nock.disableNetConnect();
 
-describe('JavaYoshi', () => {});
+import { Version, JavaYoshi } from '../../src/releasers/java-yoshi';
+import { expect } from 'chai';
+import { ReleaseType } from '../../src/release-pr';
+import { readFileSync } from 'fs';
+import { resolve } from 'path';
+import * as snapshot from 'snap-shot-it';
+
+const fixturesPath = './test/releasers/fixtures';
+
+describe('JavaYoshi', () => {
+  it('creates a release PR', async() => {
+    const versionsContent = readFileSync(resolve(fixturesPath, 'versions.txt'), 'utf8')
+    const readmeContent = readFileSync(resolve(fixturesPath, 'README.md'), 'utf8');
+    const pomContents = readFileSync(resolve(fixturesPath, 'pom.xml'), 'utf8');
+    const graphql = JSON.parse(
+      readFileSync(
+        resolve(fixturesPath, 'commits-yoshi-java.json'),
+        'utf8'
+      )
+    );
+    const req = nock('https://api.github.com')
+      .get('/repos/googleapis/java-trace/pulls?state=closed&per_page=100')
+      .reply(200, undefined)
+      .get('/repos/googleapis/java-trace/contents/versions.txt')
+      .reply(200, {
+        content: Buffer.from(versionsContent, 'utf8').toString('base64'),
+        sha: 'abc123',
+      })
+      // fetch semver tags, this will be used to determine
+      // the delta since the last release.
+      .get('/repos/googleapis/java-trace/tags?per_page=100')
+      .reply(200, [
+        {
+          name: 'v0.20.3',
+          commit: {
+            sha: 'da6e52d956c1e35d19e75e0f2fdba439739ba364',
+          },
+        },
+      ])
+      .post('/graphql')
+      .reply(200, {
+        data: graphql,
+      })
+      // finding pom.xml files
+      .get('/search/code?q=filename%3Apom.xml+repo%3Agoogleapis%2Fjava-trace')
+      .reply(200, {total_count: 1, items: [{name: 'pom.xml', path: 'pom.xml'}]})
+      // getting the latest tag
+      .get('/repos/googleapis/java-trace/git/refs?per_page=100')
+      .reply(200, [{ref: "refs/tags/v0.20.3"}])
+      // creating a new branch
+      .post('/repos/googleapis/java-trace/git/refs')
+      .reply(200)
+      // check for CHANGELOG
+      .get('/repos/googleapis/java-trace/contents/CHANGELOG.md?ref=refs%2Fheads%2Frelease-v0.20.4')
+      .reply(404)
+      .put('/repos/googleapis/java-trace/contents/CHANGELOG.md')
+      .reply(201)
+      // update README.md
+      .get('/repos/googleapis/java-trace/contents/README.md?ref=refs%2Fheads%2Frelease-v0.20.4')
+      .reply(200, {content: Buffer.from(readmeContent).toString('utf8')})
+      .put('/repos/googleapis/java-trace/contents/README.md')
+      .reply(200)
+      // update versions.txt
+      .get('/repos/googleapis/java-trace/contents/versions.txt?ref=refs%2Fheads%2Frelease-v0.20.4')
+      .reply(200, {
+        content: Buffer.from(versionsContent, 'utf8').toString('base64'),
+        sha: 'abc123',
+      })
+      .put('/repos/googleapis/java-trace/contents/versions.txt')
+      .reply(200)
+      // update pom.xml
+      .get('/repos/googleapis/java-trace/contents/pom.xml?ref=refs%2Fheads%2Frelease-v0.20.4')
+      .reply(200, {
+        content: Buffer.from(pomContents, 'utf8').toString('base64'),
+        sha: 'abc123',
+      })
+      .put('/repos/googleapis/java-trace/contents/pom.xml')
+      .reply(200)
+      // create release
+      .post('/repos/googleapis/java-trace/pulls',
+        (req: { [key: string]: string }) => {
+          const body = req.body.replace(
+            /\([0-9]{4}-[0-9]{2}-[0-9]{2}\)/g,
+            ''
+          );
+          snapshot(body);
+          return true;
+        }
+      )
+      .reply(200, {number: 1})
+      // this step tries to close any existing PRs; just return an empty list.
+      .get('/repos/googleapis/java-trace/pulls?state=open&per_page=100')
+      .reply(200, [])
+    const releasePR = new JavaYoshi({
+      repoUrl: 'googleapis/java-trace',
+      label: 'autorelease: pending',
+      releaseType: ReleaseType.JavaYoshi,
+      // not actually used by this type of repo.
+      packageName: 'java-trace',
+      apiUrl: 'https://api.github.com',
+    });
+    await releasePR.run();
+    req.done();
+  });
+});
 
 describe('Version', () => {
   describe('parse', () => {

--- a/test/releasers/java-yoshi.ts
+++ b/test/releasers/java-yoshi.ts
@@ -94,7 +94,12 @@ describe('JavaYoshi', () => {
       .put(
         '/repos/googleapis/java-trace/contents/CHANGELOG.md',
         (req: { [key: string]: string }) => {
-          snapshot('CHANGELOG', Buffer.from(req.content, 'base64').toString('utf8').replace(/\([0-9]{4}-[0-9]{2}-[0-9]{2}\)/g, ''));
+          snapshot(
+            'CHANGELOG',
+            Buffer.from(req.content, 'base64')
+              .toString('utf8')
+              .replace(/\([0-9]{4}-[0-9]{2}-[0-9]{2}\)/g, '')
+          );
           return true;
         }
       )
@@ -107,7 +112,10 @@ describe('JavaYoshi', () => {
       .put(
         '/repos/googleapis/java-trace/contents/README.md',
         (req: { [key: string]: string }) => {
-          snapshot('README', Buffer.from(req.content, 'base64').toString('utf8'));
+          snapshot(
+            'README',
+            Buffer.from(req.content, 'base64').toString('utf8')
+          );
           return true;
         }
       )
@@ -123,7 +131,10 @@ describe('JavaYoshi', () => {
       .put(
         '/repos/googleapis/java-trace/contents/versions.txt',
         (req: { [key: string]: string }) => {
-          snapshot('versions', Buffer.from(req.content, 'base64').toString('utf8'));
+          snapshot(
+            'versions',
+            Buffer.from(req.content, 'base64').toString('utf8')
+          );
           return true;
         }
       )

--- a/test/releasers/java-yoshi.ts
+++ b/test/releasers/java-yoshi.ts
@@ -17,8 +17,7 @@
 import { Version } from '../../src/releasers/java-yoshi';
 import { expect } from 'chai';
 
-describe('JavaYoshi', () => {
-});
+describe('JavaYoshi', () => {});
 
 describe('Version', () => {
   describe('parse', () => {


### PR DESCRIPTION
In Java, we allow an extra qualifier type to the semver which should be preserved across version bumps:

i.e. 0.1.2-beta -> minor bump -> 0.2.0-beta