### PR TITLE
feat: include docs and chores in PHP releases and changelogs

### DIFF
--- a/src/releasers/php-yoshi.ts
+++ b/src/releasers/php-yoshi.ts
@@ -30,6 +30,20 @@ import { PHPManifest } from '../updaters/php-manifest';
 import { RootComposer } from '../updaters/root-composer';
 import { Version } from '../updaters/version';
 
+const CHANGELOG_SECTIONS = [
+  { type: 'feat', section: 'Features' },
+  { type: 'fix', section: 'Bug Fixes' },
+  { type: 'perf', section: 'Performance Improvements' },
+  { type: 'revert', section: 'Reverts' },
+  { type: 'docs', section: 'Documentation' },
+  { type: 'chore', section: 'Miscellaneous Chores' },
+  { type: 'style', section: 'Styles', hidden: true },
+  { type: 'refactor', section: 'Code Refactoring', hidden: true },
+  { type: 'test', section: 'Tests', hidden: true },
+  { type: 'build', section: 'Build System', hidden: true },
+  { type: 'ci', section: 'Continuous Integration', hidden: true },
+];
+
 interface PHPYoshiBulkUpdate {
   changelogEntry: string;
   versionUpdates: VersionsMap;
@@ -48,6 +62,7 @@ export class PHPYoshi extends ReleasePR {
       commits,
       githubRepoUrl: this.repoUrl,
       bumpMinorPreMajor: true,
+      changelogSections: CHANGELOG_SECTIONS,
     });
     const candidate: ReleaseCandidate = await this.coerceReleaseCandidate(
       ccb,


### PR DESCRIPTION
Fixes #348.

Hello friends! This change aims to cause release-please to include `chore` and `docs` changes in our changelog, and therefore to cause those types of changes to be released, even if no other changes have been made to a given component.

I followed the relevant portions of #238, where @bcoe added a similar feature to the ruby releaser. I looked through the test suites and did not find anything which seemed to relate closely to this part of the application, but if I missed something, please let me know and I'll work to fix it!

Thanks for considering the change. :)