### PR TITLE
fix: process label was causing PRs to be closed

### DIFF
--- a/__snapshots__/java-yoshi.js
+++ b/__snapshots__/java-yoshi.js
@@ -493,8 +493,7 @@ This PR was generated with [Release Please](https://github.com/googleapis/releas
 
 exports['labels'] = {
   "labels": [
-    "autorelease: pending",
-    "type: process"
+    "autorelease: pending"
   ]
 }
 

--- a/src/github.ts
+++ b/src/github.ts
@@ -473,14 +473,18 @@ export class GitHub {
         repo: this.repo,
       }
     )) as Octokit.Response<Octokit.PullsListResponseItem[]>;
-    for (let i = 0, pull; i < pullsResponse.data.length; i++) {
-      pull = pullsResponse.data[i];
-      for (let ii = 0, label; ii < pull.labels.length; ii++) {
-        label = pull.labels[ii];
-        if (labels.indexOf(label.name) !== -1) {
-          openReleasePRs.push(pull);
+    for (const pull of pullsResponse.data) {
+      let hasAllLabels = false;
+      const observedLabels = pull.labels.map(l => l.name);
+      for (const expectedLabel of labels) {
+        if (observedLabels.includes(expectedLabel)) {
+          hasAllLabels = true;
+        } else {
+          hasAllLabels = false;
+          break;
         }
       }
+      if (hasAllLabels) openReleasePRs.push(pull);
     }
     return openReleasePRs;
   }

--- a/src/release-pr.ts
+++ b/src/release-pr.ts
@@ -57,7 +57,7 @@ export interface ReleaseCandidate {
   previousTag?: string;
 }
 
-const DEFAULT_LABELS = 'autorelease: pending,type: process';
+const DEFAULT_LABELS = 'autorelease: pending';
 
 export class ReleasePR {
   apiUrl: string;
@@ -127,7 +127,10 @@ export class ReleasePR {
         if (includePackageName && !pr.title.includes(` ${this.packageName} `)) {
           continue;
         }
-        checkpoint(`closing pull #${pr.number}`, CheckpointType.Failure);
+        checkpoint(
+          `closing pull #${pr.number} on ${this.repoUrl}`,
+          CheckpointType.Failure
+        );
         await this.gh.closePR(pr.number);
       }
     }
@@ -225,6 +228,10 @@ export class ReleasePR {
     // a return of -1 indicates that PR was not updated.
     if (pr > 0) {
       await this.gh.addLabels(this.labels, pr);
+      checkpoint(
+        `${this.repoUrl} find stale PRs with label "${this.labels.join(',')}"`,
+        CheckpointType.Success
+      );
       await this.closeStaleReleasePRs(pr, includePackageName);
     }
   }


### PR DESCRIPTION
let's just close open issues with `autorelease: pending` by default, `process` is used too commonly.