### PR TITLE
fix: support changelog types for PHP components

### DIFF
--- a/src/releasers/php-yoshi.ts
+++ b/src/releasers/php-yoshi.ts
@@ -152,6 +152,7 @@ export class PHPYoshi extends ReleasePR {
         commits: commitLookup[pkgKey],
         githubRepoUrl: this.repoUrl,
         bumpMinorPreMajor: this.bumpMinorPreMajor,
+        changelogSections: CHANGELOG_SECTIONS,
       });
 
       // some packages in the mono-repo might have only had chores,


### PR DESCRIPTION
Follows up on #352, adds custom changelog sections to component changeset.