### PR TITLE
fix: handle additional content after release-as: footer

### DIFF
--- a/src/release-pr.ts
+++ b/src/release-pr.ts
@@ -144,7 +144,7 @@ export class ReleasePR {
     cc: ConventionalCommits,
     latestTag: GitHubTag | undefined
   ): Promise<ReleaseCandidate> {
-    const releaseAsRe = /release-as: v?([0-9]+\.[0-9]+\.[0-9a-z-])+$/i;
+    const releaseAsRe = /release-as: v?([0-9]+\.[0-9]+\.[0-9a-z-])+\s*/i;
     const previousTag = latestTag ? latestTag.name : undefined;
     let version = latestTag ? latestTag.version : this.defaultInitialVersion();
 

--- a/test/release-pr.ts
+++ b/test/release-pr.ts
@@ -308,5 +308,37 @@ describe('GitHub', () => {
       const candidate = await rp.coerceReleaseCandidate(cc);
       expect(candidate.version).to.equal('2.0.0');
     });
+
+    it('it handles additional content after release-as: footer', async () => {
+      const rp = new TestableReleasePR({
+        repoUrl: 'googleapis/nodejs',
+        packageName: '@google-cloud/nodejs',
+        apiUrl: 'github.com',
+        releaseType: ReleaseType.Node,
+      });
+      const cc = new ConventionalCommits({
+        commits: [
+          {
+            sha: 'abc123',
+            message: 'fix: addresses issues with library',
+            files: [],
+          },
+          {
+            sha: 'abc124',
+            message:
+              'feat: adds a slick new feature\nRelease-As: 2.0.0\r\nSecond Footer: hello',
+            files: [],
+          },
+          {
+            sha: 'abc125',
+            message: 'fix: another fix\n\nRelease-As: 3.0.0',
+            files: [],
+          },
+        ],
+        githubRepoUrl: 'googleapis/nodejs',
+      });
+      const candidate = await rp.coerceReleaseCandidate(cc);
+      expect(candidate.version).to.equal('2.0.0');
+    });
   });
 });


### PR DESCRIPTION
If additional content followed the special `release-as:` footer, we were not parsing it.

This fix should address the issue observed [here](https://github.com/googleapis/python-spanner/pull/37).

CC: @skuruppu
