### PR TITLE
fix: we were not compiling src/bin

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,6 +40,7 @@
     "@types/mocha": "^7.0.0",
     "@types/node": "^11.13.6",
     "@types/semver": "^7.0.0",
+    "@types/yargs": "^15.0.4",
     "c8": "^7.0.0",
     "chai": "^4.2.0",
     "cross-env": "^7.0.0",

--- a/src/bin/release-please.ts
+++ b/src/bin/release-please.ts
@@ -141,7 +141,8 @@ action "github-release" {
         `);
     }
   )
-  .middleware((argv: GitHubReleaseOptions) => {
+  .middleware((_argv) => {
+    const argv = _argv as GitHubReleaseOptions;
     // allow secrets to be loaded from file path
     // rather than being passed directly to the bin.
     if (argv.token) argv.token = coerceOption(argv.token);

--- a/src/bin/release-please.ts
+++ b/src/bin/release-please.ts
@@ -141,7 +141,7 @@ action "github-release" {
         `);
     }
   )
-  .middleware((_argv) => {
+  .middleware(_argv => {
     const argv = _argv as GitHubReleaseOptions;
     // allow secrets to be loaded from file path
     // rather than being passed directly to the bin.

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -6,7 +6,7 @@
     "outDir": "build",
   },
   "include": [
-    "src/*.ts",
+    "src/**/*.ts",
     "test/*.ts",
     "system-test/*.ts"
   ]


### PR DESCRIPTION
yikes, we have a bad publication because we weren't compiling `bin` with the new config, we should add integration tests to catch this in the future.