### PR TITLE
fix: snapshots will now be taken from the latest commit

### DIFF
--- a/test/releasers/java-yoshi.ts
+++ b/test/releasers/java-yoshi.ts
@@ -216,6 +216,9 @@ describe('JavaYoshi', () => {
       'utf8'
     );
     const pomContents = readFileSync(resolve(fixturesPath, 'pom.xml'), 'utf8');
+    const graphql = JSON.parse(
+      readFileSync(resolve(fixturesPath, 'commits-yoshi-java.json'), 'utf8')
+    );
     const req = nock('https://api.github.com')
       .get('/repos/googleapis/java-trace/pulls?state=closed&per_page=100')
       .reply(200, undefined)
@@ -223,6 +226,11 @@ describe('JavaYoshi', () => {
       .reply(200, {
         content: Buffer.from(versionsContent, 'utf8').toString('base64'),
         sha: 'abc123',
+      })
+      // getting the most recent commit:
+      .post('/graphql')
+      .reply(200, {
+        data: graphql,
       })
       // fetch semver tags, this will be used to determine
       // the delta since the last release.


### PR DESCRIPTION
snapshot releases were pinning at ancient SHAs in some cases, because we use the last tag rather than the latest commit at head.

We now use the latest commit at head.