### PR TITLE
fix: stop parsing BREAKING CHANGE message after two newlines

### DIFF
--- a/__snapshots__/conventional-commits.js
+++ b/__snapshots__/conventional-commits.js
@@ -1,0 +1,19 @@
+exports[
+  'ConventionalCommits generateChangelogEntry does not include content two newlines after BREAKING CHANGE 1'
+] = `
+## v1.0.0 (2020-04-10)
+
+
+### ⚠ BREAKING CHANGES
+
+* we were on Node 6
+
+### Features
+
+* awesome feature ([abc678](https://www.github.com/bcoe/release-please/commit/abc678))
+
+
+### Miscellaneous Chores
+
+* upgrade to Node 7 ([abc345](https://www.github.com/bcoe/release-please/commit/abc345))
+`;

--- a/test/conventional-commits.ts
+++ b/test/conventional-commits.ts
@@ -16,6 +16,8 @@ import {ConventionalCommits} from '../src/conventional-commits';
 import {describe, it} from 'mocha';
 import {expect} from 'chai';
 
+import * as snapshot from 'snap-shot-it';
+
 describe('ConventionalCommits', () => {
   describe('suggestBump', () => {
     it('suggests minor release for breaking change pre 1.0', async () => {
@@ -40,6 +42,29 @@ describe('ConventionalCommits', () => {
       const bump = await cc.suggestBump('0.3.0');
       expect(bump.releaseType).to.equal('minor');
       expect(bump.reason).to.equal('There is 1 BREAKING CHANGE and 1 features');
+    });
+  });
+
+  describe('generateChangelogEntry', () => {
+    // See: https://github.com/googleapis/nodejs-logging/commit/ce29b498ebb357403c093053d1b9989f1a56f5af
+    it('does not include content two newlines after BREAKING CHANGE', async () => {
+      const cc = new ConventionalCommits({
+        commits: [
+          {
+            message:
+              'chore: upgrade to Node 7\n\nBREAKING CHANGE: we were on Node 6\n\nI should be removed',
+            sha: 'abc345',
+            files: [],
+          },
+          {message: 'feat: awesome feature', sha: 'abc678', files: []},
+        ],
+        githubRepoUrl: 'https://github.com/bcoe/release-please.git',
+        bumpMinorPreMajor: true,
+      });
+      const cl = await cc.generateChangelogEntry({
+        version: 'v1.0.0',
+      });
+      snapshot(cl);
     });
   });
 });


### PR DESCRIPTION
Introduces a mechanism for performing some cleanup after the conventional commit parse. In this case we stop reading a BREAKING CHANGE comment after two newlines, to prevent:

https://github.com/googleapis/nodejs-logging/commit/ce29b498ebb357403c093053d1b9989f1a56f5af