### PR TITLE
fix(java): logging message should not crash when there's no latestTag

### DIFF
--- a/src/releasers/java-yoshi.ts
+++ b/src/releasers/java-yoshi.ts
@@ -204,7 +204,9 @@ export class JavaYoshi extends ReleasePR {
     });
 
     console.info(
-      `attempting to open PR latestTagSha = ${latestTag!.sha} prSha = ${prSHA}`
+      `attempting to open PR latestTagSha = ${
+        latestTag ? latestTag.sha : 'none'
+      } prSha = ${prSHA}`
     );
     await this.openPR(
       prSHA!,


### PR DESCRIPTION
Fixes #423
