### PR TITLE
fix: don't include pre-release in latestTag calculation

### DIFF
--- a/__snapshots__/java-bom.js
+++ b/__snapshots__/java-bom.js
@@ -836,8 +836,8 @@ This PR was generated with [Release Please](https://github.com/googleapis/releas
 `
 
 exports['labels-bom'] = {
-  "labels": [
-    "autorelease: pending"
+  'labels': [
+    'autorelease: pending'
   ]
 }
 
@@ -1614,8 +1614,8 @@ This PR was generated with [Release Please](https://github.com/googleapis/releas
 `
 
 exports['labels-bom-snapshot'] = {
-  "labels": [
-    "type: process"
+  'labels': [
+    'type: process'
   ]
 }
 
@@ -2465,7 +2465,7 @@ This PR was generated with [Release Please](https://github.com/googleapis/releas
 `
 
 exports['labels-bom-feature'] = {
-  "labels": [
-    "autorelease: pending"
+  'labels': [
+    'autorelease: pending'
   ]
 }

--- a/src/github.ts
+++ b/src/github.ts
@@ -422,7 +422,10 @@ export class GitHub {
 
   async latestTag(perPage = 100): Promise<GitHubTag | undefined> {
     const tags: {[version: string]: GitHubTag} = await this.allTags(perPage);
-    const versions = Object.keys(tags);
+    const versions = Object.keys(tags).filter(t => {
+      // remove any pre-releases from the list:
+      return !t.includes('-');
+    });
     // no tags have been created yet.
     if (versions.length === 0) return undefined;
 

--- a/test/github.ts
+++ b/test/github.ts
@@ -104,4 +104,54 @@ describe('GitHub', () => {
       req.done();
     });
   });
+
+  describe('latestTag', () => {
+    it('returns the largest tag, even if sorting is off', async () => {
+      const req = nock('https://api.github.com')
+        .get('/repos/fake/fake/tags?per_page=100')
+        .reply(200, [
+          {
+            name: 'v1.2.0',
+            commit: {sha: 'abc123'},
+            version: 'v1.2.0',
+          },
+          {
+            name: 'v1.3.0',
+            commit: {sha: 'abc123'},
+            version: 'v1.3.0',
+          },
+          {
+            name: 'v1.1.0',
+            commit: {sha: 'abc123'},
+            version: 'v1.1.0',
+          },
+        ]);
+      const latestTag = await github.latestTag();
+      expect(latestTag!.version).to.equal('1.3.0');
+    });
+
+    it('does not return pre-releases as latest tag', async () => {
+      const req = nock('https://api.github.com')
+        .get('/repos/fake/fake/tags?per_page=100')
+        .reply(200, [
+          {
+            name: 'v1.2.0',
+            commit: {sha: 'abc123'},
+            version: 'v1.2.0',
+          },
+          {
+            name: 'v1.3.0-beta.0',
+            commit: {sha: 'abc123'},
+            version: 'v1.3.0',
+          },
+          {
+            name: 'v1.1.0',
+            commit: {sha: 'abc123'},
+            version: 'v1.1.0',
+          },
+        ]);
+      const latestTag = await github.latestTag();
+      expect(latestTag!.version).to.equal('1.2.0');
+    });
+  });
 });


### PR DESCRIPTION
pre-releases were being used in the logic for calculating the latest tag, this meant that as soon as we released a pre-release, it broke the CHANGELOG generation on the next run.