### PR TITLE
feat: return the release created by createRelease()

### DIFF
--- a/src/github.ts
+++ b/src/github.ts
@@ -40,6 +40,9 @@ type IssuesListResponseItem = PromiseValue<
 type FileSearchResponse = PromiseValue<
   ReturnType<InstanceType<typeof Octokit>['search']['code']>
 >['data'];
+export type ReleaseCreateResponse = PromiseValue<
+  ReturnType<InstanceType<typeof Octokit>['repos']['createRelease']>
+>['data'];
 
 import chalk = require('chalk');
 import * as semver from 'semver';
@@ -864,21 +867,23 @@ export class GitHub {
     version: string,
     sha: string,
     releaseNotes: string
-  ) {
+  ): Promise<ReleaseCreateResponse> {
     checkpoint(`creating release ${version}`, CheckpointType.Success);
-    await this.request(
-      `POST /repos/:owner/:repo/releases${
-        this.proxyKey ? `?key=${this.proxyKey}` : ''
-      }`,
-      {
-        owner: this.owner,
-        repo: this.repo,
-        tag_name: version,
-        target_commitish: sha,
-        body: releaseNotes,
-        name: `${packageName} ${version}`,
-      }
-    );
+    return (
+      await this.request(
+        `POST /repos/:owner/:repo/releases${
+          this.proxyKey ? `?key=${this.proxyKey}` : ''
+        }`,
+        {
+          owner: this.owner,
+          repo: this.repo,
+          tag_name: version,
+          target_commitish: sha,
+          body: releaseNotes,
+          name: `${packageName} ${version}`,
+        }
+      )
+    ).data;
   }
 
   async removeLabels(labels: string[], prNumber: number) {

--- a/test/github-release.ts
+++ b/test/github-release.ts
@@ -17,6 +17,7 @@ import {resolve} from 'path';
 import * as snapshot from 'snap-shot-it';
 import {describe, it} from 'mocha';
 import * as nock from 'nock';
+import {strictEqual} from 'assert';
 nock.disableNetConnect();
 
 import {GitHubRelease} from '../src/github-release';
@@ -49,7 +50,7 @@ describe('GitHubRelease', () => {
           content: Buffer.from('#Changelog\n\n## v1.0.3\n\n* entry', 'utf8'),
         })
         .post('/repos/googleapis/foo/releases')
-        .reply(200)
+        .reply(200, {tag_name: 'v1.0.2'})
         .post(
           '/repos/googleapis/foo/issues/1/labels',
           (body: {[key: string]: string}) => {
@@ -61,7 +62,8 @@ describe('GitHubRelease', () => {
         .delete('/repos/googleapis/foo/issues/1/labels/autorelease:%20pending')
         .reply(200);
 
-      await release.createRelease();
+      const created = await release.createRelease();
+      strictEqual(created!.tag_name, 'v1.0.2');
       requests.done();
     });
   });


### PR DESCRIPTION
by returning the release created, we can use this value as output in a GitHub action [see](https://github.com/bcoe/release-please-action/issues/8).