### PR TITLE
feat: introduce static factory helper

### DIFF
--- a/__snapshots__/release-pr-factory.js
+++ b/__snapshots__/release-pr-factory.js
@@ -1,0 +1,79 @@
+exports['ReleasePRFactory build returns instance of dynamically loaded releaser 1'] = `
+# Changelog
+
+### [0.123.5](https://www.github.com/googleapis/simple-test-repo/compare/v0.123.4...v0.123.5) 
+
+
+### Bug Fixes
+
+* **deps:** update dependency com.google.cloud:google-cloud-spanner to v1.50.0 ([1f9663c](https://www.github.com/googleapis/simple-test-repo/commit/1f9663cf08ab1cf3b68d95dee4dc99b7c4aac373))
+* **deps:** update dependency com.google.cloud:google-cloud-storage to v1.120.0 ([fcd1c89](https://www.github.com/googleapis/simple-test-repo/commit/fcd1c890dc1526f4d62ceedad561f498195c8939))
+
+`
+
+exports['ReleasePRFactory build returns instance of dynamically loaded releaser 2'] = `
+0.123.5
+
+`
+
+exports['ReleasePRFactory build returns instance of dynamically loaded releaser 3'] = `
+:robot: I have created a release \\*beep\\* \\*boop\\* 
+---
+### [0.123.5](https://www.github.com/googleapis/simple-test-repo/compare/v0.123.4...v0.123.5) 
+
+
+### Bug Fixes
+
+* **deps:** update dependency com.google.cloud:google-cloud-spanner to v1.50.0 ([1f9663c](https://www.github.com/googleapis/simple-test-repo/commit/1f9663cf08ab1cf3b68d95dee4dc99b7c4aac373))
+* **deps:** update dependency com.google.cloud:google-cloud-storage to v1.120.0 ([fcd1c89](https://www.github.com/googleapis/simple-test-repo/commit/fcd1c890dc1526f4d62ceedad561f498195c8939))
+---
+
+
+This PR was generated with [Release Please](https://github.com/googleapis/release-please).
+`
+
+exports['ReleasePRFactory build returns instance of dynamically loaded releaser 4'] = {
+  "labels": [
+    "autorelease: pending"
+  ]
+}
+
+exports['ReleasePRFactory buildStatic returns an instance of a statically loaded releaser 1'] = `
+# Changelog
+
+### [0.123.5](https://www.github.com/googleapis/simple-test-repo/compare/v0.123.4...v0.123.5) 
+
+
+### Bug Fixes
+
+* **deps:** update dependency com.google.cloud:google-cloud-spanner to v1.50.0 ([1f9663c](https://www.github.com/googleapis/simple-test-repo/commit/1f9663cf08ab1cf3b68d95dee4dc99b7c4aac373))
+* **deps:** update dependency com.google.cloud:google-cloud-storage to v1.120.0 ([fcd1c89](https://www.github.com/googleapis/simple-test-repo/commit/fcd1c890dc1526f4d62ceedad561f498195c8939))
+
+`
+
+exports['ReleasePRFactory buildStatic returns an instance of a statically loaded releaser 2'] = `
+0.123.5
+
+`
+
+exports['ReleasePRFactory buildStatic returns an instance of a statically loaded releaser 3'] = `
+:robot: I have created a release \\*beep\\* \\*boop\\* 
+---
+### [0.123.5](https://www.github.com/googleapis/simple-test-repo/compare/v0.123.4...v0.123.5) 
+
+
+### Bug Fixes
+
+* **deps:** update dependency com.google.cloud:google-cloud-spanner to v1.50.0 ([1f9663c](https://www.github.com/googleapis/simple-test-repo/commit/1f9663cf08ab1cf3b68d95dee4dc99b7c4aac373))
+* **deps:** update dependency com.google.cloud:google-cloud-storage to v1.120.0 ([fcd1c89](https://www.github.com/googleapis/simple-test-repo/commit/fcd1c890dc1526f4d62ceedad561f498195c8939))
+---
+
+
+This PR was generated with [Release Please](https://github.com/googleapis/release-please).
+`
+
+exports['ReleasePRFactory buildStatic returns an instance of a statically loaded releaser 4'] = {
+  "labels": [
+    "autorelease: pending"
+  ]
+}

--- a/__snapshots__/release-pr-factory.js
+++ b/__snapshots__/release-pr-factory.js
@@ -33,8 +33,8 @@ This PR was generated with [Release Please](https://github.com/googleapis/releas
 `
 
 exports['ReleasePRFactory build returns instance of dynamically loaded releaser 4'] = {
-  "labels": [
-    "autorelease: pending"
+  'labels': [
+    'autorelease: pending'
   ]
 }
 
@@ -73,7 +73,7 @@ This PR was generated with [Release Please](https://github.com/googleapis/releas
 `
 
 exports['ReleasePRFactory buildStatic returns an instance of a statically loaded releaser 4'] = {
-  "labels": [
-    "autorelease: pending"
+  'labels': [
+    'autorelease: pending'
   ]
 }

--- a/src/release-pr-factory.ts
+++ b/src/release-pr-factory.ts
@@ -13,21 +13,49 @@
 // limitations under the License.
 
 import {BuildOptions, ReleasePR, ReleasePROptions} from './release-pr';
-import releasers from './releasers';
+import {RubyReleasePROptions} from './releasers/ruby';
+import {getReleasers} from './releasers';
+
+import {Node} from './releasers/node';
+import {Python} from './releasers/python';
+import {Simple} from './releasers/simple';
+import {TerraformModule} from './releasers/terraform-module';
 
 export class ReleasePRFactory {
   static build(releaseType: string, options: BuildOptions): ReleasePR {
-    const releaseOptions: ReleasePROptions = {
+    const releaseOptions: ReleasePROptions | RubyReleasePROptions = {
       ...options,
       ...{releaseType},
     };
     return new (ReleasePRFactory.class(releaseType))(releaseOptions);
   }
+  // Return a ReleasePR class, based on the release type, e.g., node, python:
   static class(releaseType: string): typeof ReleasePR {
+    const releasers = getReleasers();
     const releaser = releasers[releaseType];
     if (!releaser) {
       throw Error('unknown release type');
     }
     return releaser;
+  }
+  // For the benefit of WebPack, we provide a static factory for a subset
+  // of the releasers available in the release please GitHub action:
+  static buildStatic(releaseType: string, options: BuildOptions) {
+    const releaseOptions: ReleasePROptions = {
+      ...options,
+      ...{releaseType},
+    };
+    switch (releaseType) {
+      case 'node':
+        return new Node(releaseOptions);
+      case 'python':
+        return new Python(releaseOptions);
+      case 'simple':
+        return new Simple(releaseOptions);
+      case 'terraform-module':
+        return new TerraformModule(releaseOptions);
+      default:
+        throw Error('unknown release type');
+    }
   }
 }

--- a/src/releasers/index.ts
+++ b/src/releasers/index.ts
@@ -19,26 +19,28 @@ import {dirname} from 'path';
 
 // dynamically load all the releasers in the folder, and index based on their
 // releaserName property:
-const releasers: {[key: string]: typeof ReleasePR} = {};
-const root = dirname(require.resolve('./'));
-for (const file of readdirSync(root, {withFileTypes: true})) {
-  if (
-    file.isFile() &&
-    !file.name.match(/.*\.ts.*/) &&
-    !file.name.match(/.*\.map$/) &&
-    !file.name.match(/index\.js/)
-  ) {
-    const obj = require(`./${file.name}`) as {[key: string]: typeof ReleasePR};
-    const releaser = obj[Object.keys(obj)[0]];
-    releasers[releaser.releaserName] = releaser;
+export function getReleasers(): {[key: string]: typeof ReleasePR} {
+  const releasers: {[key: string]: typeof ReleasePR} = {};
+  const root = dirname(require.resolve('./'));
+  for (const file of readdirSync(root, {withFileTypes: true})) {
+    if (
+      file.isFile() &&
+      !file.name.match(/.*\.ts.*/) &&
+      !file.name.match(/.*\.map$/) &&
+      !file.name.match(/index\.js/)
+    ) {
+      const obj = require(`./${file.name}`) as {[key: string]: typeof ReleasePR};
+      const releaser = obj[Object.keys(obj)[0]];
+      releasers[releaser.releaserName] = releaser;
+    }
   }
+  return releasers;
 }
 
 export function getReleaserNames(): string[] {
+  const releasers = getReleasers();
   return Object.keys(releasers).map(key => {
     const releaser = releasers[key];
     return releaser.releaserName;
   });
 }
-
-export default releasers;

--- a/src/releasers/index.ts
+++ b/src/releasers/index.ts
@@ -29,7 +29,9 @@ export function getReleasers(): {[key: string]: typeof ReleasePR} {
       !file.name.match(/.*\.map$/) &&
       !file.name.match(/index\.js/)
     ) {
-      const obj = require(`./${file.name}`) as {[key: string]: typeof ReleasePR};
+      const obj = require(`./${file.name}`) as {
+        [key: string]: typeof ReleasePR;
+      };
       const releaser = obj[Object.keys(obj)[0]];
       releasers[releaser.releaserName] = releaser;
     }

--- a/test/release-pr-factory.ts
+++ b/test/release-pr-factory.ts
@@ -1,0 +1,244 @@
+// Copyright 2020 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import {describe, it} from 'mocha';
+import * as nock from 'nock';
+import {ReleasePRFactory} from '../src/release-pr-factory';
+import {readFileSync} from 'fs';
+import {resolve} from 'path';
+import * as snapshot from 'snap-shot-it';
+
+const fixturesPath = './test/releasers/fixtures/simple';
+
+interface MochaThis {
+  [skip: string]: Function;
+}
+
+describe('ReleasePRFactory', () => {
+  describe('build', () => {
+    it('returns instance of dynamically loaded releaser', async () => {
+      const versionContent = readFileSync(
+        resolve(fixturesPath, 'version.txt'),
+        'utf8'
+      );
+      const graphql = JSON.parse(
+        readFileSync(resolve(fixturesPath, 'commits.json'), 'utf8')
+      );
+      const req = nock('https://api.github.com')
+        .get(
+          '/repos/googleapis/simple-test-repo/pulls?state=closed&per_page=100'
+        )
+        .reply(200, undefined)
+        .get('/repos/googleapis/simple-test-repo/contents/version.txt')
+        .reply(200, {
+          content: Buffer.from(versionContent, 'utf8').toString('base64'),
+          sha: 'abc123',
+        })
+        // fetch semver tags, this will be used to determine
+        // the delta since the last release.
+        .get('/repos/googleapis/simple-test-repo/tags?per_page=100')
+        .reply(200, [
+          {
+            name: 'v0.123.4',
+            commit: {
+              sha: 'da6e52d956c1e35d19e75e0f2fdba439739ba364',
+            },
+          },
+        ])
+        .post('/graphql')
+        .reply(200, {
+          data: graphql,
+        })
+        // getting the latest tag
+        .get('/repos/googleapis/simple-test-repo/git/refs?per_page=100')
+        .reply(200, [{ref: 'refs/tags/v0.123.4'}])
+        // creating a new branch
+        .post('/repos/googleapis/simple-test-repo/git/refs')
+        .reply(200)
+        // check for CHANGELOG
+        .get(
+          '/repos/googleapis/simple-test-repo/contents/CHANGELOG.md?ref=refs%2Fheads%2Frelease-v0.123.5'
+        )
+        .reply(404)
+        .put(
+          '/repos/googleapis/simple-test-repo/contents/CHANGELOG.md',
+          (req: {[key: string]: string}) => {
+            snapshot(
+              Buffer.from(req.content, 'base64')
+                .toString('utf8')
+                .replace(/\([0-9]{4}-[0-9]{2}-[0-9]{2}\)/g, '')
+            );
+            return true;
+          }
+        )
+        .reply(201)
+        // update version.txt
+        .get(
+          '/repos/googleapis/simple-test-repo/contents/version.txt?ref=refs%2Fheads%2Frelease-v0.123.5'
+        )
+        .reply(200, {
+          content: Buffer.from(versionContent, 'utf8').toString('base64'),
+          sha: 'abc123',
+        })
+        .put(
+          '/repos/googleapis/simple-test-repo/contents/version.txt',
+          (req: {[key: string]: string}) => {
+            snapshot(Buffer.from(req.content, 'base64').toString('utf8'));
+            return true;
+          }
+        )
+        .reply(200)
+        // create release
+        .post(
+          '/repos/googleapis/simple-test-repo/pulls',
+          (req: {[key: string]: string}) => {
+            const body = req.body.replace(
+              /\([0-9]{4}-[0-9]{2}-[0-9]{2}\)/g,
+              ''
+            );
+            snapshot(body);
+            return true;
+          }
+        )
+        .reply(200, {number: 1})
+        .post(
+          '/repos/googleapis/simple-test-repo/issues/1/labels',
+          (req: {[key: string]: string}) => {
+            snapshot(req);
+            return true;
+          }
+        )
+        .reply(200, {})
+        // this step tries to close any existing PRs; just return an empty list.
+        .get('/repos/googleapis/simple-test-repo/pulls?state=open&per_page=100')
+        .reply(200, []);
+      const releasePR = ReleasePRFactory.build('simple', {
+        repoUrl: 'googleapis/simple-test-repo',
+        // not actually used by this type of repo.
+        packageName: 'simple-test-repo',
+        apiUrl: 'https://api.github.com',
+      });
+      await releasePR.run();
+      req.done();
+    });
+  });
+
+  describe('buildStatic', () => {
+    it('returns an instance of a statically loaded releaser', async () => {
+      const versionContent = readFileSync(
+        resolve(fixturesPath, 'version.txt'),
+        'utf8'
+      );
+      const graphql = JSON.parse(
+        readFileSync(resolve(fixturesPath, 'commits.json'), 'utf8')
+      );
+      const req = nock('https://api.github.com')
+        .get(
+          '/repos/googleapis/simple-test-repo/pulls?state=closed&per_page=100'
+        )
+        .reply(200, undefined)
+        .get('/repos/googleapis/simple-test-repo/contents/version.txt')
+        .reply(200, {
+          content: Buffer.from(versionContent, 'utf8').toString('base64'),
+          sha: 'abc123',
+        })
+        // fetch semver tags, this will be used to determine
+        // the delta since the last release.
+        .get('/repos/googleapis/simple-test-repo/tags?per_page=100')
+        .reply(200, [
+          {
+            name: 'v0.123.4',
+            commit: {
+              sha: 'da6e52d956c1e35d19e75e0f2fdba439739ba364',
+            },
+          },
+        ])
+        .post('/graphql')
+        .reply(200, {
+          data: graphql,
+        })
+        // getting the latest tag
+        .get('/repos/googleapis/simple-test-repo/git/refs?per_page=100')
+        .reply(200, [{ref: 'refs/tags/v0.123.4'}])
+        // creating a new branch
+        .post('/repos/googleapis/simple-test-repo/git/refs')
+        .reply(200)
+        // check for CHANGELOG
+        .get(
+          '/repos/googleapis/simple-test-repo/contents/CHANGELOG.md?ref=refs%2Fheads%2Frelease-v0.123.5'
+        )
+        .reply(404)
+        .put(
+          '/repos/googleapis/simple-test-repo/contents/CHANGELOG.md',
+          (req: {[key: string]: string}) => {
+            snapshot(
+              Buffer.from(req.content, 'base64')
+                .toString('utf8')
+                .replace(/\([0-9]{4}-[0-9]{2}-[0-9]{2}\)/g, '')
+            );
+            return true;
+          }
+        )
+        .reply(201)
+        // update version.txt
+        .get(
+          '/repos/googleapis/simple-test-repo/contents/version.txt?ref=refs%2Fheads%2Frelease-v0.123.5'
+        )
+        .reply(200, {
+          content: Buffer.from(versionContent, 'utf8').toString('base64'),
+          sha: 'abc123',
+        })
+        .put(
+          '/repos/googleapis/simple-test-repo/contents/version.txt',
+          (req: {[key: string]: string}) => {
+            snapshot(Buffer.from(req.content, 'base64').toString('utf8'));
+            return true;
+          }
+        )
+        .reply(200)
+        // create release
+        .post(
+          '/repos/googleapis/simple-test-repo/pulls',
+          (req: {[key: string]: string}) => {
+            const body = req.body.replace(
+              /\([0-9]{4}-[0-9]{2}-[0-9]{2}\)/g,
+              ''
+            );
+            snapshot(body);
+            return true;
+          }
+        )
+        .reply(200, {number: 1})
+        .post(
+          '/repos/googleapis/simple-test-repo/issues/1/labels',
+          (req: {[key: string]: string}) => {
+            snapshot(req);
+            return true;
+          }
+        )
+        .reply(200, {})
+        // this step tries to close any existing PRs; just return an empty list.
+        .get('/repos/googleapis/simple-test-repo/pulls?state=open&per_page=100')
+        .reply(200, []);
+      const releasePR = ReleasePRFactory.buildStatic('simple', {
+        repoUrl: 'googleapis/simple-test-repo',
+        // not actually used by this type of repo.
+        packageName: 'simple-test-repo',
+        apiUrl: 'https://api.github.com',
+      });
+      await releasePR.run();
+      req.done();
+    });
+  });
+});


### PR DESCRIPTION
The GitHub action I've been working on uses WebPack for shipping (which is a suggested best practice), by moving our factory to being dynamic, this broke WebPack.

This PR leaves the dynamic factory (this is reasonable to have as we've been tending to add helpers for yoshi/google specific library structures, and this reduces the number of steps for doing so), but introduces a static factory helper for fetching classes which are likely to be used by the wider community.