### PR TITLE
feat: a flag to skip CI

### DIFF
--- a/__snapshots__/java-yoshi.js
+++ b/__snapshots__/java-yoshi.js
@@ -973,3 +973,23 @@ public final class GoogleUtils {
   private GoogleUtils() {}
 }
 `
+
+exports['CHANGELOG-message'] = `
+created CHANGELOG.md [ci skip]
+`
+
+exports['README-message'] = `
+updated README.md [ci skip]
+`
+
+exports['GoogleUtils-message'] = `
+updated google-api-client/src/main/java/com/google/api/client/googleapis/GoogleUtils.java [ci skip]
+`
+
+exports['versions-message'] = `
+updated versions.txt [ci skip]
+`
+
+exports['pom-message'] = `
+updated pom.xml
+`

--- a/__snapshots__/simple.js
+++ b/__snapshots__/simple.js
@@ -33,7 +33,15 @@ This PR was generated with [Release Please](https://github.com/googleapis/releas
 `
 
 exports['labels-simple'] = {
-  'labels': [
-    'autorelease: pending'
+  "labels": [
+    "autorelease: pending"
   ]
 }
+
+exports['CHANGELOG-simple-message'] = `
+created CHANGELOG.md [ci skip]
+`
+
+exports['version-txt-simple-message'] = `
+updated version.txt
+`

--- a/__snapshots__/simple.js
+++ b/__snapshots__/simple.js
@@ -33,8 +33,8 @@ This PR was generated with [Release Please](https://github.com/googleapis/releas
 `
 
 exports['labels-simple'] = {
-  "labels": [
-    "autorelease: pending"
+  'labels': [
+    'autorelease: pending'
   ]
 }
 

--- a/src/github.ts
+++ b/src/github.ts
@@ -770,7 +770,8 @@ export class GitHub {
             owner: this.owner,
             repo: this.repo,
             path: update.path,
-            message: `updated ${update.path} [ci skip]`,
+            message:
+              `updated ${update.path}` + (update.skipCi ? ' [ci skip]' : ''),
             content: Buffer.from(updatedContent, 'utf8').toString('base64'),
             sha: content.data.sha,
             branch,
@@ -785,7 +786,8 @@ export class GitHub {
             owner: this.owner,
             repo: this.repo,
             path: update.path,
-            message: `created ${update.path} [ci skip]`,
+            message:
+              `created ${update.path}` + (update.skipCi ? ' [ci skip]' : ''),
             content: Buffer.from(updatedContent, 'utf8').toString('base64'),
             branch,
           }

--- a/src/github.ts
+++ b/src/github.ts
@@ -723,6 +723,24 @@ export class GitHub {
   }
 
   async updateFiles(updates: Update[], branch: string, refName: string) {
+    // does the user care about skipping CI at all?
+    const skipCiEverSet = updates.some(
+      upd => typeof upd.skipCi !== 'undefined'
+    );
+    if (skipCiEverSet) {
+      // if skipCi was set for some of the updates, disable CI for others
+      updates.forEach(upd => {
+        if (typeof upd.skipCi === 'undefined') {
+          upd.skipCi = true;
+        }
+      });
+    }
+    if (!skipCiEverSet && updates.length > 0) {
+      // if skipCi was not set for any of the files, disable CI for all files except the last one
+      updates.forEach(upd => (upd.skipCi = true));
+      updates[updates.length - 1].skipCi = false;
+    }
+
     for (let i = 0; i < updates.length; i++) {
       const update = updates[i];
       let content;

--- a/src/releasers/simple.ts
+++ b/src/releasers/simple.ts
@@ -84,6 +84,7 @@ export class Simple extends ReleasePR {
         version: candidate.version,
         packageName: this.packageName,
         contents,
+        skipCi: false,
       })
     );
 

--- a/src/updaters/changelog.ts
+++ b/src/updaters/changelog.ts
@@ -24,6 +24,7 @@ export class Changelog implements Update {
   packageName: string;
   create: boolean;
   contents?: GitHubFileContents;
+  skipCi?: boolean;
 
   constructor(options: UpdateOptions) {
     this.create = true;
@@ -31,6 +32,7 @@ export class Changelog implements Update {
     this.changelogEntry = options.changelogEntry;
     this.version = options.version;
     this.packageName = options.packageName;
+    this.skipCi = options.skipCi ?? true;
   }
 
   updateContent(content: string | undefined): string {

--- a/src/updaters/changelog.ts
+++ b/src/updaters/changelog.ts
@@ -32,7 +32,7 @@ export class Changelog implements Update {
     this.changelogEntry = options.changelogEntry;
     this.version = options.version;
     this.packageName = options.packageName;
-    this.skipCi = options.skipCi ?? true;
+    this.skipCi = options.skipCi;
   }
 
   updateContent(content: string | undefined): string {

--- a/src/updaters/java/google-utils.ts
+++ b/src/updaters/java/google-utils.ts
@@ -23,6 +23,7 @@ export class GoogleUtils implements Update {
   packageName: string;
   create: boolean;
   contents?: GitHubFileContents;
+  skipCi?: boolean;
 
   constructor(options: UpdateOptions) {
     this.create = false;
@@ -30,6 +31,7 @@ export class GoogleUtils implements Update {
     this.changelogEntry = options.changelogEntry;
     this.version = options.version;
     this.packageName = options.packageName;
+    this.skipCi = options.skipCi;
   }
   updateContent(content: string): string {
     return content.replace(

--- a/src/updaters/java/java_update.ts
+++ b/src/updaters/java/java_update.ts
@@ -28,6 +28,8 @@ export class JavaUpdate implements Update {
   packageName: string;
   create: boolean;
   contents?: GitHubFileContents;
+  skipCi?: boolean;
+
   constructor(options: UpdateOptions) {
     this.create = false;
     this.path = options.path;
@@ -35,6 +37,7 @@ export class JavaUpdate implements Update {
     this.versions = new Map<string, string>();
     this.version = 'unused';
     this.packageName = 'unused';
+    this.skipCi = options.skipCi;
     if (options.versions) {
       this.versions = options.versions;
     } else if (options.version) {
@@ -43,6 +46,7 @@ export class JavaUpdate implements Update {
       this.packageName = options.packageName;
     }
   }
+
   updateContent(content: string): string {
     const newLines: string[] = [];
     let blockPackageName: string | null = null;

--- a/src/updaters/package-json.ts
+++ b/src/updaters/package-json.ts
@@ -24,6 +24,7 @@ export class PackageJson implements Update {
   packageName: string;
   create: boolean;
   contents?: GitHubFileContents;
+  skipCi?: boolean;
 
   constructor(options: UpdateOptions) {
     this.create = false;
@@ -31,7 +32,9 @@ export class PackageJson implements Update {
     this.changelogEntry = options.changelogEntry;
     this.version = options.version;
     this.packageName = options.packageName;
+    this.skipCi = options.skipCi;
   }
+
   updateContent(content: string): string {
     const parsed = JSON.parse(content);
     checkpoint(

--- a/src/updaters/php-client-version.ts
+++ b/src/updaters/php-client-version.ts
@@ -24,6 +24,7 @@ export class PHPClientVersion implements Update {
   packageName: string;
   create: boolean;
   contents?: GitHubFileContents;
+  skipCi?: boolean;
 
   constructor(options: UpdateOptions) {
     this.create = false;
@@ -32,7 +33,9 @@ export class PHPClientVersion implements Update {
     this.version = options.version;
     this.packageName = options.packageName;
     this.contents = options.contents;
+    this.skipCi = options.skipCi;
   }
+
   updateContent(content: string): string {
     return content.replace(
       /const VERSION = '[0-9]+\.[0-9]+\.[0-9]+'/,

--- a/src/updaters/php-manifest.ts
+++ b/src/updaters/php-manifest.ts
@@ -29,6 +29,7 @@ export class PHPManifest implements Update {
   packageName: string;
   create: boolean;
   contents?: GitHubFileContents;
+  skipCi?: boolean;
 
   constructor(options: UpdateOptions) {
     this.create = false;
@@ -37,7 +38,9 @@ export class PHPManifest implements Update {
     this.version = options.version;
     this.versions = options.versions;
     this.packageName = options.packageName;
+    this.skipCi = options.skipCi;
   }
+
   updateContent(content: string): string {
     if (!this.versions || this.versions.size === 0) {
       checkpoint(

--- a/src/updaters/python/setup-cfg.ts
+++ b/src/updaters/python/setup-cfg.ts
@@ -23,6 +23,7 @@ export class SetupCfg implements Update {
   packageName: string;
   create: boolean;
   contents?: GitHubFileContents;
+  skipCi?: boolean;
 
   constructor(options: UpdateOptions) {
     this.create = false;
@@ -30,6 +31,7 @@ export class SetupCfg implements Update {
     this.changelogEntry = options.changelogEntry;
     this.version = options.version;
     this.packageName = options.packageName;
+    this.skipCi = options.skipCi;
   }
   updateContent(content: string): string {
     return content.replace(

--- a/src/updaters/python/setup-py.ts
+++ b/src/updaters/python/setup-py.ts
@@ -23,6 +23,7 @@ export class SetupPy implements Update {
   packageName: string;
   create: boolean;
   contents?: GitHubFileContents;
+  skipCi?: boolean;
 
   constructor(options: UpdateOptions) {
     this.create = false;
@@ -30,6 +31,7 @@ export class SetupPy implements Update {
     this.changelogEntry = options.changelogEntry;
     this.version = options.version;
     this.packageName = options.packageName;
+    this.skipCi = options.skipCi;
   }
   updateContent(content: string): string {
     return content.replace(

--- a/src/updaters/root-composer.ts
+++ b/src/updaters/root-composer.ts
@@ -24,6 +24,7 @@ export class RootComposer implements Update {
   packageName: string;
   create: boolean;
   contents?: GitHubFileContents;
+  skipCi?: boolean;
 
   constructor(options: UpdateOptions) {
     this.create = false;
@@ -32,7 +33,9 @@ export class RootComposer implements Update {
     this.version = options.version;
     this.versions = options.versions;
     this.packageName = options.packageName;
+    this.skipCi = options.skipCi;
   }
+
   updateContent(content: string): string {
     if (!this.versions || this.versions.size === 0) {
       checkpoint(

--- a/src/updaters/samples-package-json.ts
+++ b/src/updaters/samples-package-json.ts
@@ -24,6 +24,7 @@ export class SamplesPackageJson implements Update {
   packageName: string;
   create: boolean;
   contents?: GitHubFileContents;
+  skipCi?: boolean;
 
   constructor(options: UpdateOptions) {
     this.create = false;
@@ -31,7 +32,9 @@ export class SamplesPackageJson implements Update {
     this.changelogEntry = options.changelogEntry;
     this.version = options.version;
     this.packageName = options.packageName;
+    this.skipCi = options.skipCi;
   }
+
   updateContent(content: string): string {
     const parsed = JSON.parse(content);
     if (!parsed.dependencies || !parsed.dependencies[this.packageName]) {

--- a/src/updaters/terraform/readme.ts
+++ b/src/updaters/terraform/readme.ts
@@ -23,6 +23,7 @@ export class ReadMe implements Update {
   packageName: string;
   create: boolean;
   contents?: GitHubFileContents;
+  skipCi?: boolean;
 
   constructor(options: UpdateOptions) {
     this.create = false;
@@ -30,7 +31,9 @@ export class ReadMe implements Update {
     this.changelogEntry = options.changelogEntry;
     this.version = options.version;
     this.packageName = options.packageName;
+    this.skipCi = options.skipCi;
   }
+
   updateContent(content: string): string {
     const minorVersion = this.version.split('.').slice(0, 2).join('.');
     return content.replace(

--- a/src/updaters/update.ts
+++ b/src/updaters/update.ts
@@ -23,6 +23,7 @@ export interface UpdateOptions {
   version: string;
   versions?: VersionsMap;
   contents?: GitHubFileContents;
+  skipCi?: boolean;
 }
 
 export interface Update {
@@ -33,5 +34,6 @@ export interface Update {
   version: string;
   versions?: VersionsMap;
   contents?: GitHubFileContents;
+  skipCi?: boolean;
   updateContent(content: string | undefined): string;
 }

--- a/src/updaters/version-rb.ts
+++ b/src/updaters/version-rb.ts
@@ -23,6 +23,7 @@ export class VersionRB implements Update {
   packageName: string;
   create: boolean;
   contents?: GitHubFileContents;
+  skipCi?: boolean;
 
   constructor(options: UpdateOptions) {
     this.create = false;
@@ -30,7 +31,9 @@ export class VersionRB implements Update {
     this.changelogEntry = options.changelogEntry;
     this.version = options.version;
     this.packageName = options.packageName;
+    this.skipCi = options.skipCi;
   }
+
   updateContent(content: string): string {
     return content.replace(
       /"[0-9]+\.[0-9]+\.[0-9](-\w+)?"/,

--- a/src/updaters/version-txt.ts
+++ b/src/updaters/version-txt.ts
@@ -30,7 +30,7 @@ export class VersionTxt implements Update {
     this.changelogEntry = options.changelogEntry;
     this.version = options.version;
     this.packageName = options.packageName;
-    this.skipCi = options.skipCi ?? true;
+    this.skipCi = options.skipCi;
   }
 
   updateContent(): string {

--- a/src/updaters/version-txt.ts
+++ b/src/updaters/version-txt.ts
@@ -22,6 +22,7 @@ export class VersionTxt implements Update {
   packageName: string;
   create: boolean;
   contents?: GitHubFileContents;
+  skipCi?: boolean;
 
   constructor(options: UpdateOptions) {
     this.create = false;
@@ -29,6 +30,7 @@ export class VersionTxt implements Update {
     this.changelogEntry = options.changelogEntry;
     this.version = options.version;
     this.packageName = options.packageName;
+    this.skipCi = options.skipCi ?? true;
   }
 
   updateContent(): string {

--- a/src/updaters/version.ts
+++ b/src/updaters/version.ts
@@ -23,6 +23,7 @@ export class Version implements Update {
   packageName: string;
   create: boolean;
   contents?: GitHubFileContents;
+  skipCi?: boolean;
 
   constructor(options: UpdateOptions) {
     this.create = false;
@@ -31,7 +32,9 @@ export class Version implements Update {
     this.version = options.version;
     this.packageName = options.packageName;
     this.contents = options.contents;
+    this.skipCi = options.skipCi;
   }
+
   updateContent(): string {
     return `${this.version}`;
   }

--- a/test/releasers/java-yoshi.ts
+++ b/test/releasers/java-yoshi.ts
@@ -95,6 +95,7 @@ describe('JavaYoshi', () => {
       .put(
         '/repos/googleapis/java-trace/contents/CHANGELOG.md',
         (req: {[key: string]: string}) => {
+          snapshot('CHANGELOG-message', req.message);
           snapshot(
             'CHANGELOG',
             Buffer.from(req.content, 'base64')
@@ -115,6 +116,7 @@ describe('JavaYoshi', () => {
       .put(
         '/repos/googleapis/java-trace/contents/README.md',
         (req: {[key: string]: string}) => {
+          snapshot('README-message', req.message);
           snapshot(
             'README',
             Buffer.from(req.content, 'base64').toString('utf8')
@@ -134,6 +136,7 @@ describe('JavaYoshi', () => {
       .put(
         '/repos/googleapis/java-trace/contents/versions.txt',
         (req: {[key: string]: string}) => {
+          snapshot('versions-message', req.message);
           snapshot(
             'versions',
             Buffer.from(req.content, 'base64').toString('utf8')
@@ -153,6 +156,7 @@ describe('JavaYoshi', () => {
       .put(
         '/repos/googleapis/java-trace/contents/pom.xml',
         (req: {[key: string]: string}) => {
+          snapshot('pom-message', req.message);
           snapshot('pom', Buffer.from(req.content, 'base64').toString('utf8'));
           return true;
         }
@@ -169,6 +173,7 @@ describe('JavaYoshi', () => {
       .put(
         '/repos/googleapis/java-trace/contents/google-api-client/src/main/java/com/google/api/client/googleapis/GoogleUtils.java',
         (req: {[key: string]: string}) => {
+          snapshot('GoogleUtils-message', req.message);
           snapshot(
             'GoogleUtils',
             Buffer.from(req.content, 'base64').toString('utf8')

--- a/test/releasers/simple.ts
+++ b/test/releasers/simple.ts
@@ -81,6 +81,7 @@ describe('Simple', () => {
         .put(
           '/repos/googleapis/simple-test-repo/contents/CHANGELOG.md',
           (req: {[key: string]: string}) => {
+            snapshot('CHANGELOG-simple-message', req.message);
             snapshot(
               'CHANGELOG-simple',
               Buffer.from(req.content, 'base64')
@@ -102,6 +103,7 @@ describe('Simple', () => {
         .put(
           '/repos/googleapis/simple-test-repo/contents/version.txt',
           (req: {[key: string]: string}) => {
+            snapshot('version-txt-simple-message', req.message);
             snapshot(
               'version-txt-simple',
               Buffer.from(req.content, 'base64').toString('utf8')


### PR DESCRIPTION
Instead of making assumptions such as "let's run / let's not run CI for the first / the last / whatever file", let's just make it configurable. I'm only using this flag in the simple releaser but any other releaser can be upgraded if needed. The default behavior is `skipCi: true` so nothing is changed for other releasers.