### PR TITLE
fix: merge commits now handled

### DIFF
--- a/test/fixtures/commits-with-labels.json
+++ b/test/fixtures/commits-with-labels.json
@@ -87,7 +87,7 @@
                     "edges": [
                       {
                         "node": {
-                          "mergeCommit": {"oid": "35abf13fa8acb3988aa086f3eb23f5ce1483cc5d"},
+                          "mergeCommit": {"oid": "fcd1c890dc1526f4d62ceedad561f498195c8939"},
                           "number": 291,
                           "labels": {
                             "edges": [


### PR DESCRIPTION
For merge commits, prEdge.node.mergeCommit.oid references the SHA of the
commit at the top of the list of commits, vs., its own SHA. We track the
SHAs observed, and if the commit references a SHA from earlier in the list
of commitHistory.edges being processed, we accept it as a valid commit.