### PR TITLE
feat(java-yoshi): handle build.gradle and dependencies.properties files

### DIFF
--- a/src/releasers/java-yoshi.ts
+++ b/src/releasers/java-yoshi.ts
@@ -194,6 +194,9 @@ export class JavaYoshi extends ReleasePR {
 
     const pomFilesSearch = this.gh.findFilesByFilename('pom.xml');
     const buildFilesSearch = this.gh.findFilesByFilename('build.gradle');
+    const dependenciesSearch = this.gh.findFilesByFilename(
+      'dependencies.properties'
+    );
 
     const pomFiles = await pomFilesSearch;
     pomFiles.forEach(path => {
@@ -221,15 +224,18 @@ export class JavaYoshi extends ReleasePR {
       );
     });
 
-    updates.push(
-      new JavaUpdate({
-        path: 'dependencies.properties',
-        changelogEntry,
-        versions: candidateVersions,
-        version: candidate.version,
-        packageName: this.packageName,
-      })
-    );
+    const dependenciesFiles = await dependenciesSearch;
+    dependenciesFiles.forEach(path => {
+      updates.push(
+        new JavaUpdate({
+          path,
+          changelogEntry,
+          versions: candidateVersions,
+          version: candidate.version,
+          packageName: this.packageName,
+        })
+      );
+    });
 
     console.info(
       `attempting to open PR latestTagSha = ${

--- a/src/releasers/java-yoshi.ts
+++ b/src/releasers/java-yoshi.ts
@@ -29,7 +29,7 @@ import {VersionsManifest} from '../updaters/java/versions-manifest';
 import {Readme} from '../updaters/java/readme';
 import {Version} from './java/version';
 import {fromSemverReleaseType} from './java/bump_type';
-import { JavaUpdate } from '../updaters/java/java_update';
+import {JavaUpdate} from '../updaters/java/java_update';
 
 const CHANGELOG_SECTIONS = [
   {type: 'feat', section: 'Features'},

--- a/test/releasers/java-yoshi.ts
+++ b/test/releasers/java-yoshi.ts
@@ -82,7 +82,9 @@ describe('JavaYoshi', () => {
         items: [{name: 'pom.xml', path: 'pom.xml'}],
       })
       // finding build.gradle files
-      .get('/search/code?q=filename%3Abuild.gradle+repo%3Agoogleapis%2Fjava-trace')
+      .get(
+        '/search/code?q=filename%3Abuild.gradle+repo%3Agoogleapis%2Fjava-trace'
+      )
       .reply(200, {
         total_count: 0,
         items: [],
@@ -259,7 +261,9 @@ describe('JavaYoshi', () => {
         items: [{name: 'pom.xml', path: 'pom.xml'}],
       })
       // finding build.gradle files
-      .get('/search/code?q=filename%3Abuild.gradle+repo%3Agoogleapis%2Fjava-trace')
+      .get(
+        '/search/code?q=filename%3Abuild.gradle+repo%3Agoogleapis%2Fjava-trace'
+      )
       .reply(200, {
         total_count: 0,
         items: [],

--- a/test/releasers/java-yoshi.ts
+++ b/test/releasers/java-yoshi.ts
@@ -89,6 +89,14 @@ describe('JavaYoshi', () => {
         total_count: 0,
         items: [],
       })
+      // finding dependencies.properties files
+      .get(
+        '/search/code?q=filename%3Adependencies.properties+repo%3Agoogleapis%2Fjava-trace'
+      )
+      .reply(200, {
+        total_count: 0,
+        items: [],
+      })
       // getting the latest tag
       .get('/repos/googleapis/java-trace/git/refs?per_page=100')
       .reply(200, [{ref: 'refs/tags/v0.20.3'}])
@@ -263,6 +271,14 @@ describe('JavaYoshi', () => {
       // finding build.gradle files
       .get(
         '/search/code?q=filename%3Abuild.gradle+repo%3Agoogleapis%2Fjava-trace'
+      )
+      .reply(200, {
+        total_count: 0,
+        items: [],
+      })
+      // finding dependencies.properties files
+      .get(
+        '/search/code?q=filename%3Adependencies.properties+repo%3Agoogleapis%2Fjava-trace'
       )
       .reply(200, {
         total_count: 0,

--- a/test/releasers/java-yoshi.ts
+++ b/test/releasers/java-yoshi.ts
@@ -81,6 +81,12 @@ describe('JavaYoshi', () => {
         total_count: 1,
         items: [{name: 'pom.xml', path: 'pom.xml'}],
       })
+      // finding build.gradle files
+      .get('/search/code?q=filename%3Abuild.gradle+repo%3Agoogleapis%2Fjava-trace')
+      .reply(200, {
+        total_count: 0,
+        items: [],
+      })
       // getting the latest tag
       .get('/repos/googleapis/java-trace/git/refs?per_page=100')
       .reply(200, [{ref: 'refs/tags/v0.20.3'}])
@@ -251,6 +257,12 @@ describe('JavaYoshi', () => {
       .reply(200, {
         total_count: 1,
         items: [{name: 'pom.xml', path: 'pom.xml'}],
+      })
+      // finding build.gradle files
+      .get('/search/code?q=filename%3Abuild.gradle+repo%3Agoogleapis%2Fjava-trace')
+      .reply(200, {
+        total_count: 0,
+        items: [],
       })
       // getting the latest tag
       .get('/repos/googleapis/java-trace/git/refs?per_page=100')


### PR DESCRIPTION
This will allow release-please to handle repos like gax-java and other gradle projects we manage
