### PR TITLE
feat(node): update version number in package-lock.json

### DIFF
--- a/__snapshots__/node.js
+++ b/__snapshots__/node.js
@@ -1,0 +1,122 @@
+exports['papckage-lock-json-node-with'] = `
+{
+  "name": "node-test-repo",
+  "version": "0.123.5",
+  "lockfileVersion": 1,
+  "requires": true,
+  "dependencies": {}
+}
+
+`
+
+exports['CHANGELOG-node-message-no-package-lock'] = `
+created CHANGELOG.md [ci skip]
+`
+
+exports['CHANGELOG-node-no-package-lock'] = `
+# Changelog
+
+### [0.123.5](https://www.github.com/googleapis/node-test-repo/compare/v0.123.4...v0.123.5) 
+
+
+### Bug Fixes
+
+* **deps:** update dependency com.google.cloud:google-cloud-spanner to v1.50.0 ([1f9663c](https://www.github.com/googleapis/node-test-repo/commit/1f9663cf08ab1cf3b68d95dee4dc99b7c4aac373))
+* **deps:** update dependency com.google.cloud:google-cloud-storage to v1.120.0 ([fcd1c89](https://www.github.com/googleapis/node-test-repo/commit/fcd1c890dc1526f4d62ceedad561f498195c8939))
+
+`
+
+exports['package-json-node-message-no-package-lock'] = `
+updated package.json [ci skip]
+`
+
+exports['package-json-node-no-package-lock'] = `
+{
+  "name": "node-test-repo",
+  "version": "0.123.5",
+  "repository": {
+    "url": "git@github.com:samples/node-test-repo.git"
+  }
+}
+
+`
+
+exports['CHANGELOG-node-message-with-package-lock'] = `
+created CHANGELOG.md [ci skip]
+`
+
+exports['CHANGELOG-node-with-package-lock'] = `
+# Changelog
+
+### [0.123.5](https://www.github.com/googleapis/node-test-repo/compare/v0.123.4...v0.123.5) 
+
+
+### Bug Fixes
+
+* **deps:** update dependency com.google.cloud:google-cloud-spanner to v1.50.0 ([1f9663c](https://www.github.com/googleapis/node-test-repo/commit/1f9663cf08ab1cf3b68d95dee4dc99b7c4aac373))
+* **deps:** update dependency com.google.cloud:google-cloud-storage to v1.120.0 ([fcd1c89](https://www.github.com/googleapis/node-test-repo/commit/fcd1c890dc1526f4d62ceedad561f498195c8939))
+
+`
+
+exports['package-json-node-message-with-package-lock'] = `
+updated package.json [ci skip]
+`
+
+exports['package-json-node-with-package-lock'] = `
+{
+  "name": "node-test-repo",
+  "version": "0.123.5",
+  "repository": {
+    "url": "git@github.com:samples/node-test-repo.git"
+  }
+}
+
+`
+
+exports['package-lock-json-node-message'] = `
+updated package-lock.json [ci skip]
+`
+
+exports['PR body-node-no-package-lock'] = `
+:robot: I have created a release \\*beep\\* \\*boop\\* 
+---
+### [0.123.5](https://www.github.com/googleapis/node-test-repo/compare/v0.123.4...v0.123.5) 
+
+
+### Bug Fixes
+
+* **deps:** update dependency com.google.cloud:google-cloud-spanner to v1.50.0 ([1f9663c](https://www.github.com/googleapis/node-test-repo/commit/1f9663cf08ab1cf3b68d95dee4dc99b7c4aac373))
+* **deps:** update dependency com.google.cloud:google-cloud-storage to v1.120.0 ([fcd1c89](https://www.github.com/googleapis/node-test-repo/commit/fcd1c890dc1526f4d62ceedad561f498195c8939))
+---
+
+
+This PR was generated with [Release Please](https://github.com/googleapis/release-please).
+`
+
+exports['labels-node-no-package-lock'] = {
+  'labels': [
+    'autorelease: pending'
+  ]
+}
+
+exports['PR body-node-with-package-lock'] = `
+:robot: I have created a release \\*beep\\* \\*boop\\* 
+---
+### [0.123.5](https://www.github.com/googleapis/node-test-repo/compare/v0.123.4...v0.123.5) 
+
+
+### Bug Fixes
+
+* **deps:** update dependency com.google.cloud:google-cloud-spanner to v1.50.0 ([1f9663c](https://www.github.com/googleapis/node-test-repo/commit/1f9663cf08ab1cf3b68d95dee4dc99b7c4aac373))
+* **deps:** update dependency com.google.cloud:google-cloud-storage to v1.120.0 ([fcd1c89](https://www.github.com/googleapis/node-test-repo/commit/fcd1c890dc1526f4d62ceedad561f498195c8939))
+---
+
+
+This PR was generated with [Release Please](https://github.com/googleapis/release-please).
+`
+
+exports['labels-node-with-package-lock'] = {
+  'labels': [
+    'autorelease: pending'
+  ]
+}

--- a/src/releasers/node.ts
+++ b/src/releasers/node.ts
@@ -93,6 +93,15 @@ export class Node extends ReleasePR {
     );
 
     updates.push(
+      new PackageJson({
+        path: 'package-lock.json',
+        changelogEntry,
+        version: candidate.version,
+        packageName: this.packageName,
+      })
+    );
+
+    updates.push(
       new SamplesPackageJson({
         path: 'samples/package.json',
         changelogEntry,

--- a/test/releasers/fixtures/node/commits.json
+++ b/test/releasers/fixtures/node/commits.json
@@ -1,0 +1,97 @@
+{
+  "repository": {
+    "defaultBranchRef": {
+      "target": {
+        "history": {
+          "edges": [
+            {
+              "node": {
+                "message": "fix(deps): update dependency com.google.cloud:google-cloud-storage to v1.120.0",
+                "oid": "fcd1c890dc1526f4d62ceedad561f498195c8939",
+                "associatedPullRequests": {
+                  "edges": [
+                    {
+                      "node": {
+                        "mergeCommit": {
+                          "oid": "fcd1c890dc1526f4d62ceedad561f498195c8939"
+                        },
+                        "number": 292,
+                        "labels": {
+                          "edges": [
+                            {
+                              "node": {
+                                "name": "cla: yes"
+                              }
+                            }
+                          ]
+                        }
+                      }
+                    }
+                  ]
+                }
+              }
+            },
+            {
+              "node": {
+                "message": "fix(deps): update dependency com.google.cloud:google-cloud-spanner to v1.50.0",
+                "oid": "1f9663cf08ab1cf3b68d95dee4dc99b7c4aac373",
+                "associatedPullRequests": {
+                  "edges": [
+                    {
+                      "node": {
+                        "mergeCommit": {
+                          "oid": "1f9663cf08ab1cf3b68d95dee4dc99b7c4aac373"
+                        },
+                        "number": 301,
+                        "labels": {
+                          "edges": [
+                            {
+                              "node": {
+                                "name": "cla: yes"
+                              }
+                            }
+                          ]
+                        }
+                      }
+                    }
+                  ]
+                }
+              }
+            },
+            {
+              "node": {
+                "message": "chore: update common templates",
+                "oid": "3006009a2b1b2cb4bd5108c0f469c410759f3a6a",
+                "associatedPullRequests": {
+                  "edges": [
+                    {
+                      "node": {
+                        "mergeCommit": {
+                          "oid": "3006009a2b1b2cb4bd5108c0f469c410759f3a6a"
+                        },
+                        "number": 300,
+                        "labels": {
+                          "edges": [
+                            {
+                              "node": {
+                                "name": "cla: yes"
+                              }
+                            }
+                          ]
+                        }
+                      }
+                    }
+                  ]
+                }
+              }
+            }
+          ],
+          "pageInfo": {
+            "endCursor": "fcd1c890dc1526f4d62ceedad561f498195c8939 99",
+            "hasNextPage": false
+          }
+        }
+      }
+    }
+  }
+}

--- a/test/releasers/fixtures/node/package-lock.json
+++ b/test/releasers/fixtures/node/package-lock.json
@@ -1,0 +1,7 @@
+{
+  "name": "node-test-repo",
+  "version": "0.123.4",
+  "lockfileVersion": 1,
+  "requires": true,
+  "dependencies": {}
+}

--- a/test/releasers/fixtures/node/package.json
+++ b/test/releasers/fixtures/node/package.json
@@ -1,0 +1,7 @@
+{
+  "name": "node-test-repo",
+  "version": "0.123.4",
+  "repository": {
+    "url": "git@github.com:samples/node-test-repo.git"
+  }
+}

--- a/test/releasers/node.ts
+++ b/test/releasers/node.ts
@@ -1,0 +1,194 @@
+// Copyright 2020 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import {describe, it} from 'mocha';
+import * as nock from 'nock';
+import {Node} from '../../src/releasers/node';
+import {readFileSync} from 'fs';
+import {resolve} from 'path';
+import * as snapshot from 'snap-shot-it';
+
+const fixturesPath = './test/releasers/fixtures/node';
+
+interface MochaThis {
+  [skip: string]: Function;
+}
+
+function mockRequest(snapName: string) {
+  const packageContent = readFileSync(
+    resolve(fixturesPath, 'package.json'),
+    'utf8'
+  );
+  const graphql = JSON.parse(
+    readFileSync(resolve(fixturesPath, 'commits.json'), 'utf8')
+  );
+
+  const req = nock('https://api.github.com')
+    // check for default branch
+    .get('/repos/googleapis/node-test-repo')
+    // eslint-disable-next-line @typescript-eslint/no-var-requires
+    .reply(200, require('../../../test/fixtures/repo-get-1.json'))
+    .get('/repos/googleapis/node-test-repo/pulls?state=closed&per_page=100')
+    .reply(200, undefined)
+    .get('/repos/googleapis/node-test-repo/contents/package.json')
+    .reply(200, {
+      content: Buffer.from(packageContent, 'utf8').toString('base64'),
+      sha: 'abc123',
+    })
+    // fetch semver tags, this will be used to determine
+    // the delta since the last release.
+    .get('/repos/googleapis/node-test-repo/tags?per_page=100')
+    .reply(200, [
+      {
+        name: 'v0.123.4',
+        commit: {
+          sha: 'da6e52d956c1e35d19e75e0f2fdba439739ba364',
+        },
+      },
+    ])
+    .post('/graphql')
+    .reply(200, {
+      data: graphql,
+    })
+    // getting the latest tag
+    .get('/repos/googleapis/node-test-repo/git/refs?per_page=100')
+    .reply(200, [{ref: 'refs/tags/v0.123.4'}])
+    // creating a new branch
+    .post('/repos/googleapis/node-test-repo/git/refs')
+    .reply(200)
+    // check for CHANGELOG
+    .get(
+      '/repos/googleapis/node-test-repo/contents/CHANGELOG.md?ref=refs%2Fheads%2Frelease-v0.123.5'
+    )
+    .reply(404)
+    .put(
+      '/repos/googleapis/node-test-repo/contents/CHANGELOG.md',
+      (req: {[key: string]: string}) => {
+        snapshot(`CHANGELOG-node-message-${snapName}`, req.message);
+        snapshot(
+          `CHANGELOG-node-${snapName}`,
+          Buffer.from(req.content, 'base64')
+            .toString('utf8')
+            .replace(/\([0-9]{4}-[0-9]{2}-[0-9]{2}\)/g, '')
+        );
+        return true;
+      }
+    )
+    .reply(201)
+    // update package.json
+    .get(
+      '/repos/googleapis/node-test-repo/contents/package.json?ref=refs%2Fheads%2Frelease-v0.123.5'
+    )
+    .reply(200, {
+      content: Buffer.from(packageContent, 'utf8').toString('base64'),
+      sha: 'abc123',
+    })
+    .put(
+      '/repos/googleapis/node-test-repo/contents/package.json',
+      (req: {[key: string]: string}) => {
+        snapshot(`package-json-node-message-${snapName}`, req.message);
+        snapshot(
+          `package-json-node-${snapName}`,
+          Buffer.from(req.content, 'base64').toString('utf8')
+        );
+        return true;
+      }
+    )
+    .reply(200)
+    .get(
+      '/repos/googleapis/node-test-repo/contents/samples/package.json?ref=refs%2Fheads%2Frelease-v0.123.5'
+    )
+    .reply(404)
+    // create release
+    .post(
+      '/repos/googleapis/node-test-repo/pulls',
+      (req: {[key: string]: string}) => {
+        const body = req.body.replace(/\([0-9]{4}-[0-9]{2}-[0-9]{2}\)/g, '');
+        snapshot(`PR body-node-${snapName}`, body);
+        return true;
+      }
+    )
+    .reply(200, {number: 1})
+    .post(
+      '/repos/googleapis/node-test-repo/issues/1/labels',
+      (req: {[key: string]: string}) => {
+        snapshot(`labels-node-${snapName}`, req);
+        return true;
+      }
+    )
+    .reply(200, {})
+    // this step tries to close any existing PRs; just return an empty list.
+    .get('/repos/googleapis/node-test-repo/pulls?state=open&per_page=100')
+    .reply(200, []);
+
+  return req;
+}
+
+describe('Node', () => {
+  describe('run', () => {
+    it('creates a release PR without package-lock.json', async () => {
+      const req = mockRequest('no-package-lock')
+        .get(
+          '/repos/googleapis/node-test-repo/contents/package-lock.json?ref=refs%2Fheads%2Frelease-v0.123.5'
+        )
+        .reply(404);
+
+      const releasePR = new Node({
+        repoUrl: 'googleapis/node-test-repo',
+        releaseType: 'node',
+        // not actually used by this type of repo.
+        packageName: 'node-test-repo',
+        apiUrl: 'https://api.github.com',
+      });
+      await releasePR.run();
+      req.done();
+    });
+    it('creates a release PR with package-lock.json', async () => {
+      const packageLockContent = readFileSync(
+        resolve(fixturesPath, 'package-lock.json'),
+        'utf8'
+      );
+      const req = mockRequest('with-package-lock')
+        .get(
+          '/repos/googleapis/node-test-repo/contents/package-lock.json?ref=refs%2Fheads%2Frelease-v0.123.5'
+        )
+        .reply(200, {
+          content: Buffer.from(packageLockContent, 'utf8').toString('base64'),
+          sha: 'abc123',
+        })
+        .put(
+          '/repos/googleapis/node-test-repo/contents/package-lock.json',
+          (req: {[key: string]: string}) => {
+            snapshot('package-lock-json-node-message', req.message);
+            snapshot(
+              'papckage-lock-json-node-with',
+              Buffer.from(req.content, 'base64').toString('utf8')
+            );
+            return true;
+          }
+        )
+        .reply(201);
+
+      const releasePR = new Node({
+        repoUrl: 'googleapis/node-test-repo',
+        releaseType: 'node',
+        // not actually used by this type of repo.
+        packageName: 'node-test-repo',
+        apiUrl: 'https://api.github.com',
+      });
+      await releasePR.run();
+      req.done();
+    });
+  });
+});


### PR DESCRIPTION
Keep version number in package-lock.json in sync with package.json.

Thank you for opening a Pull Request! Before submitting your PR, there are a few things you can do to make sure it goes smoothly:
- [x] Make sure to open an issue as a [bug/issue](https://github.com/googleapis/release-please/issues/new/choose) before writing your code!  That way we can discuss the change, evaluate designs, and agree on the general idea
- [x] Ensure the tests and linter pass
- [x] Code coverage does not decrease (if any source code was changed)
- [x] Appropriate docs were updated (if necessary)

Fixes #464

I had some time to kill so I thought I would implement this PR despite the issue still being in triage.  I know there is a chance that updating `package-lock.json` isn't the desired behavior, but I did have some time to kill and understand if issue #464 and this PR are declined.