### PR TITLE
refactor(snapshot): do not delay before running snapshot logic

### DIFF
--- a/src/releasers/java-bom.ts
+++ b/src/releasers/java-bom.ts
@@ -46,15 +46,6 @@ const CHANGELOG_SECTIONS = [
 const DEPENDENCY_UPDATE_REGEX = /^deps: update dependency (.*) to (v.*)(\s\(#\d+\))?$/m;
 const DEPENDENCY_PATCH_VERSION_REGEX = /^v\d+\.\d+\.[1-9]\d*(-.*)?/;
 
-async function delay({ms = 3000}) {
-  if (process.env.ENVIRONMENT === 'test') return;
-  new Promise(resolve => {
-    setTimeout(() => {
-      return resolve();
-    }, ms);
-  });
-}
-
 export class JavaBom extends ReleasePR {
   static releaserName = 'java-bom';
   protected async _run() {
@@ -70,15 +61,11 @@ export class JavaBom extends ReleasePR {
     );
     if (this.snapshot) {
       this.labels = ['type: process'];
-      // TODO: this temporarily resolves a race condition between creating a release
-      // and updating tags on the release PR. This should be replaced by a queuing
-      // mechanism to delay/retry this request.
       if (this.snapshot) {
         checkpoint(
           'snapshot: sleeping for 15 seconds...',
           CheckpointType.Success
         );
-        await delay({ms: 15000});
         checkpoint('snapshot: finished sleeping', CheckpointType.Success);
       }
     }

--- a/src/releasers/java-yoshi.ts
+++ b/src/releasers/java-yoshi.ts
@@ -46,15 +46,6 @@ const CHANGELOG_SECTIONS = [
   {type: 'ci', section: 'Continuous Integration', hidden: true},
 ];
 
-async function delay({ms = 3000}) {
-  if (process.env.ENVIRONMENT === 'test') return;
-  new Promise(resolve => {
-    setTimeout(() => {
-      return resolve();
-    }, ms);
-  });
-}
-
 export class JavaYoshi extends ReleasePR {
   static releaserName = 'java-yoshi';
   protected async _run() {
@@ -70,15 +61,11 @@ export class JavaYoshi extends ReleasePR {
     );
     if (this.snapshot) {
       this.labels = ['type: process'];
-      // TODO: this temporarily resolves a race condition between creating a release
-      // and updating tags on the release PR. This should be replaced by a queuing
-      // mechanism to delay/retry this request.
       if (this.snapshot) {
         checkpoint(
           'snapshot: sleeping for 15 seconds...',
           CheckpointType.Success
         );
-        await delay({ms: 15000});
         checkpoint('snapshot: finished sleeping', CheckpointType.Success);
       }
     }


### PR DESCRIPTION
This logic was not working any ways, now that we're configuring a nightly cron, let's move away from it.