### PR TITLE
feat(snapshot): skip snapshot releases for releasers that lack this concept

### DIFF
--- a/src/release-pr.ts
+++ b/src/release-pr.ts
@@ -98,6 +98,13 @@ export class ReleasePR {
   }
 
   async run() {
+    if (this.snapshot && !this.supportsSnapshots()) {
+      checkpoint(
+        'snapshot releases not supported for this releaser',
+        CheckpointType.Failure
+      );
+      return;
+    }
     const pr: GitHubReleasePR | undefined = await this.gh.findMergedReleasePR(
       this.labels
     );
@@ -114,6 +121,10 @@ export class ReleasePR {
 
   protected async _run() {
     throw Error('must be implemented by subclass');
+  }
+
+  protected supportsSnapshots(): boolean {
+    return false;
   }
 
   private async closeStaleReleasePRs(

--- a/src/releasers/java-auth-yoshi.ts
+++ b/src/releasers/java-auth-yoshi.ts
@@ -137,4 +137,8 @@ export class JavaAuthYoshi extends ReleasePR {
       candidate.version
     );
   }
+
+  protected supportsSnapshots(): boolean {
+    return true;
+  }
 }

--- a/src/releasers/java-bom.ts
+++ b/src/releasers/java-bom.ts
@@ -202,6 +202,10 @@ export class JavaBom extends ReleasePR {
     );
   }
 
+  protected supportsSnapshots(): boolean {
+    return true;
+  }
+
   protected defaultInitialVersion(): string {
     return '0.1.0';
   }

--- a/src/releasers/java-yoshi.ts
+++ b/src/releasers/java-yoshi.ts
@@ -250,6 +250,10 @@ export class JavaYoshi extends ReleasePR {
     );
   }
 
+  protected supportsSnapshots(): boolean {
+    return true;
+  }
+
   protected defaultInitialVersion(): string {
     return '0.1.0';
   }

--- a/test/releasers/java-bom.ts
+++ b/test/releasers/java-bom.ts
@@ -317,6 +317,7 @@ describe('JavaBom', () => {
         // not actually used by this type of repo.
         packageName: 'java-cloud-bom',
         apiUrl: 'https://api.github.com',
+        snapshot: true,
       });
       await releasePR.run();
       req.done();

--- a/test/releasers/java-bom.ts
+++ b/test/releasers/java-bom.ts
@@ -317,7 +317,9 @@ describe('JavaBom', () => {
         // not actually used by this type of repo.
         packageName: 'java-cloud-bom',
         apiUrl: 'https://api.github.com',
-        snapshot: true,
+        // we will detect that a snapshot is needed, and still perform a
+        // snapshot release:
+        snapshot: false,
       });
       await releasePR.run();
       req.done();

--- a/test/releasers/java-yoshi.ts
+++ b/test/releasers/java-yoshi.ts
@@ -363,6 +363,7 @@ describe('JavaYoshi', () => {
       // not actually used by this type of repo.
       packageName: 'java-trace',
       apiUrl: 'https://api.github.com',
+      snapshot: true,
     });
     await releasePR.run();
     req.done();

--- a/test/releasers/node.ts
+++ b/test/releasers/node.ts
@@ -190,5 +190,16 @@ describe('Node', () => {
       await releasePR.run();
       req.done();
     });
+    it('does not support snapshot releases', async () => {
+      const releasePR = new Node({
+        repoUrl: 'googleapis/node-test-repo',
+        releaseType: 'node',
+        // not actually used by this type of repo.
+        packageName: 'node-test-repo',
+        apiUrl: 'https://api.github.com',
+        snapshot: true,
+      });
+      await releasePR.run();
+    });
   });
 });


### PR DESCRIPTION
releasers now need to indicate that they support nightly snapshot builds, before they will start running.