### PR TITLE
fix: skip Java releases if snapshot is specified, but does not match repo state

### DIFF
--- a/src/releasers/java-bom.ts
+++ b/src/releasers/java-bom.ts
@@ -65,9 +65,17 @@ export class JavaBom extends ReleasePR {
     const currentVersions = VersionsManifest.parseVersions(
       versionsManifestContent.parsedContent
     );
-    this.snapshot = VersionsManifest.needsSnapshot(
+
+    const snapshotNeeded = VersionsManifest.needsSnapshot(
       versionsManifestContent.parsedContent
     );
+    if (this.snapshot === undefined) {
+      this.snapshot = snapshotNeeded;
+    } else if (this.snapshot !== snapshotNeeded) {
+      checkpoint('release asked for a snapshot, but no snapshot is needed', CheckpointType.Failure);
+      return;
+    }
+
     if (this.snapshot) {
       this.labels = ['type: process'];
       // TODO: this temporarily resolves a race condition between creating a release

--- a/src/releasers/java-bom.ts
+++ b/src/releasers/java-bom.ts
@@ -72,7 +72,10 @@ export class JavaBom extends ReleasePR {
     if (this.snapshot === undefined) {
       this.snapshot = snapshotNeeded;
     } else if (this.snapshot !== snapshotNeeded) {
-      checkpoint('release asked for a snapshot, but no snapshot is needed', CheckpointType.Failure);
+      checkpoint(
+        'release asked for a snapshot, but no snapshot is needed',
+        CheckpointType.Failure
+      );
       return;
     }
 

--- a/src/releasers/java-yoshi.ts
+++ b/src/releasers/java-yoshi.ts
@@ -65,9 +65,17 @@ export class JavaYoshi extends ReleasePR {
     const currentVersions = VersionsManifest.parseVersions(
       versionsManifestContent.parsedContent
     );
-    this.snapshot = VersionsManifest.needsSnapshot(
+
+    const snapshotNeeded = VersionsManifest.needsSnapshot(
       versionsManifestContent.parsedContent
     );
+    if (this.snapshot === undefined) {
+      this.snapshot = snapshotNeeded;
+    } else if (this.snapshot !== snapshotNeeded) {
+      checkpoint('release asked for a snapshot, but no snapshot is needed', CheckpointType.Failure);
+      return;
+    }
+
     if (this.snapshot) {
       this.labels = ['type: process'];
       // TODO: this temporarily resolves a race condition between creating a release

--- a/src/releasers/java-yoshi.ts
+++ b/src/releasers/java-yoshi.ts
@@ -72,7 +72,10 @@ export class JavaYoshi extends ReleasePR {
     if (this.snapshot === undefined) {
       this.snapshot = snapshotNeeded;
     } else if (this.snapshot !== snapshotNeeded) {
-      checkpoint('release asked for a snapshot, but no snapshot is needed', CheckpointType.Failure);
+      checkpoint(
+        'release asked for a snapshot, but no snapshot is needed',
+        CheckpointType.Failure
+      );
       return;
     }
 

--- a/test/releasers/java-bom.ts
+++ b/test/releasers/java-bom.ts
@@ -322,6 +322,54 @@ describe('JavaBom', () => {
       await releasePR.run();
       req.done();
     });
+    it('ignores a snapshot release if no snapshot needed', async () => {
+      const versionsContent = readFileSync(
+        resolve(fixturesPath, 'versions.txt'),
+        'utf8'
+      );
+      const req = nock('https://api.github.com')
+        .get('/repos/googleapis/java-cloud-bom/pulls?state=closed&per_page=100')
+        .reply(200, undefined)
+        .get('/repos/googleapis/java-cloud-bom/contents/versions.txt')
+        .reply(200, {
+          content: Buffer.from(versionsContent, 'utf8').toString('base64'),
+          sha: 'abc123',
+        });
+      const releasePR = new JavaBom({
+        repoUrl: 'googleapis/java-cloud-bom',
+        releaseType: 'java-bom',
+        // not actually used by this type of repo.
+        packageName: 'java-cloud-bom',
+        apiUrl: 'https://api.github.com',
+        snapshot: true,
+      });
+      await releasePR.run();
+      req.done();
+    });
+    it('ignores an explicit release if no snapshot needed', async () => {
+      const versionsContent = readFileSync(
+        resolve(fixturesPath, 'released-versions.txt'),
+        'utf8'
+      );
+      const req = nock('https://api.github.com')
+        .get('/repos/googleapis/java-cloud-bom/pulls?state=closed&per_page=100')
+        .reply(200, undefined)
+        .get('/repos/googleapis/java-cloud-bom/contents/versions.txt')
+        .reply(200, {
+          content: Buffer.from(versionsContent, 'utf8').toString('base64'),
+          sha: 'abc123',
+        });
+      const releasePR = new JavaBom({
+        repoUrl: 'googleapis/java-cloud-bom',
+        releaseType: 'java-bom',
+        // not actually used by this type of repo.
+        packageName: 'java-cloud-bom',
+        apiUrl: 'https://api.github.com',
+        snapshot: false,
+      });
+      await releasePR.run();
+      req.done();
+    });
     it('merges conventional commit messages', async () => {
       const versionsContent = readFileSync(
         resolve(fixturesPath, 'versions.txt'),

--- a/test/releasers/java-bom.ts
+++ b/test/releasers/java-bom.ts
@@ -317,9 +317,7 @@ describe('JavaBom', () => {
         // not actually used by this type of repo.
         packageName: 'java-cloud-bom',
         apiUrl: 'https://api.github.com',
-        // we will detect that a snapshot is needed, and still perform a
-        // snapshot release:
-        snapshot: false,
+        snapshot: true,
       });
       await releasePR.run();
       req.done();

--- a/test/releasers/java-yoshi.ts
+++ b/test/releasers/java-yoshi.ts
@@ -368,4 +368,52 @@ describe('JavaYoshi', () => {
     await releasePR.run();
     req.done();
   });
+  it('ignores a snapshot release if no snapshot needed', async () => {
+    const versionsContent = readFileSync(
+      resolve(fixturesPath, 'versions.txt'),
+      'utf8'
+    );
+    const req = nock('https://api.github.com')
+      .get('/repos/googleapis/java-trace/pulls?state=closed&per_page=100')
+      .reply(200, undefined)
+      .get('/repos/googleapis/java-trace/contents/versions.txt')
+      .reply(200, {
+        content: Buffer.from(versionsContent, 'utf8').toString('base64'),
+        sha: 'abc123',
+      });
+    const releasePR = new JavaYoshi({
+      repoUrl: 'googleapis/java-trace',
+      releaseType: 'java-yoshi',
+      // not actually used by this type of repo.
+      packageName: 'java-trace',
+      apiUrl: 'https://api.github.com',
+      snapshot: true,
+    });
+    await releasePR.run();
+    req.done();
+  });
+  it('ignores an explicit release if a snapshot needed', async () => {
+    const versionsContent = readFileSync(
+      resolve(fixturesPath, 'released-versions.txt'),
+      'utf8'
+    );
+    const req = nock('https://api.github.com')
+      .get('/repos/googleapis/java-trace/pulls?state=closed&per_page=100')
+      .reply(200, undefined)
+      .get('/repos/googleapis/java-trace/contents/versions.txt')
+      .reply(200, {
+        content: Buffer.from(versionsContent, 'utf8').toString('base64'),
+        sha: 'abc123',
+      });
+    const releasePR = new JavaYoshi({
+      repoUrl: 'googleapis/java-trace',
+      releaseType: 'java-yoshi',
+      // not actually used by this type of repo.
+      packageName: 'java-trace',
+      apiUrl: 'https://api.github.com',
+      snapshot: false,
+    });
+    await releasePR.run();
+    req.done();
+  });
 });


### PR DESCRIPTION
`snapshot` is a `boolean?` on release-pr. This changes the behavior such that if you specify `snapshot`, we will now ensure that only that type of release is created.

If you don't provide `snapshot` (i.e. it is undefined), then we will detect whatever state the repo is in and propose the correct release accordingly.