### PR TITLE
fix: exception was thrown when 0 commits found

### DIFF
--- a/src/releasers/java-auth-yoshi.ts
+++ b/src/releasers/java-auth-yoshi.ts
@@ -41,6 +41,15 @@ export class JavaAuthYoshi extends ReleasePR {
           },
         ]
       : await this.commits(latestTag ? latestTag.sha : undefined, 100, true);
+    if (commits.length === 0) {
+      checkpoint(
+        `no commits found since ${
+          latestTag ? latestTag.sha : 'beginning of time'
+        }`,
+        CheckpointType.Failure
+      );
+      return;
+    }
     let prSHA = commits[0].sha;
 
     const cc = new ConventionalCommits({

--- a/src/releasers/java-bom.ts
+++ b/src/releasers/java-bom.ts
@@ -88,6 +88,15 @@ export class JavaBom extends ReleasePR {
       this.snapshot ? 1 : 100,
       true
     );
+    if (commits.length === 0) {
+      checkpoint(
+        `no commits found since ${
+          latestTag ? latestTag.sha : 'beginning of time'
+        }`,
+        CheckpointType.Failure
+      );
+      return;
+    }
     const prSHA = commits[0].sha;
     const cc = new ConventionalCommits({
       commits,

--- a/src/releasers/java-yoshi.ts
+++ b/src/releasers/java-yoshi.ts
@@ -91,6 +91,15 @@ export class JavaYoshi extends ReleasePR {
           },
         ]
       : await this.commits(latestTag ? latestTag.sha : undefined, 100, true);
+    if (commits.length === 0) {
+      checkpoint(
+        `no commits found since ${
+          latestTag ? latestTag.sha : 'beginning of time'
+        }`,
+        CheckpointType.Failure
+      );
+      return;
+    }
     let prSHA = commits[0].sha;
     // Snapshots populate a fake "fix:"" commit, so that they will always
     // result in a patch update. We still need to know the HEAD sba, so that


### PR DESCRIPTION
Noticed this in logs when we were testing the new nightly cron.