### PR TITLE
fix: missing authorization header for repos.get()

### DIFF
--- a/src/github.ts
+++ b/src/github.ts
@@ -732,6 +732,9 @@ export class GitHub {
     const {data} = await this.octokit.repos.get({
       repo,
       owner,
+      headers: {
+        Authorization: `${this.proxyKey ? '' : 'token '}${this.token}`,
+      },
     });
     this.defaultBranch = data.default_branch;
     return this.defaultBranch;


### PR DESCRIPTION
Octokit seems to expect headers (including authorization) to be passed along with the repo and owner params. The issue is described in #474.

Thank you for opening a Pull Request! Before submitting your PR, there are a few things you can do to make sure it goes smoothly:
- [X] Make sure to open an issue as a [bug/issue](https://github.com/googleapis/release-please/issues/new/choose) before writing your code!  That way we can discuss the change, evaluate designs, and agree on the general idea
- [X] Ensure the tests and linter pass
- [X] Code coverage does not decrease (if any source code was changed)
- [X] Appropriate docs were updated (if necessary)

Fixes #474 🦕
