### PR TITLE
fix(node): reorder files added, so that skip logic works

### DIFF
--- a/__snapshots__/node.js
+++ b/__snapshots__/node.js
@@ -27,7 +27,7 @@ exports['CHANGELOG-node-no-package-lock'] = `
 `
 
 exports['package-json-node-message-no-package-lock'] = `
-updated package.json [ci skip]
+updated package.json
 `
 
 exports['package-json-node-no-package-lock'] = `
@@ -59,7 +59,7 @@ exports['CHANGELOG-node-with-package-lock'] = `
 `
 
 exports['package-json-node-message-with-package-lock'] = `
-updated package.json [ci skip]
+updated package.json
 `
 
 exports['package-json-node-with-package-lock'] = `

--- a/src/releasers/node.ts
+++ b/src/releasers/node.ts
@@ -74,6 +74,24 @@ export class Node extends ReleasePR {
     if (pkg.name) this.packageName = pkg.name;
 
     updates.push(
+      new PackageJson({
+        path: 'package-lock.json',
+        changelogEntry,
+        version: candidate.version,
+        packageName: this.packageName,
+      })
+    );
+
+    updates.push(
+      new SamplesPackageJson({
+        path: 'samples/package.json',
+        changelogEntry,
+        version: candidate.version,
+        packageName: this.packageName,
+      })
+    );
+
+    updates.push(
       new Changelog({
         path: 'CHANGELOG.md',
         changelogEntry,
@@ -89,24 +107,6 @@ export class Node extends ReleasePR {
         version: candidate.version,
         packageName: this.packageName,
         contents,
-      })
-    );
-
-    updates.push(
-      new PackageJson({
-        path: 'package-lock.json',
-        changelogEntry,
-        version: candidate.version,
-        packageName: this.packageName,
-      })
-    );
-
-    updates.push(
-      new SamplesPackageJson({
-        path: 'samples/package.json',
-        changelogEntry,
-        version: candidate.version,
-        packageName: this.packageName,
       })
     );
 


### PR DESCRIPTION
By moving files that are required updates to the end of the update loop, like `package.json`, we guarantee that at least one commit will be added that forces CI/CD.