### PR TITLE
fix: use conventional commits for our own commits

### DIFF
--- a/__snapshots__/java-yoshi.js
+++ b/__snapshots__/java-yoshi.js
@@ -964,21 +964,21 @@ public final class GoogleUtils {
 `
 
 exports['CHANGELOG-message'] = `
-created CHANGELOG.md [ci skip]
+chore: created CHANGELOG.md [ci skip]
 `
 
 exports['README-message'] = `
-updated README.md [ci skip]
+chore: updated README.md [ci skip]
 `
 
 exports['GoogleUtils-message'] = `
-updated google-api-client/src/main/java/com/google/api/client/googleapis/GoogleUtils.java [ci skip]
+chore: updated google-api-client/src/main/java/com/google/api/client/googleapis/GoogleUtils.java [ci skip]
 `
 
 exports['versions-message'] = `
-updated versions.txt [ci skip]
+chore: updated versions.txt [ci skip]
 `
 
 exports['pom-message'] = `
-updated pom.xml
+chore: updated pom.xml
 `

--- a/__snapshots__/node.js
+++ b/__snapshots__/node.js
@@ -10,7 +10,7 @@ exports['papckage-lock-json-node-with'] = `
 `
 
 exports['CHANGELOG-node-message-no-package-lock'] = `
-created CHANGELOG.md [ci skip]
+chore: created CHANGELOG.md [ci skip]
 `
 
 exports['CHANGELOG-node-no-package-lock'] = `
@@ -27,7 +27,7 @@ exports['CHANGELOG-node-no-package-lock'] = `
 `
 
 exports['package-json-node-message-no-package-lock'] = `
-updated package.json
+chore: updated package.json
 `
 
 exports['package-json-node-no-package-lock'] = `
@@ -42,7 +42,7 @@ exports['package-json-node-no-package-lock'] = `
 `
 
 exports['CHANGELOG-node-message-with-package-lock'] = `
-created CHANGELOG.md [ci skip]
+chore: created CHANGELOG.md [ci skip]
 `
 
 exports['CHANGELOG-node-with-package-lock'] = `
@@ -59,7 +59,7 @@ exports['CHANGELOG-node-with-package-lock'] = `
 `
 
 exports['package-json-node-message-with-package-lock'] = `
-updated package.json
+chore: updated package.json
 `
 
 exports['package-json-node-with-package-lock'] = `
@@ -74,7 +74,7 @@ exports['package-json-node-with-package-lock'] = `
 `
 
 exports['package-lock-json-node-message'] = `
-updated package-lock.json [ci skip]
+chore: updated package-lock.json [ci skip]
 `
 
 exports['PR body-node-no-package-lock'] = `

--- a/__snapshots__/simple.js
+++ b/__snapshots__/simple.js
@@ -30,9 +30,9 @@ exports['labels-simple'] = {
 }
 
 exports['CHANGELOG-simple-message'] = `
-created CHANGELOG.md [ci skip]
+chore: created CHANGELOG.md [ci skip]
 `
 
 exports['version-txt-simple-message'] = `
-updated version.txt
+chore: updated version.txt
 `

--- a/src/github.ts
+++ b/src/github.ts
@@ -807,7 +807,8 @@ export class GitHub {
             repo: this.repo,
             path: update.path,
             message:
-              `updated ${update.path}` + (update.skipCi ? ' [ci skip]' : ''),
+              `chore: updated ${update.path}` +
+              (update.skipCi ? ' [ci skip]' : ''),
             content: Buffer.from(updatedContent, 'utf8').toString('base64'),
             sha: content.data.sha,
             branch,
@@ -823,7 +824,8 @@ export class GitHub {
             repo: this.repo,
             path: update.path,
             message:
-              `created ${update.path}` + (update.skipCi ? ' [ci skip]' : ''),
+              `chore: created ${update.path}` +
+              (update.skipCi ? ' [ci skip]' : ''),
             content: Buffer.from(updatedContent, 'utf8').toString('base64'),
             branch,
           }


### PR DESCRIPTION
@ghermeto pointed out we weren't using conventional commit messages for our own commit messages.

Let's do so. After talking to Guilherme, we've opted for `chore:`.