### PR TITLE
feat: add support for monorepos/releasing from alternate folders

### DIFF
--- a/README.md
+++ b/README.md
@@ -148,10 +148,12 @@ release-please release-pr --package-name=@google-cloud/firestore" \
 
 | option            | description                                             |
 |-------------------|---------------------------------------------------------|
-| `--package-name`  | is the name of the package to publish to publish to  an upstream registry such as npm. |
+| `--package-name`  | is the name of the package to publish to publish to an upstream registry such as npm. |
 | `--repo-url`      | is the URL of the repository on GitHub.                 |
 | `--token`         | a token with write access to `--repo-url`.              |
 | `--default-branch`| branch to open pull release PR against (detected by default). |
+| `--path`          | create a release from a path other than the repository's root |
+| `--monorepo-tags` | add prefix to tags and branches, allowing multiple libraries to be released from the same repository. |
 
 ### Creating a release on GitHub
 
@@ -165,6 +167,7 @@ release-please github-release --repo-url=googleapis/nodejs-firestore \
 | `--package-name`  | is the name of the package to publish to publish to  an upstream registry such as npm. |
 | `--repo-url`      | is the URL of the repository on GitHub.                 |
 | `--token`         | a token with write access to `--repo-url`.              |
+| `--path`          | create a release from a path other than the repository's root |
 
 ### Running as a GitHub App
 

--- a/__snapshots__/node.js
+++ b/__snapshots__/node.js
@@ -9,38 +9,6 @@ exports['papckage-lock-json-node-with'] = `
 
 `
 
-exports['CHANGELOG-node-message-no-package-lock'] = `
-chore: created CHANGELOG.md [ci skip]
-`
-
-exports['CHANGELOG-node-no-package-lock'] = `
-# Changelog
-
-### [0.123.5](https://www.github.com/googleapis/node-test-repo/compare/v0.123.4...v0.123.5) 
-
-
-### Bug Fixes
-
-* **deps:** update dependency com.google.cloud:google-cloud-spanner to v1.50.0 ([1f9663c](https://www.github.com/googleapis/node-test-repo/commit/1f9663cf08ab1cf3b68d95dee4dc99b7c4aac373))
-* **deps:** update dependency com.google.cloud:google-cloud-storage to v1.120.0 ([fcd1c89](https://www.github.com/googleapis/node-test-repo/commit/fcd1c890dc1526f4d62ceedad561f498195c8939))
-
-`
-
-exports['package-json-node-message-no-package-lock'] = `
-chore: updated package.json
-`
-
-exports['package-json-node-no-package-lock'] = `
-{
-  "name": "node-test-repo",
-  "version": "0.123.5",
-  "repository": {
-    "url": "git@github.com:samples/node-test-repo.git"
-  }
-}
-
-`
-
 exports['CHANGELOG-node-message-with-package-lock'] = `
 chore: created CHANGELOG.md [ci skip]
 `
@@ -77,28 +45,6 @@ exports['package-lock-json-node-message'] = `
 chore: updated package-lock.json [ci skip]
 `
 
-exports['PR body-node-no-package-lock'] = `
-:robot: I have created a release \\*beep\\* \\*boop\\* 
----
-### [0.123.5](https://www.github.com/googleapis/node-test-repo/compare/v0.123.4...v0.123.5) 
-
-
-### Bug Fixes
-
-* **deps:** update dependency com.google.cloud:google-cloud-spanner to v1.50.0 ([1f9663c](https://www.github.com/googleapis/node-test-repo/commit/1f9663cf08ab1cf3b68d95dee4dc99b7c4aac373))
-* **deps:** update dependency com.google.cloud:google-cloud-storage to v1.120.0 ([fcd1c89](https://www.github.com/googleapis/node-test-repo/commit/fcd1c890dc1526f4d62ceedad561f498195c8939))
----
-
-
-This PR was generated with [Release Please](https://github.com/googleapis/release-please).
-`
-
-exports['labels-node-no-package-lock'] = {
-  'labels': [
-    'autorelease: pending'
-  ]
-}
-
 exports['PR body-node-with-package-lock'] = `
 :robot: I have created a release \\*beep\\* \\*boop\\* 
 ---
@@ -116,6 +62,114 @@ This PR was generated with [Release Please](https://github.com/googleapis/releas
 `
 
 exports['labels-node-with-package-lock'] = {
+  'labels': [
+    'autorelease: pending'
+  ]
+}
+
+exports['CHANGELOG-node-message-'] = `
+chore: created CHANGELOG.md [ci skip]
+`
+
+exports['CHANGELOG-node-'] = `
+# Changelog
+
+### [0.123.5](https://www.github.com/googleapis/node-test-repo/compare/v0.123.4...v0.123.5) 
+
+
+### Bug Fixes
+
+* **deps:** update dependency com.google.cloud:google-cloud-spanner to v1.50.0 ([1f9663c](https://www.github.com/googleapis/node-test-repo/commit/1f9663cf08ab1cf3b68d95dee4dc99b7c4aac373))
+* **deps:** update dependency com.google.cloud:google-cloud-storage to v1.120.0 ([fcd1c89](https://www.github.com/googleapis/node-test-repo/commit/fcd1c890dc1526f4d62ceedad561f498195c8939))
+
+`
+
+exports['package-json-node-message-'] = `
+chore: updated package.json
+`
+
+exports['package-json-node-'] = `
+{
+  "name": "node-test-repo",
+  "version": "0.123.5",
+  "repository": {
+    "url": "git@github.com:samples/node-test-repo.git"
+  }
+}
+
+`
+
+exports['PR body-node-'] = `
+:robot: I have created a release \\*beep\\* \\*boop\\* 
+---
+### [0.123.5](https://www.github.com/googleapis/node-test-repo/compare/v0.123.4...v0.123.5) 
+
+
+### Bug Fixes
+
+* **deps:** update dependency com.google.cloud:google-cloud-spanner to v1.50.0 ([1f9663c](https://www.github.com/googleapis/node-test-repo/commit/1f9663cf08ab1cf3b68d95dee4dc99b7c4aac373))
+* **deps:** update dependency com.google.cloud:google-cloud-storage to v1.120.0 ([fcd1c89](https://www.github.com/googleapis/node-test-repo/commit/fcd1c890dc1526f4d62ceedad561f498195c8939))
+---
+
+
+This PR was generated with [Release Please](https://github.com/googleapis/release-please).
+`
+
+exports['labels-node-'] = {
+  'labels': [
+    'autorelease: pending'
+  ]
+}
+
+exports['CHANGELOG-node-message-with-path'] = `
+chore: created packages/foo/CHANGELOG.md [ci skip]
+`
+
+exports['CHANGELOG-node-with-path'] = `
+# Changelog
+
+### [0.123.5](https://www.github.com/googleapis/node-test-repo/compare/v0.123.4...v0.123.5) 
+
+
+### Bug Fixes
+
+* **deps:** update dependency com.google.cloud:google-cloud-spanner to v1.50.0 ([1f9663c](https://www.github.com/googleapis/node-test-repo/commit/1f9663cf08ab1cf3b68d95dee4dc99b7c4aac373))
+* **deps:** update dependency com.google.cloud:google-cloud-storage to v1.120.0 ([fcd1c89](https://www.github.com/googleapis/node-test-repo/commit/fcd1c890dc1526f4d62ceedad561f498195c8939))
+
+`
+
+exports['package-json-node-message-with-path'] = `
+chore: updated packages/foo/package.json
+`
+
+exports['package-json-node-with-path'] = `
+{
+  "name": "node-test-repo",
+  "version": "0.123.5",
+  "repository": {
+    "url": "git@github.com:samples/node-test-repo.git"
+  }
+}
+
+`
+
+exports['PR body-node-with-path'] = `
+:robot: I have created a release \\*beep\\* \\*boop\\* 
+---
+### [0.123.5](https://www.github.com/googleapis/node-test-repo/compare/v0.123.4...v0.123.5) 
+
+
+### Bug Fixes
+
+* **deps:** update dependency com.google.cloud:google-cloud-spanner to v1.50.0 ([1f9663c](https://www.github.com/googleapis/node-test-repo/commit/1f9663cf08ab1cf3b68d95dee4dc99b7c4aac373))
+* **deps:** update dependency com.google.cloud:google-cloud-storage to v1.120.0 ([fcd1c89](https://www.github.com/googleapis/node-test-repo/commit/fcd1c890dc1526f4d62ceedad561f498195c8939))
+---
+
+
+This PR was generated with [Release Please](https://github.com/googleapis/release-please).
+`
+
+exports['labels-node-with-path'] = {
   'labels': [
     'autorelease: pending'
   ]

--- a/src/bin/release-please.ts
+++ b/src/bin/release-please.ts
@@ -72,6 +72,15 @@ const argv = yargs
         .option('default-branch', {
           describe: 'default branch to open release PR against',
           type: 'string',
+        })
+        .option('path', {
+          describe: 'release from path other than root directory',
+          type: 'string',
+        })
+        .option('monorepo-tags', {
+          describe: 'include library name in tags and release branches',
+          type: 'boolean',
+          default: false,
         });
     },
     (argv: ReleasePROptions) => {
@@ -99,6 +108,10 @@ const argv = yargs
           describe: 'what type of repo is a release being created for?',
           choices: getReleaserNames(),
           default: 'node',
+        })
+        .option('path', {
+          describe: 'release from path other than root directory',
+          type: 'string',
         });
     },
     (argv: GitHubReleaseOptions) => {

--- a/src/release-pr.ts
+++ b/src/release-pr.ts
@@ -23,7 +23,6 @@ type PullsListResponseItem = PromiseValue<
   ReturnType<InstanceType<typeof Octokit>['pulls']['get']>
 >['data'];
 
-import {join} from 'path';
 import * as semver from 'semver';
 
 import {checkpoint, CheckpointType} from './util/checkpoint';
@@ -294,7 +293,9 @@ export class ReleasePR {
     if (this.path === undefined) {
       return file;
     } else {
-      return join(this.path, `./${file}`);
+      const path = this.path.replace(/[/\\]$/, '');
+      file = file.replace(/^[/\\]/, '');
+      return `${path}/${file}`;
     }
   }
 }

--- a/src/releasers/java-auth-yoshi.ts
+++ b/src/releasers/java-auth-yoshi.ts
@@ -40,7 +40,10 @@ export class JavaAuthYoshi extends ReleasePR {
             files: [],
           },
         ]
-      : await this.commits(latestTag ? latestTag.sha : undefined, 100, true);
+      : await this.commits({
+          sha: latestTag ? latestTag.sha : undefined,
+          labels: true,
+        });
     if (commits.length === 0) {
       checkpoint(
         `no commits found since ${
@@ -139,12 +142,13 @@ export class JavaAuthYoshi extends ReleasePR {
       );
     });
 
-    await this.openPR(
-      prSHA!,
-      `${changelogEntry}\n---\n`,
+    await this.openPR({
+      sha: prSHA!,
+      changelogEntry: `${changelogEntry}\n---\n`,
       updates,
-      candidate.version
-    );
+      version: candidate.version,
+      includePackageName: this.monorepoTags,
+    });
   }
 
   protected supportsSnapshots(): boolean {

--- a/src/releasers/java-bom.ts
+++ b/src/releasers/java-bom.ts
@@ -83,11 +83,11 @@ export class JavaBom extends ReleasePR {
 
     const latestTag: GitHubTag | undefined = await this.gh.latestTag();
 
-    const commits = await this.commits(
-      latestTag ? latestTag.sha : undefined,
-      this.snapshot ? 1 : 100,
-      true
-    );
+    const commits = await this.commits({
+      sha: latestTag ? latestTag.sha : undefined,
+      perPage: this.snapshot ? 1 : 100,
+      labels: true,
+    });
     if (commits.length === 0) {
       checkpoint(
         `no commits found since ${
@@ -201,12 +201,13 @@ export class JavaBom extends ReleasePR {
     console.info(
       `attempting to open PR latestTagSha = ${latestTag!.sha} prSha = ${prSHA}`
     );
-    await this.openPR(
-      prSHA!,
-      `${changelogEntry}\n---\n`,
+    await this.openPR({
+      sha: prSHA!,
+      changelogEntry: `${changelogEntry}\n---\n`,
       updates,
-      candidate.version
-    );
+      version: candidate.version,
+      includePackageName: this.monorepoTags,
+    });
   }
 
   protected supportsSnapshots(): boolean {

--- a/src/releasers/java-yoshi.ts
+++ b/src/releasers/java-yoshi.ts
@@ -90,7 +90,10 @@ export class JavaYoshi extends ReleasePR {
             files: [],
           },
         ]
-      : await this.commits(latestTag ? latestTag.sha : undefined, 100, true);
+      : await this.commits({
+          sha: latestTag ? latestTag.sha : undefined,
+          labels: true,
+        });
     if (commits.length === 0) {
       checkpoint(
         `no commits found since ${
@@ -106,7 +109,11 @@ export class JavaYoshi extends ReleasePR {
     // we can use this as a starting point for the snapshot PR:
     if (this.snapshot) {
       const latestCommit = (
-        await this.commits(latestTag ? latestTag.sha : undefined, 1, true)
+        await this.commits({
+          sha: latestTag ? latestTag.sha : undefined,
+          perPage: 1,
+          labels: true,
+        })
       )[0];
       prSHA = latestCommit.sha;
     }
@@ -249,12 +256,13 @@ export class JavaYoshi extends ReleasePR {
         latestTag ? latestTag.sha : 'none'
       } prSha = ${prSHA}`
     );
-    await this.openPR(
-      prSHA!,
-      `${changelogEntry}\n---\n`,
+    await this.openPR({
+      sha: prSHA!,
+      changelogEntry: `${changelogEntry}\n---\n`,
       updates,
-      candidate.version
-    );
+      version: candidate.version,
+      includePackageName: this.monorepoTags,
+    });
   }
 
   protected supportsSnapshots(): boolean {

--- a/src/releasers/php-yoshi.ts
+++ b/src/releasers/php-yoshi.ts
@@ -53,9 +53,9 @@ export class PHPYoshi extends ReleasePR {
   static releaserName = 'php-yoshi';
   protected async _run() {
     const latestTag: GitHubTag | undefined = await this.gh.latestTag();
-    const commits: Commit[] = await this.commits(
-      latestTag ? latestTag.sha : undefined
-    );
+    const commits: Commit[] = await this.commits({
+      sha: latestTag ? latestTag.sha : undefined,
+    });
 
     // we create an instance of conventional CHANGELOG for bumping the
     // top-level tag version we maintain on the mono-repo itself.
@@ -125,12 +125,13 @@ export class PHPYoshi extends ReleasePR {
       );
     });
 
-    await this.openPR(
-      commits[0].sha!,
+    await this.openPR({
+      sha: commits[0].sha!,
       changelogEntry,
       updates,
-      candidate.version
-    );
+      version: candidate.version,
+      includePackageName: this.monorepoTags,
+    });
   }
 
   private async releaseAllPHPLibraries(

--- a/src/releasers/ruby-yoshi.ts
+++ b/src/releasers/ruby-yoshi.ts
@@ -48,12 +48,10 @@ export class RubyYoshi extends ReleasePR {
           `${this.packageName}/v${this.lastPackageVersion}`
         )
       : undefined;
-    const commits: Commit[] = await this.commits(
-      lastReleaseSha,
-      100,
-      false,
-      this.packageName
-    );
+    const commits: Commit[] = await this.commits({
+      sha: lastReleaseSha,
+      path: this.packageName,
+    });
     if (commits.length === 0) {
       checkpoint(
         `no commits found since ${lastReleaseSha}`,
@@ -128,16 +126,16 @@ export class RubyYoshi extends ReleasePR {
         })
       );
 
-      await this.openPR(
-        commits[0].sha!,
-        `${changelogEntry}\n---\n${this.summarizeCommits(
+      await this.openPR({
+        sha: commits[0].sha!,
+        changelogEntry: `${changelogEntry}\n---\n${this.summarizeCommits(
           lastReleaseSha,
           commits
         )}\n`,
         updates,
-        candidate.version,
-        true
-      );
+        version: candidate.version,
+        includePackageName: true,
+      });
     }
   }
   // create a summary of the commits landed since the last release,

--- a/src/releasers/ruby.ts
+++ b/src/releasers/ruby.ts
@@ -40,10 +40,13 @@ export class Ruby extends ReleasePR {
     this.versionFile = options.versionFile;
   }
   protected async _run() {
-    const latestTag: GitHubTag | undefined = await this.gh.latestTag();
-    const commits: Commit[] = await this.commits(
-      latestTag ? latestTag.sha : undefined
+    const latestTag: GitHubTag | undefined = await this.gh.latestTag(
+      this.monorepoTags ? `${this.packageName}-` : undefined
     );
+    const commits: Commit[] = await this.commits({
+      sha: latestTag ? latestTag.sha : undefined,
+      path: this.path,
+    });
 
     const cc = new ConventionalCommits({
       commits: postProcessCommits(commits),
@@ -78,7 +81,7 @@ export class Ruby extends ReleasePR {
 
     updates.push(
       new Changelog({
-        path: 'CHANGELOG.md',
+        path: this.addPath('CHANGELOG.md'),
         changelogEntry,
         version: candidate.version,
         packageName: this.packageName,
@@ -87,19 +90,20 @@ export class Ruby extends ReleasePR {
 
     updates.push(
       new VersionRB({
-        path: this.versionFile,
+        path: this.addPath(this.versionFile),
         changelogEntry,
         version: candidate.version,
         packageName: this.packageName,
       })
     );
 
-    await this.openPR(
-      commits[0].sha!,
-      `${changelogEntry}\n---\n`,
+    await this.openPR({
+      sha: commits[0].sha!,
+      changelogEntry: `${changelogEntry}\n---\n`,
       updates,
-      candidate.version
-    );
+      version: candidate.version,
+      includePackageName: this.monorepoTags,
+    });
   }
 }
 

--- a/src/releasers/simple.ts
+++ b/src/releasers/simple.ts
@@ -28,10 +28,13 @@ import {VersionTxt} from '../updaters/version-txt';
 export class Simple extends ReleasePR {
   static releaserName = 'simple';
   protected async _run() {
-    const latestTag: GitHubTag | undefined = await this.gh.latestTag();
-    const commits: Commit[] = await this.commits(
-      latestTag ? latestTag.sha : undefined
+    const latestTag: GitHubTag | undefined = await this.gh.latestTag(
+      this.monorepoTags ? `${this.packageName}-` : undefined
     );
+    const commits: Commit[] = await this.commits({
+      sha: latestTag ? latestTag.sha : undefined,
+      path: this.path,
+    });
 
     const cc = new ConventionalCommits({
       commits,
@@ -88,11 +91,12 @@ export class Simple extends ReleasePR {
       })
     );
 
-    await this.openPR(
-      commits[0].sha!,
-      `${changelogEntry}\n---\n`,
+    await this.openPR({
+      sha: commits[0].sha!,
+      changelogEntry: `${changelogEntry}\n---\n`,
       updates,
-      candidate.version
-    );
+      version: candidate.version,
+      includePackageName: this.monorepoTags,
+    });
   }
 }


### PR DESCRIPTION
This PR adds support for releasing libraries from a folder other than a repository's root:

You can now set the option `--path` which represents the path that package lives in, e.g., `--path packages/gcf-utils`.

You can also set the flag `--monorepo-tags`, which will prepend the library name to release branches and tags  (this allows you to release multiple libraries from one repository (see: https://github.com/bcoe/test-release-please/pull/43).