### PR TITLE
feat(go): add support for releasing yoshi gapic go libraries

### DIFF
--- a/__snapshots__/yoshi-go.js
+++ b/__snapshots__/yoshi-go.js
@@ -1,0 +1,29 @@
+exports['CHANGELOG-go-yoshi-message'] = `
+chore: created CHANGELOG.md
+`
+
+exports['CHANGELOG-go-yoshi'] = `
+# Changelog
+
+## [0.124.0](https://www.github.com/googleapis/yoshi-go-test-repo/compare/v0.123.4...v0.124.0) 
+
+
+### Bug Fixes
+
+* **automl:** update dependency com.google.cloud:google-cloud-storage to v1.120.0 ([fcd1c89](https://www.github.com/googleapis/yoshi-go-test-repo/commit/fcd1c890dc1526f4d62ceedad561f498195c8939))
+* **deps:** update dependency com.google.cloud:google-cloud-spanner to v1.50.0 ([1f9663c](https://www.github.com/googleapis/yoshi-go-test-repo/commit/1f9663cf08ab1cf3b68d95dee4dc99b7c4aac373))
+
+`
+
+exports['PR body-go-yoshi'] = {
+  'title': 'chore: release 0.124.0',
+  'body': ':robot: I have created a release \\*beep\\* \\*boop\\* \n---\n## [0.124.0](https://www.github.com/googleapis/yoshi-go-test-repo/compare/v0.123.4...v0.124.0) \n\n\n### Bug Fixes\n\n* **automl:** update dependency com.google.cloud:google-cloud-storage to v1.120.0 ([fcd1c89](https://www.github.com/googleapis/yoshi-go-test-repo/commit/fcd1c890dc1526f4d62ceedad561f498195c8939))\n* **deps:** update dependency com.google.cloud:google-cloud-spanner to v1.50.0 ([1f9663c](https://www.github.com/googleapis/yoshi-go-test-repo/commit/1f9663cf08ab1cf3b68d95dee4dc99b7c4aac373))\n---\n\n\nThis PR was generated with [Release Please](https://github.com/googleapis/release-please).',
+  'head': 'release-v0.124.0',
+  'base': 'master'
+}
+
+exports['labels-go-yoshi'] = {
+  'labels': [
+    'autorelease: pending'
+  ]
+}

--- a/__snapshots__/yoshi-go.js
+++ b/__snapshots__/yoshi-go.js
@@ -8,22 +8,27 @@ exports['CHANGES-go-yoshi'] = `
 ## [0.124.0](https://www.github.com/googleapis/yoshi-go-test-repo/compare/v0.123.4...v0.124.0) 
 
 
+### Features
+
+* **all:** auto-regenerate gapics ([#1000](https://www.github.com/googleapis/yoshi-go-test-repo/issues/1000)) ([#1001](https://www.github.com/googleapis/yoshi-go-test-repo/issues/1001))
+* **asset:** added a really cool feature ([d7d1c89](https://www.github.com/googleapis/yoshi-go-test-repo/commit/d7d1c890dc1526f4d62ceedad581f498195c8939))
+
+
 ### Bug Fixes
 
-* **automl:** update dependency com.google.cloud:google-cloud-storage to v1.120.0 ([fcd1c89](https://www.github.com/googleapis/yoshi-go-test-repo/commit/fcd1c890dc1526f4d62ceedad561f498195c8939))
-* **deps:** update dependency com.google.cloud:google-cloud-spanner to v1.50.0 ([1f9663c](https://www.github.com/googleapis/yoshi-go-test-repo/commit/1f9663cf08ab1cf3b68d95dee4dc99b7c4aac373))
+* **automl:** fixed a really bad bug ([d7d1c89](https://www.github.com/googleapis/yoshi-go-test-repo/commit/d7d1c890dc1526f4d62ceedad581f498195c8939))
 
 `
 
 exports['PR body-go-yoshi'] = {
-  'title': 'chore: release 0.124.0',
-  'body': ':robot: I have created a release \\*beep\\* \\*boop\\* \n---\n## [0.124.0](https://www.github.com/googleapis/yoshi-go-test-repo/compare/v0.123.4...v0.124.0) \n\n\n### Bug Fixes\n\n* **automl:** update dependency com.google.cloud:google-cloud-storage to v1.120.0 ([fcd1c89](https://www.github.com/googleapis/yoshi-go-test-repo/commit/fcd1c890dc1526f4d62ceedad561f498195c8939))\n* **deps:** update dependency com.google.cloud:google-cloud-spanner to v1.50.0 ([1f9663c](https://www.github.com/googleapis/yoshi-go-test-repo/commit/1f9663cf08ab1cf3b68d95dee4dc99b7c4aac373))\n---\n\n\nThis PR was generated with [Release Please](https://github.com/googleapis/release-please).',
-  'head': 'release-v0.124.0',
-  'base': 'master'
+  "title": "chore: release 0.124.0",
+  "body": ":robot: I have created a release \\*beep\\* \\*boop\\* \n---\n## [0.124.0](https://www.github.com/googleapis/yoshi-go-test-repo/compare/v0.123.4...v0.124.0) \n\n\n### Features\n\n* **all:** auto-regenerate gapics ([#1000](https://www.github.com/googleapis/yoshi-go-test-repo/issues/1000)) ([#1001](https://www.github.com/googleapis/yoshi-go-test-repo/issues/1001))\n* **asset:** added a really cool feature ([d7d1c89](https://www.github.com/googleapis/yoshi-go-test-repo/commit/d7d1c890dc1526f4d62ceedad581f498195c8939))\n\n\n### Bug Fixes\n\n* **automl:** fixed a really bad bug ([d7d1c89](https://www.github.com/googleapis/yoshi-go-test-repo/commit/d7d1c890dc1526f4d62ceedad581f498195c8939))\n---\n\n\nThis PR was generated with [Release Please](https://github.com/googleapis/release-please).",
+  "head": "release-v0.124.0",
+  "base": "master"
 }
 
 exports['labels-go-yoshi'] = {
-  'labels': [
-    'autorelease: pending'
+  "labels": [
+    "autorelease: pending"
   ]
 }

--- a/__snapshots__/yoshi-go.js
+++ b/__snapshots__/yoshi-go.js
@@ -1,8 +1,8 @@
-exports['CHANGELOG-go-yoshi-message'] = `
-chore: created CHANGELOG.md
+exports['CHANGES-go-yoshi-message'] = `
+chore: created CHANGES.md
 `
 
-exports['CHANGELOG-go-yoshi'] = `
+exports['CHANGES-go-yoshi'] = `
 # Changelog
 
 ## [0.124.0](https://www.github.com/googleapis/yoshi-go-test-repo/compare/v0.123.4...v0.124.0) 

--- a/package.json
+++ b/package.json
@@ -60,7 +60,7 @@
     "@octokit/rest": "^18.0.0",
     "chalk": "^4.0.0",
     "concat-stream": "^2.0.0",
-    "conventional-changelog-conventionalcommits": "^4.0.0",
+    "conventional-changelog-conventionalcommits": "^4.4.0",
     "conventional-changelog-writer": "^4.0.6",
     "conventional-commits-filter": "^2.0.2",
     "conventional-commits-parser": "^3.0.3",

--- a/src/conventional-commits.ts
+++ b/src/conventional-commits.ts
@@ -236,7 +236,9 @@ export class ConventionalCommits {
     // point to branch from for PRs.
     const commitsReadable = new Readable();
     this.commits.forEach((commit: Commit) => {
-      commitsReadable.push(`${commit.message}\n-hash-\n${commit.sha}`);
+      commitsReadable.push(
+        `${commit.message}\n-hash-\n${commit.sha ? commit.sha : ''}`
+      );
     });
     commitsReadable.push(null);
     return commitsReadable;

--- a/src/releasers/go-yoshi.ts
+++ b/src/releasers/go-yoshi.ts
@@ -1,4 +1,4 @@
-// Copyright 2019 Google LLC
+// Copyright 2020 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/releasers/go-yoshi.ts
+++ b/src/releasers/go-yoshi.ts
@@ -116,7 +116,7 @@ export class GoYoshi extends ReleasePR {
 
     updates.push(
       new Changelog({
-        path: this.addPath('CHANGELOG.md'),
+        path: this.addPath('CHANGES.md'),
         changelogEntry,
         version: candidate.version,
         packageName: this.packageName,

--- a/src/releasers/go-yoshi.ts
+++ b/src/releasers/go-yoshi.ts
@@ -1,0 +1,151 @@
+// * we need a deny list of modules that are mono repos, which we keep track of
+// ideally with minimal human intervention:
+//   * these should not show up in CHANGELOG for an "all" release.
+// * We need to also be able to manage the release of our snowflake, hand-written
+// libraries. Which get released.
+// * top level changes relate to all.
+
+// Copyright 2019 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import {ReleasePR, ReleaseCandidate} from '../release-pr';
+
+import {ConventionalCommits} from '../conventional-commits';
+import {GitHubTag} from '../github';
+import {checkpoint, CheckpointType} from '../util/checkpoint';
+import {Update} from '../updaters/update';
+import {Commit} from '../graphql-to-commits';
+
+import {ReleaseType} from 'semver';
+import * as semver from 'semver';
+
+// Generic
+import {Changelog} from '../updaters/changelog';
+
+// These repos should be ignored when generating a release for the
+// top level mono-repo:
+const IGNORED_PATHS = [
+  'bigtable',
+  'bigquery',
+  'datastore',
+  'firestore',
+  'logging',
+  'pubsub',
+  'spanner',
+  'storage',
+];
+const GAPIC_PR_REGEX = /.*auto-regenerate gapics.*/;
+
+export class GoYoshi extends ReleasePR {
+  static releaserName = 'go-yoshi';
+  protected async _run() {
+    const latestTag: GitHubTag | undefined = await this.gh.latestTag(
+      this.monorepoTags ? `${this.packageName}-` : undefined
+    );
+    let gapicPR: Commit;
+    const commits: Commit[] = (
+      await this.commits({
+        sha: latestTag ? latestTag.sha : undefined,
+        path: this.path,
+      })
+    ).filter(commit => {
+      for (const ignoredPath of IGNORED_PATHS) {
+        const re = new RegExp(`^\\w+\\(${ignoredPath}.*\\)`);
+        if (re.test(commit.message)) {
+          return false;
+        }
+      }
+      if (GAPIC_PR_REGEX.test(commit.message)) {
+        if (gapicPR) {
+          const issueRe = /.*(?<pr>\(.*\))$/;
+          const match = commit.message.match(issueRe);
+          if (match && match?.groups?.pr) {
+            gapicPR.message = `${gapicPR.message} ${match.groups.pr}`;
+          }
+          return false;
+        } else {
+          gapicPR = commit;
+        }
+      }
+      return true;
+    });
+
+    const cc = new ConventionalCommits({
+      commits: commits,
+      githubRepoUrl: this.repoUrl,
+      bumpMinorPreMajor: this.bumpMinorPreMajor,
+    });
+    const candidate: ReleaseCandidate = await this.coerceReleaseCandidate(
+      cc,
+      latestTag
+    );
+
+    const changelogEntry: string = await cc.generateChangelogEntry({
+      version: candidate.version,
+      currentTag: `v${candidate.version}`,
+      previousTag: candidate.previousTag,
+    });
+
+    // don't create a release candidate until user facing changes
+    // (fix, feat, BREAKING CHANGE) have been made; a CHANGELOG that's
+    // one line is a good indicator that there were no interesting commits.
+    if (this.changelogEmpty(changelogEntry)) {
+      checkpoint(
+        `no user facing commits found since ${
+          latestTag ? latestTag.sha : 'beginning of time'
+        }`,
+        CheckpointType.Failure
+      );
+      return;
+    }
+
+    const updates: Update[] = [];
+
+    console.info(changelogEntry);
+
+    updates.push(
+      new Changelog({
+        path: this.addPath('CHANGELOG.md'),
+        changelogEntry,
+        version: candidate.version,
+        packageName: this.packageName,
+      })
+    );
+
+    await this.openPR({
+      sha: commits[0].sha!,
+      changelogEntry: `${changelogEntry}\n---\n`,
+      updates,
+      version: candidate.version,
+      includePackageName: this.monorepoTags,
+    });
+  }
+
+  protected async coerceReleaseCandidate(
+    cc: ConventionalCommits,
+    latestTag: GitHubTag | undefined
+  ): Promise<ReleaseCandidate> {
+    const version = latestTag
+      ? latestTag.version
+      : this.defaultInitialVersion();
+    const previousTag = latestTag ? latestTag.name : undefined;
+    const bump: ReleaseType = 'minor';
+    const candidate: string | null = semver.inc(version, bump);
+    return {version: candidate as string, previousTag};
+  }
+
+  protected defaultInitialVersion(): string {
+    return '0.1.0';
+  }
+}

--- a/src/releasers/go-yoshi.ts
+++ b/src/releasers/go-yoshi.ts
@@ -98,14 +98,11 @@ export class GoYoshi extends ReleasePR {
       latestTag
     );
 
-    let changelogEntry: string = await cc.generateChangelogEntry({
+    const changelogEntry: string = await cc.generateChangelogEntry({
       version: candidate.version,
       currentTag: `v${candidate.version}`,
       previousTag: candidate.previousTag,
     });
-
-    // remove commit reference from auto-generate gapics
-    changelogEntry = changelogEntry.replace(/\s\(\[null\].*\n/, '\n');
 
     // don't create a release candidate until user facing changes
     // (fix, feat, BREAKING CHANGE) have been made; a CHANGELOG that's

--- a/test/releasers/fixtures/yoshi-go/commits.json
+++ b/test/releasers/fixtures/yoshi-go/commits.json
@@ -1,0 +1,124 @@
+{
+  "repository": {
+    "defaultBranchRef": {
+      "target": {
+        "history": {
+          "edges": [
+            {
+              "node": {
+                "message": "fix(automl): update dependency com.google.cloud:google-cloud-storage to v1.120.0",
+                "oid": "fcd1c890dc1526f4d62ceedad561f498195c8939",
+                "associatedPullRequests": {
+                  "edges": [
+                    {
+                      "node": {
+                        "mergeCommit": {
+                          "oid": "fcd1c890dc1526f4d62ceedad561f498195c8939"
+                        },
+                        "number": 292,
+                        "labels": {
+                          "edges": [
+                            {
+                              "node": {
+                                "name": "cla: yes"
+                              }
+                            }
+                          ]
+                        }
+                      }
+                    }
+                  ]
+                }
+              }
+            },
+            {
+              "node": {
+                "message": "fix(pubsub): this commit should be ignored",
+                "oid": "dcd1c890dc1526f4d62ceedad581f498195c8939",
+                "associatedPullRequests": {
+                  "edges": [
+                    {
+                      "node": {
+                        "mergeCommit": {
+                          "oid": "dcd1c890dc1526f4d62ceedad581f498195c8939"
+                        },
+                        "number": 293,
+                        "labels": {
+                          "edges": [
+                            {
+                              "node": {
+                                "name": "cla: yes"
+                              }
+                            }
+                          ]
+                        }
+                      }
+                    }
+                  ]
+                }
+              }
+            },
+            {
+              "node": {
+                "message": "fix(deps): update dependency com.google.cloud:google-cloud-spanner to v1.50.0",
+                "oid": "1f9663cf08ab1cf3b68d95dee4dc99b7c4aac373",
+                "associatedPullRequests": {
+                  "edges": [
+                    {
+                      "node": {
+                        "mergeCommit": {
+                          "oid": "1f9663cf08ab1cf3b68d95dee4dc99b7c4aac373"
+                        },
+                        "number": 301,
+                        "labels": {
+                          "edges": [
+                            {
+                              "node": {
+                                "name": "cla: yes"
+                              }
+                            }
+                          ]
+                        }
+                      }
+                    }
+                  ]
+                }
+              }
+            },
+            {
+              "node": {
+                "message": "chore: update common templates",
+                "oid": "3006009a2b1b2cb4bd5108c0f469c410759f3a6a",
+                "associatedPullRequests": {
+                  "edges": [
+                    {
+                      "node": {
+                        "mergeCommit": {
+                          "oid": "3006009a2b1b2cb4bd5108c0f469c410759f3a6a"
+                        },
+                        "number": 300,
+                        "labels": {
+                          "edges": [
+                            {
+                              "node": {
+                                "name": "cla: yes"
+                              }
+                            }
+                          ]
+                        }
+                      }
+                    }
+                  ]
+                }
+              }
+            }
+          ],
+          "pageInfo": {
+            "endCursor": "fcd1c890dc1526f4d62ceedad561f498195c8939 99",
+            "hasNextPage": false
+          }
+        }
+      }
+    }
+  }
+}

--- a/test/releasers/fixtures/yoshi-go/commits.json
+++ b/test/releasers/fixtures/yoshi-go/commits.json
@@ -6,16 +6,43 @@
           "edges": [
             {
               "node": {
-                "message": "fix(automl): update dependency com.google.cloud:google-cloud-storage to v1.120.0",
-                "oid": "fcd1c890dc1526f4d62ceedad561f498195c8939",
+                "message": "fix(automl): fixed a really bad bug",
+                "oid": "d7d1c890dc1526f4d62ceedad581f498195c8939",
                 "associatedPullRequests": {
                   "edges": [
                     {
                       "node": {
                         "mergeCommit": {
-                          "oid": "fcd1c890dc1526f4d62ceedad561f498195c8939"
+                          "oid": "d7d1c890dc1526f4d62ceedad581f498195c8939"
                         },
-                        "number": 292,
+                        "number": 293,
+                        "labels": {
+                          "edges": [
+                            {
+                              "node": {
+                                "name": "cla: yes"
+                              }
+                            }
+                          ]
+                        }
+                      }
+                    }
+                  ]
+                }
+              }
+            },
+            {
+              "node": {
+                "message": "feat(asset): added a really cool feature",
+                "oid": "d7d1c890dc1526f4d62ceedad581f498195c8939",
+                "associatedPullRequests": {
+                  "edges": [
+                    {
+                      "node": {
+                        "mergeCommit": {
+                          "oid": "d7d1c890dc1526f4d62ceedad581f498195c8939"
+                        },
+                        "number": 293,
                         "labels": {
                           "edges": [
                             {
@@ -60,14 +87,41 @@
             },
             {
               "node": {
-                "message": "fix(deps): update dependency com.google.cloud:google-cloud-spanner to v1.50.0",
-                "oid": "1f9663cf08ab1cf3b68d95dee4dc99b7c4aac373",
+                "message": "fix: this commit should be ignored",
+                "oid": "ecd1c890dc1526f4d62ceedad581f489195c8939",
                 "associatedPullRequests": {
                   "edges": [
                     {
                       "node": {
                         "mergeCommit": {
-                          "oid": "1f9663cf08ab1cf3b68d95dee4dc99b7c4aac373"
+                          "oid": "ecd1c890dc1526f4d62ceedad581f489195c8939"
+                        },
+                        "number": 293,
+                        "labels": {
+                          "edges": [
+                            {
+                              "node": {
+                                "name": "cla: yes"
+                              }
+                            }
+                          ]
+                        }
+                      }
+                    }
+                  ]
+                }
+              }
+            },
+            {
+              "node": {
+                "message": "feat(all): auto-regenerate gapics (#1000)",
+                "oid": "2f9663cf08ab1cf3b68d95dee4dc99b7c4aac372",
+                "associatedPullRequests": {
+                  "edges": [
+                    {
+                      "node": {
+                        "mergeCommit": {
+                          "oid": "2f9663cf08ab1cf3b68d95dee4dc99b7c4aac372"
                         },
                         "number": 301,
                         "labels": {
@@ -87,16 +141,16 @@
             },
             {
               "node": {
-                "message": "chore: update common templates",
-                "oid": "3006009a2b1b2cb4bd5108c0f469c410759f3a6a",
+                "message": "feat(all): auto-regenerate gapics (#1001)",
+                "oid": "1f9663cf08ab1cf3b68d95dee4dc99b7c4aac371",
                 "associatedPullRequests": {
                   "edges": [
                     {
                       "node": {
                         "mergeCommit": {
-                          "oid": "3006009a2b1b2cb4bd5108c0f469c410759f3a6a"
+                          "oid": "1f9663cf08ab1cf3b68d95dee4dc99b7c4aac371"
                         },
-                        "number": 300,
+                        "number": 301,
                         "labels": {
                           "edges": [
                             {

--- a/test/releasers/yoshi-go.ts
+++ b/test/releasers/yoshi-go.ts
@@ -33,7 +33,10 @@ function requireNode10(this: MochaThis) {
 
 describe('YoshiGo', () => {
   describe('run', () => {
-    before(requireNode10);
+    before(() => {
+      requireNode10;
+      nock.disableNetConnect();
+    });
     it('creates a release PR', async () => {
       const graphql = JSON.parse(
         readFileSync(resolve(fixturesPath, 'commits.json'), 'utf8')

--- a/test/releasers/yoshi-go.ts
+++ b/test/releasers/yoshi-go.ts
@@ -64,17 +64,17 @@ describe('YoshiGo', () => {
         // creating a new branch
         .post('/repos/googleapis/yoshi-go-test-repo/git/refs')
         .reply(200)
-        // check for CHANGELOG
+        // check for CHANGES.md
         .get(
-          '/repos/googleapis/yoshi-go-test-repo/contents/CHANGELOG.md?ref=refs%2Fheads%2Frelease-v0.124.0'
+          '/repos/googleapis/yoshi-go-test-repo/contents/CHANGES.md?ref=refs%2Fheads%2Frelease-v0.124.0'
         )
         .reply(404)
         .put(
-          '/repos/googleapis/yoshi-go-test-repo/contents/CHANGELOG.md',
+          '/repos/googleapis/yoshi-go-test-repo/contents/CHANGES.md',
           (req: {[key: string]: string}) => {
-            snapshot('CHANGELOG-go-yoshi-message', req.message);
+            snapshot('CHANGES-go-yoshi-message', req.message);
             snapshot(
-              'CHANGELOG-go-yoshi',
+              'CHANGES-go-yoshi',
               Buffer.from(req.content, 'base64')
                 .toString('utf8')
                 .replace(/\([0-9]{4}-[0-9]{2}-[0-9]{2}\)/g, '')

--- a/test/releasers/yoshi-go.ts
+++ b/test/releasers/yoshi-go.ts
@@ -1,0 +1,124 @@
+// Copyright 2020 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import {describe, it, before} from 'mocha';
+import * as nock from 'nock';
+import {GoYoshi} from '../../src/releasers/go-yoshi';
+import {readFileSync} from 'fs';
+import {resolve} from 'path';
+import * as snapshot from 'snap-shot-it';
+
+const fixturesPath = './test/releasers/fixtures/yoshi-go';
+
+interface MochaThis {
+  [skip: string]: Function;
+}
+function requireNode10(this: MochaThis) {
+  const match = process.version.match(/v([0-9]+)/);
+  if (match) {
+    if (Number(match[1]) < 10) this.skip();
+  }
+}
+
+describe('YoshiGo', () => {
+  describe('run', () => {
+    before(requireNode10);
+    it('creates a release PR', async () => {
+      const graphql = JSON.parse(
+        readFileSync(resolve(fixturesPath, 'commits.json'), 'utf8')
+      );
+      const req = nock('https://api.github.com')
+        .get(
+          '/repos/googleapis/yoshi-go-test-repo/pulls?state=closed&per_page=100'
+        )
+        .reply(200, undefined)
+        // fetch semver tags, this will be used to determine
+        // the delta since the last release.
+        .get('/repos/googleapis/yoshi-go-test-repo/tags?per_page=100')
+        .reply(200, [
+          {
+            name: 'v0.123.4',
+            commit: {
+              sha: 'da6e52d956c1e35d19e75e0f2fdba439739ba364',
+            },
+          },
+        ])
+        .post('/graphql')
+        .reply(200, {
+          data: graphql,
+        })
+        // getting the latest tag
+        .get('/repos/googleapis/yoshi-go-test-repo/git/refs?per_page=100')
+        .reply(200, [{ref: 'refs/tags/v0.123.4'}])
+        // creating a new branch
+        .post('/repos/googleapis/yoshi-go-test-repo/git/refs')
+        .reply(200)
+        // check for CHANGELOG
+        .get(
+          '/repos/googleapis/yoshi-go-test-repo/contents/CHANGELOG.md?ref=refs%2Fheads%2Frelease-v0.124.0'
+        )
+        .reply(404)
+        .put(
+          '/repos/googleapis/yoshi-go-test-repo/contents/CHANGELOG.md',
+          (req: {[key: string]: string}) => {
+            snapshot('CHANGELOG-go-yoshi-message', req.message);
+            snapshot(
+              'CHANGELOG-go-yoshi',
+              Buffer.from(req.content, 'base64')
+                .toString('utf8')
+                .replace(/\([0-9]{4}-[0-9]{2}-[0-9]{2}\)/g, '')
+            );
+            return true;
+          }
+        )
+        .reply(201)
+        // check for default branch
+        .get('/repos/googleapis/yoshi-go-test-repo')
+        // eslint-disable-next-line @typescript-eslint/no-var-requires
+        .reply(200, require('../../../test/fixtures/repo-get-1.json'))
+        // create release
+        .post(
+          '/repos/googleapis/yoshi-go-test-repo/pulls',
+          (req: {[key: string]: string}) => {
+            req.body = req.body.replace(/\([0-9]{4}-[0-9]{2}-[0-9]{2}\)/g, '');
+            snapshot('PR body-go-yoshi', req);
+            return true;
+          }
+        )
+        .reply(200, {number: 1})
+        .post(
+          '/repos/googleapis/yoshi-go-test-repo/issues/1/labels',
+          (req: {[key: string]: string}) => {
+            snapshot('labels-go-yoshi', req);
+            return true;
+          }
+        )
+        .reply(200, {})
+        // this step tries to close any existing PRs; just return an empty list.
+        .get(
+          '/repos/googleapis/yoshi-go-test-repo/pulls?state=open&per_page=100'
+        )
+        .reply(200, []);
+      const releasePR = new GoYoshi({
+        repoUrl: 'googleapis/yoshi-go-test-repo',
+        releaseType: 'yoshi-go',
+        // not actually used by this type of repo.
+        packageName: 'yoshi-go',
+        apiUrl: 'https://api.github.com',
+      });
+      await releasePR.run();
+      req.done();
+    });
+  });
+});

--- a/test/releasers/yoshi-go.ts
+++ b/test/releasers/yoshi-go.ts
@@ -24,17 +24,10 @@ const fixturesPath = './test/releasers/fixtures/yoshi-go';
 interface MochaThis {
   [skip: string]: Function;
 }
-function requireNode10(this: MochaThis) {
-  const match = process.version.match(/v([0-9]+)/);
-  if (match) {
-    if (Number(match[1]) < 10) this.skip();
-  }
-}
 
 describe('YoshiGo', () => {
   describe('run', () => {
     before(() => {
-      requireNode10;
       nock.disableNetConnect();
     });
     it('creates a release PR', async () => {


### PR DESCRIPTION
This adds support for releasing the Yoshi gapic go libraries.

TODO:

- [x] get the CHANGES.md closer to the current style.
- [x] properly build up a combined gapic PR, as we dedupe it.
- [ ] setup the configuration in the go repository, so this actually works.

Future Work:

* figure out the manual yoshi libraries.

CC: @codyoss 