### PR TITLE
fix(go): Update scope matching and regen regex

### DIFF
--- a/__snapshots__/yoshi-go.js
+++ b/__snapshots__/yoshi-go.js
@@ -12,6 +12,7 @@ exports['CHANGES-go-yoshi'] = `
 
 * **all:** auto-regenerate gapics ([#1000](https://www.github.com/googleapis/yoshi-go-test-repo/issues/1000)) ([#1001](https://www.github.com/googleapis/yoshi-go-test-repo/issues/1001))
 * **asset:** added a really cool feature ([d7d1c89](https://www.github.com/googleapis/yoshi-go-test-repo/commit/d7d1c890dc1526f4d62ceedad581f498195c8939))
+* **pubsublite:** start generating v1 ([1d9662c](https://www.github.com/googleapis/yoshi-go-test-repo/commit/1d9662cf08ab1cf3b68d95dee4dc99b7c4aac371))
 
 
 ### Bug Fixes
@@ -21,14 +22,14 @@ exports['CHANGES-go-yoshi'] = `
 `
 
 exports['PR body-go-yoshi'] = {
-  'title': 'chore: release 0.124.0',
-  'body': ':robot: I have created a release \\*beep\\* \\*boop\\* \n---\n## [0.124.0](https://www.github.com/googleapis/yoshi-go-test-repo/compare/v0.123.4...v0.124.0) \n\n\n### Features\n\n* **all:** auto-regenerate gapics ([#1000](https://www.github.com/googleapis/yoshi-go-test-repo/issues/1000)) ([#1001](https://www.github.com/googleapis/yoshi-go-test-repo/issues/1001))\n* **asset:** added a really cool feature ([d7d1c89](https://www.github.com/googleapis/yoshi-go-test-repo/commit/d7d1c890dc1526f4d62ceedad581f498195c8939))\n\n\n### Bug Fixes\n\n* **automl:** fixed a really bad bug ([d7d1c89](https://www.github.com/googleapis/yoshi-go-test-repo/commit/d7d1c890dc1526f4d62ceedad581f498195c8939))\n---\n\n\nThis PR was generated with [Release Please](https://github.com/googleapis/release-please).',
-  'head': 'release-v0.124.0',
-  'base': 'master'
+  "title": "chore: release 0.124.0",
+  "body": ":robot: I have created a release \\*beep\\* \\*boop\\* \n---\n## [0.124.0](https://www.github.com/googleapis/yoshi-go-test-repo/compare/v0.123.4...v0.124.0) \n\n\n### Features\n\n* **all:** auto-regenerate gapics ([#1000](https://www.github.com/googleapis/yoshi-go-test-repo/issues/1000)) ([#1001](https://www.github.com/googleapis/yoshi-go-test-repo/issues/1001))\n* **asset:** added a really cool feature ([d7d1c89](https://www.github.com/googleapis/yoshi-go-test-repo/commit/d7d1c890dc1526f4d62ceedad581f498195c8939))\n* **pubsublite:** start generating v1 ([1d9662c](https://www.github.com/googleapis/yoshi-go-test-repo/commit/1d9662cf08ab1cf3b68d95dee4dc99b7c4aac371))\n\n\n### Bug Fixes\n\n* **automl:** fixed a really bad bug ([d7d1c89](https://www.github.com/googleapis/yoshi-go-test-repo/commit/d7d1c890dc1526f4d62ceedad581f498195c8939))\n---\n\n\nThis PR was generated with [Release Please](https://github.com/googleapis/release-please).",
+  "head": "release-v0.124.0",
+  "base": "master"
 }
 
 exports['labels-go-yoshi'] = {
-  'labels': [
-    'autorelease: pending'
+  "labels": [
+    "autorelease: pending"
   ]
 }

--- a/src/releasers/go-yoshi.ts
+++ b/src/releasers/go-yoshi.ts
@@ -63,7 +63,7 @@ export class GoYoshi extends ReleasePR {
       // Skipping commits related to sub-modules as they are not apart of the
       // parent module.
       for (const subModule of SUB_MODULES) {
-        if (scope.startsWith(subModule)) {
+        if (scope === subModule || scope.startsWith(subModule + '/')) {
           // TODO(codyoss): eventually gather these commits into a map so we can
           // purpose releases for sub-modules.
           return false;
@@ -73,7 +73,7 @@ export class GoYoshi extends ReleasePR {
       // If there are more than one of these commits, append associated PR.
       if (GAPIC_PR_REGEX.test(commit.message)) {
         if (gapicPR) {
-          const issueRe = /.*(?<pr>\(.*\))$/;
+          const issueRe = /.*(?<pr>\(.*\))/;
           const match = commit.message.match(issueRe);
           if (match?.groups?.pr) {
             gapicPR.message = `${gapicPR.message} ${match.groups.pr}`;

--- a/test/releasers/fixtures/yoshi-go/commits.json
+++ b/test/releasers/fixtures/yoshi-go/commits.json
@@ -87,6 +87,33 @@
             },
             {
               "node": {
+                "message": "fix(pubsub/pstest): this commit should be ignored",
+                "oid": "dad2c890dc1526f4d62ceedad581f498195c8939",
+                "associatedPullRequests": {
+                  "edges": [
+                    {
+                      "node": {
+                        "mergeCommit": {
+                          "oid": "dad2c890dc1526f4d62ceedad581f498195c8939"
+                        },
+                        "number": 293,
+                        "labels": {
+                          "edges": [
+                            {
+                              "node": {
+                                "name": "cla: yes"
+                              }
+                            }
+                          ]
+                        }
+                      }
+                    }
+                  ]
+                }
+              }
+            },
+            {
+              "node": {
                 "message": "fix: this commit should be ignored",
                 "oid": "ecd1c890dc1526f4d62ceedad581f489195c8939",
                 "associatedPullRequests": {
@@ -141,7 +168,7 @@
             },
             {
               "node": {
-                "message": "feat(all): auto-regenerate gapics (#1001)",
+                "message": "feat(all): auto-regenerate gapics (#1001)\n\nCommit Body",
                 "oid": "1f9663cf08ab1cf3b68d95dee4dc99b7c4aac371",
                 "associatedPullRequests": {
                   "edges": [
@@ -149,6 +176,33 @@
                       "node": {
                         "mergeCommit": {
                           "oid": "1f9663cf08ab1cf3b68d95dee4dc99b7c4aac371"
+                        },
+                        "number": 301,
+                        "labels": {
+                          "edges": [
+                            {
+                              "node": {
+                                "name": "cla: yes"
+                              }
+                            }
+                          ]
+                        }
+                      }
+                    }
+                  ]
+                }
+              }
+            },
+            {
+              "node": {
+                "message": "feat(pubsublite): start generating v1",
+                "oid": "1d9662cf08ab1cf3b68d95dee4dc99b7c4aac371",
+                "associatedPullRequests": {
+                  "edges": [
+                    {
+                      "node": {
+                        "mergeCommit": {
+                          "oid": "1d9662cf08ab1cf3b68d95dee4dc99b7c4aac371"
                         },
                         "number": 301,
                         "labels": {


### PR DESCRIPTION
The scope matching was too greedy and caught things like
"pubsublite". Scope should be an exact match or be within the same
directory structure.