### PR TITLE
fix(yoshi-go): store the sha of the first commit

### DIFF
--- a/__snapshots__/yoshi-go.js
+++ b/__snapshots__/yoshi-go.js
@@ -10,7 +10,7 @@ exports['CHANGES-go-yoshi'] = `
 
 ### Features
 
-* **all:** auto-regenerate gapics ([#1000](https://www.github.com/googleapis/yoshi-go-test-repo/issues/1000)) ([#1001](https://www.github.com/googleapis/yoshi-go-test-repo/issues/1001))
+* **all:** auto-regenerate gapics , refs [#1000](https://www.github.com/googleapis/yoshi-go-test-repo/issues/1000) [#1001](https://www.github.com/googleapis/yoshi-go-test-repo/issues/1001)
 * **asset:** added a really cool feature ([d7d1c89](https://www.github.com/googleapis/yoshi-go-test-repo/commit/d7d1c890dc1526f4d62ceedad581f498195c8939))
 * **pubsublite:** start generating v1 ([1d9662c](https://www.github.com/googleapis/yoshi-go-test-repo/commit/1d9662cf08ab1cf3b68d95dee4dc99b7c4aac371))
 
@@ -23,7 +23,7 @@ exports['CHANGES-go-yoshi'] = `
 
 exports['PR body-go-yoshi'] = {
   'title': 'chore: release 0.124.0',
-  'body': ':robot: I have created a release \\*beep\\* \\*boop\\* \n---\n## [0.124.0](https://www.github.com/googleapis/yoshi-go-test-repo/compare/v0.123.4...v0.124.0) \n\n\n### Features\n\n* **all:** auto-regenerate gapics ([#1000](https://www.github.com/googleapis/yoshi-go-test-repo/issues/1000)) ([#1001](https://www.github.com/googleapis/yoshi-go-test-repo/issues/1001))\n* **asset:** added a really cool feature ([d7d1c89](https://www.github.com/googleapis/yoshi-go-test-repo/commit/d7d1c890dc1526f4d62ceedad581f498195c8939))\n* **pubsublite:** start generating v1 ([1d9662c](https://www.github.com/googleapis/yoshi-go-test-repo/commit/1d9662cf08ab1cf3b68d95dee4dc99b7c4aac371))\n\n\n### Bug Fixes\n\n* **automl:** fixed a really bad bug ([d7d1c89](https://www.github.com/googleapis/yoshi-go-test-repo/commit/d7d1c890dc1526f4d62ceedad581f498195c8939))\n---\n\n\nThis PR was generated with [Release Please](https://github.com/googleapis/release-please).',
+  'body': ':robot: I have created a release \\*beep\\* \\*boop\\* \n---\n## [0.124.0](https://www.github.com/googleapis/yoshi-go-test-repo/compare/v0.123.4...v0.124.0) \n\n\n### Features\n\n* **all:** auto-regenerate gapics , refs [#1000](https://www.github.com/googleapis/yoshi-go-test-repo/issues/1000) [#1001](https://www.github.com/googleapis/yoshi-go-test-repo/issues/1001)\n* **asset:** added a really cool feature ([d7d1c89](https://www.github.com/googleapis/yoshi-go-test-repo/commit/d7d1c890dc1526f4d62ceedad581f498195c8939))\n* **pubsublite:** start generating v1 ([1d9662c](https://www.github.com/googleapis/yoshi-go-test-repo/commit/1d9662cf08ab1cf3b68d95dee4dc99b7c4aac371))\n\n\n### Bug Fixes\n\n* **automl:** fixed a really bad bug ([d7d1c89](https://www.github.com/googleapis/yoshi-go-test-repo/commit/d7d1c890dc1526f4d62ceedad581f498195c8939))\n\nThis PR was generated with [Release Please](https://github.com/googleapis/release-please).',
   'head': 'release-v0.124.0',
   'base': 'master'
 }

--- a/__snapshots__/yoshi-go.js
+++ b/__snapshots__/yoshi-go.js
@@ -22,14 +22,14 @@ exports['CHANGES-go-yoshi'] = `
 `
 
 exports['PR body-go-yoshi'] = {
-  "title": "chore: release 0.124.0",
-  "body": ":robot: I have created a release \\*beep\\* \\*boop\\* \n---\n## [0.124.0](https://www.github.com/googleapis/yoshi-go-test-repo/compare/v0.123.4...v0.124.0) \n\n\n### Features\n\n* **all:** auto-regenerate gapics ([#1000](https://www.github.com/googleapis/yoshi-go-test-repo/issues/1000)) ([#1001](https://www.github.com/googleapis/yoshi-go-test-repo/issues/1001))\n* **asset:** added a really cool feature ([d7d1c89](https://www.github.com/googleapis/yoshi-go-test-repo/commit/d7d1c890dc1526f4d62ceedad581f498195c8939))\n* **pubsublite:** start generating v1 ([1d9662c](https://www.github.com/googleapis/yoshi-go-test-repo/commit/1d9662cf08ab1cf3b68d95dee4dc99b7c4aac371))\n\n\n### Bug Fixes\n\n* **automl:** fixed a really bad bug ([d7d1c89](https://www.github.com/googleapis/yoshi-go-test-repo/commit/d7d1c890dc1526f4d62ceedad581f498195c8939))\n---\n\n\nThis PR was generated with [Release Please](https://github.com/googleapis/release-please).",
-  "head": "release-v0.124.0",
-  "base": "master"
+  'title': 'chore: release 0.124.0',
+  'body': ':robot: I have created a release \\*beep\\* \\*boop\\* \n---\n## [0.124.0](https://www.github.com/googleapis/yoshi-go-test-repo/compare/v0.123.4...v0.124.0) \n\n\n### Features\n\n* **all:** auto-regenerate gapics ([#1000](https://www.github.com/googleapis/yoshi-go-test-repo/issues/1000)) ([#1001](https://www.github.com/googleapis/yoshi-go-test-repo/issues/1001))\n* **asset:** added a really cool feature ([d7d1c89](https://www.github.com/googleapis/yoshi-go-test-repo/commit/d7d1c890dc1526f4d62ceedad581f498195c8939))\n* **pubsublite:** start generating v1 ([1d9662c](https://www.github.com/googleapis/yoshi-go-test-repo/commit/1d9662cf08ab1cf3b68d95dee4dc99b7c4aac371))\n\n\n### Bug Fixes\n\n* **automl:** fixed a really bad bug ([d7d1c89](https://www.github.com/googleapis/yoshi-go-test-repo/commit/d7d1c890dc1526f4d62ceedad581f498195c8939))\n---\n\n\nThis PR was generated with [Release Please](https://github.com/googleapis/release-please).',
+  'head': 'release-v0.124.0',
+  'base': 'master'
 }
 
 exports['labels-go-yoshi'] = {
-  "labels": [
-    "autorelease: pending"
+  'labels': [
+    'autorelease: pending'
   ]
 }

--- a/src/releasers/go-yoshi.ts
+++ b/src/releasers/go-yoshi.ts
@@ -108,6 +108,8 @@ export class GoYoshi extends ReleasePR {
       latestTag
     );
 
+    // "closes" is a little presumptuous, let's just indicate that the
+    // PR references these other commits:
     const changelogEntry: string = (
       await cc.generateChangelogEntry({
         version: candidate.version,
@@ -144,8 +146,6 @@ export class GoYoshi extends ReleasePR {
     }
     await this.openPR({
       sha: sha!,
-      // "closes" is a little presumptuous, let's just indicate that the
-      // PR references these other commits:
       changelogEntry,
       updates,
       version: candidate.version,

--- a/src/releasers/go-yoshi.ts
+++ b/src/releasers/go-yoshi.ts
@@ -48,6 +48,7 @@ export class GoYoshi extends ReleasePR {
       this.monorepoTags ? `${this.packageName}-` : undefined
     );
     let gapicPR: Commit | undefined;
+    let sha: null | string = null;
     const commits = (
       await this.commits({
         sha: latestTag?.sha,
@@ -68,6 +69,11 @@ export class GoYoshi extends ReleasePR {
           // purpose releases for sub-modules.
           return false;
         }
+      }
+      // Store the very first SHA returned, this represents the HEAD of the
+      // release being created:
+      if (!sha) {
+        sha = commit.sha;
       }
       // Only have a single entry of the nightly regen listed in the changelog.
       // If there are more than one of these commits, append associated PR.
@@ -127,9 +133,11 @@ export class GoYoshi extends ReleasePR {
         packageName: this.packageName,
       })
     );
-
+    if (!sha) {
+      throw Error('no sha found for pull request');
+    }
     await this.openPR({
-      sha: commits[0].sha!,
+      sha: sha!,
       changelogEntry: `${changelogEntry}\n---\n`,
       updates,
       version: candidate.version,


### PR DESCRIPTION
If the first commit was of the `all` type, we were setting its sha to `null`, this meant we had no sha to base a commit on.