### PR TITLE
feat: allow CHANGELOG path to be  set

### DIFF
--- a/src/bin/release-please.ts
+++ b/src/bin/release-please.ts
@@ -100,6 +100,10 @@ const argv = yargs
           describe: 'GitHub URL to generate release for',
           demand: true,
         })
+        .option('changelog-path', {
+          default: 'CHANGELOG.md',
+          describe: 'where can the CHANGELOG be found in the project?',
+        })
         .option('label', {
           default: 'autorelease: pending',
           describe: 'label to remove from release PR',

--- a/src/github-release.ts
+++ b/src/github-release.ts
@@ -38,6 +38,7 @@ export interface GitHubReleaseOptions {
   proxyKey?: string;
   octokitAPIs?: OctokitAPIs;
   releaseType?: string;
+  changelogPath?: string;
 }
 
 export class GitHubRelease {
@@ -62,7 +63,7 @@ export class GitHubRelease {
     this.packageName = options.packageName;
     this.releaseType = options.releaseType;
 
-    this.changelogPath = 'CHANGELOG.md';
+    this.changelogPath = options.changelogPath ?? 'CHANGELOG.md';
 
     this.gh = this.gitHubInstance(options.octokitAPIs);
   }


### PR DESCRIPTION
Allow CHANGELOG path to  be configured, so that go can have an alternate name.