### PR TITLE
feat(release-as): release-as now supports pre-release

### DIFF
--- a/src/release-pr.ts
+++ b/src/release-pr.ts
@@ -191,7 +191,7 @@ export class ReleasePR {
     cc: ConventionalCommits,
     latestTag: GitHubTag | undefined
   ): Promise<ReleaseCandidate> {
-    const releaseAsRe = /release-as: v?([0-9]+\.[0-9]+\.[0-9a-z-])+\s*/i;
+    const releaseAsRe = /release-as:\s*v?([0-9]+\.[0-9]+\.[0-9a-z]+(-[0-9a-z.]+)?)\s*/i;
     const previousTag = latestTag ? latestTag.name : undefined;
     let version = latestTag ? latestTag.version : this.defaultInitialVersion();
 


### PR DESCRIPTION
The regex for `release-as` now supports pre-releases, e.g., `v1.0.0-foo.0`.