### PR TITLE
fix(simple): create version.txt if it does not exist

### DIFF
--- a/src/releasers/simple.ts
+++ b/src/releasers/simple.ts
@@ -15,7 +15,7 @@
 import {ReleasePR, ReleaseCandidate} from '../release-pr';
 
 import {ConventionalCommits} from '../conventional-commits';
-import {GitHubTag, GitHubFileContents} from '../github';
+import {GitHubTag} from '../github';
 import {checkpoint, CheckpointType} from '../util/checkpoint';
 import {Update} from '../updaters/update';
 import {Commit} from '../graphql-to-commits';
@@ -67,10 +67,6 @@ export class Simple extends ReleasePR {
 
     const updates: Update[] = [];
 
-    const contents: GitHubFileContents = await this.gh.getFileContents(
-      'version.txt'
-    );
-
     updates.push(
       new Changelog({
         path: 'CHANGELOG.md',
@@ -86,7 +82,6 @@ export class Simple extends ReleasePR {
         changelogEntry,
         version: candidate.version,
         packageName: this.packageName,
-        contents,
         skipCi: false,
       })
     );

--- a/src/updaters/version-txt.ts
+++ b/src/updaters/version-txt.ts
@@ -25,7 +25,7 @@ export class VersionTxt implements Update {
   skipCi?: boolean;
 
   constructor(options: UpdateOptions) {
-    this.create = false;
+    this.create = true;
     this.path = options.path;
     this.changelogEntry = options.changelogEntry;
     this.version = options.version;

--- a/test/release-pr-factory.ts
+++ b/test/release-pr-factory.ts
@@ -40,11 +40,6 @@ describe('ReleasePRFactory', () => {
           '/repos/googleapis/simple-test-repo/pulls?state=closed&per_page=100'
         )
         .reply(200, undefined)
-        .get('/repos/googleapis/simple-test-repo/contents/version.txt')
-        .reply(200, {
-          content: Buffer.from(versionContent, 'utf8').toString('base64'),
-          sha: 'abc123',
-        })
         // fetch semver tags, this will be used to determine
         // the delta since the last release.
         .get('/repos/googleapis/simple-test-repo/tags?per_page=100')
@@ -149,11 +144,6 @@ describe('ReleasePRFactory', () => {
           '/repos/googleapis/simple-test-repo/pulls?state=closed&per_page=100'
         )
         .reply(200, undefined)
-        .get('/repos/googleapis/simple-test-repo/contents/version.txt')
-        .reply(200, {
-          content: Buffer.from(versionContent, 'utf8').toString('base64'),
-          sha: 'abc123',
-        })
         // fetch semver tags, this will be used to determine
         // the delta since the last release.
         .get('/repos/googleapis/simple-test-repo/tags?per_page=100')

--- a/test/releasers/simple.ts
+++ b/test/releasers/simple.ts
@@ -47,11 +47,6 @@ describe('Simple', () => {
           '/repos/googleapis/simple-test-repo/pulls?state=closed&per_page=100'
         )
         .reply(200, undefined)
-        .get('/repos/googleapis/simple-test-repo/contents/version.txt')
-        .reply(200, {
-          content: Buffer.from(versionContent, 'utf8').toString('base64'),
-          sha: 'abc123',
-        })
         // fetch semver tags, this will be used to determine
         // the delta since the last release.
         .get('/repos/googleapis/simple-test-repo/tags?per_page=100')


### PR DESCRIPTION
there's no reason we can't just create the `version.txt` if it doesn't exist.