### PR TITLE
fix: return 0 rather than -1 if PR not found

### DIFF
--- a/src/github.ts
+++ b/src/github.ts
@@ -622,7 +622,7 @@ export class GitHub {
         `PR https://github.com/${this.owner}/${this.repo}/pull/${openReleasePR.number} remained the same`,
         CheckpointType.Failure
       );
-      return -1;
+      return 0;
     }
 
     //  Actually update the files for the release:


### PR DESCRIPTION
0 now represents a pull request that requires no updates.