### PR TITLE
fix: forks do not work for GitHub Actions or apps

### DIFF
--- a/package.json
+++ b/package.json
@@ -62,7 +62,7 @@
     "@octokit/request": "^5.3.4",
     "@octokit/rest": "^18.0.4",
     "chalk": "^4.0.0",
-    "code-suggester": "^1.3.0",
+    "code-suggester": "^1.4.0-beta.0",
     "concat-stream": "^2.0.0",
     "conventional-changelog-conventionalcommits": "^4.4.0",
     "conventional-changelog-writer": "^4.0.6",

--- a/package.json
+++ b/package.json
@@ -62,7 +62,7 @@
     "@octokit/request": "^5.3.4",
     "@octokit/rest": "^18.0.4",
     "chalk": "^4.0.0",
-    "code-suggester": "^1.4.0-beta.0",
+    "code-suggester": "^1.4.0",
     "concat-stream": "^2.0.0",
     "conventional-changelog-conventionalcommits": "^4.4.0",
     "conventional-changelog-writer": "^4.0.6",

--- a/src/github.ts
+++ b/src/github.ts
@@ -638,6 +638,7 @@ export class GitHub {
         description: options.body,
         primary: defaultBranch,
         force: true,
+        fork: false,
         message: options.title,
       },
       {level: 'silent'}


### PR DESCRIPTION
forking does not work in the context of a GitHub Action. Let's turn off the functionality for now.

_Note: dependent on work happening in code-suggester that's not landed yet._
