### PR TITLE
feat: initial support for pre-releases

### DIFF
--- a/src/github.ts
+++ b/src/github.ts
@@ -432,16 +432,32 @@ export class GitHub {
     return refResponse.data.object.sha;
   }
 
-  async latestTag(prefix?: string): Promise<GitHubTag | undefined> {
+  async latestTag(
+    prefix?: string,
+    preRelease = false
+  ): Promise<GitHubTag | undefined> {
     const tags: {[version: string]: GitHubTag} = await this.allTags(prefix);
     const versions = Object.keys(tags).filter(t => {
       // remove any pre-releases from the list:
-      return !t.includes('-');
+      return preRelease || !t.includes('-');
     });
     // no tags have been created yet.
     if (versions.length === 0) return undefined;
 
-    versions.sort(semver.rcompare);
+    // We use a slightly modified version of semver's sorting algorithm, which
+    // prefixes the numeric part of a pre-release with '0's, so that
+    // 010 is greater than > 002.
+    versions.sort((v1, v2) => {
+      if (v1.includes('-')) {
+        const [prefix, suffix] = v1.split('-');
+        v1 = prefix + '-' + suffix.replace(/[a-zA-Z.]/, '').padStart(6, '0');
+      }
+      if (v2.includes('-')) {
+        const [prefix, suffix] = v2.split('-');
+        v2 = prefix + '-' + suffix.replace(/[a-zA-Z.]/, '').padStart(6, '0');
+      }
+      return semver.rcompare(v1, v2);
+    });
     return {
       name: tags[versions[0]].name,
       sha: tags[versions[0]].sha,

--- a/test/github.ts
+++ b/test/github.ts
@@ -155,5 +155,50 @@ describe('GitHub', () => {
       expect(latestTag!.version).to.equal('1.2.0');
       req.done();
     });
+
+    it('returns pre-releases as latest, when preRelease is true', async () => {
+      const req = nock('https://api.github.com')
+        .get('/repos/fake/fake/tags?per_page=100')
+        .reply(200, [
+          {
+            name: 'v1.2.0',
+            commit: {sha: 'abc123'},
+            version: 'v1.2.0',
+          },
+          {
+            name: 'v1.3.0-beta.0',
+            commit: {sha: 'abc123'},
+            version: 'v1.3.0',
+          },
+          {
+            name: 'v1.1.0',
+            commit: {sha: 'abc123'},
+            version: 'v1.1.0',
+          },
+          {
+            name: 'v1.4.0-beta10',
+            commit: {sha: 'abc123'},
+            version: 'v1.3.0',
+          },
+          {
+            name: 'v1.4.0-beta2',
+            commit: {sha: 'abc123'},
+            version: 'v1.3.0',
+          },
+          {
+            name: 'v1.4.0-beta0',
+            commit: {sha: 'abc123'},
+            version: 'v1.3.0',
+          },
+          {
+            name: 'v1.3.0',
+            commit: {sha: 'abc123'},
+            version: 'v1.1.0',
+          },
+        ]);
+      const latestTag = await github.latestTag(undefined, true);
+      expect(latestTag!.version).to.equal('1.4.0-beta10');
+      req.done();
+    });
   });
 });


### PR DESCRIPTION
This adds support for pre-releases, prior to the first major version of the library being shipped (_v1.0.0-alpha1_, `v1.0.0-alpha2`, etc).

This is for the benefit of `dotnet` which uses this approach.