### PR TITLE
fix: sort commits from graphql output by descending commit date so we get fresh results

### DIFF
--- a/src/github.ts
+++ b/src/github.ts
@@ -242,7 +242,8 @@ export class GitHub {
       const response = await this.graphqlRequest({
         query: `query commitsWithFiles($cursor: String, $owner: String!, $repo: String!, $baseBranch: String!, $perPage: Int, $maxFilesChanged: Int, $path: String) {
           repository(owner: $owner, name: $repo) {
-            refs(first: 1, refPrefix: "refs/heads/", query: $baseBranch) {
+            refs(first: 1, refPrefix: "refs/heads/", query: $baseBranch,
+                  orderBy:{field:TAG_COMMIT_DATE, direction:DESC}) {
               edges {
                 node {
                   target {
@@ -330,7 +331,8 @@ export class GitHub {
       const response = await this.graphqlRequest({
         query: `query commitsWithLabels($cursor: String, $owner: String!, $repo: String!, $baseBranch: String!, $perPage: Int, $maxLabels: Int, $path: String) {
           repository(owner: $owner, name: $repo) {
-            refs(first: 1, refPrefix: "refs/heads/", query: $baseBranch) {
+            refs(first: 1, refPrefix: "refs/heads/", query: $baseBranch,
+                  orderBy:{field:TAG_COMMIT_DATE, direction:DESC}) {
               edges {
                 node {
                   target {


### PR DESCRIPTION
Fix for a bug found in the work for https://github.com/googleapis/release-please/issues/428