### PR TITLE
fix: using two query based connections at once (refs, and history) seems to have undefined search results

### DIFF
--- a/src/github.ts
+++ b/src/github.ts
@@ -64,7 +64,12 @@ import {
 } from './graphql-to-commits';
 import {Update} from './updaters/update';
 
-const VERSION_FROM_BRANCH_RE = /^.*:release-(.*)$/;
+// Short explanation of this regex:
+// - skip the owner tag (e.g. googleapis)
+// - make sure the branch name starts with "release"
+// - skip everything up to the last "-v"
+// - take everything after the v as a match group
+const VERSION_FROM_BRANCH_RE = /^.*:release.*-v(?=[^v]+$)(.+)$/;
 
 export interface OctokitAPIs {
   graphql: Function;

--- a/src/graphql-to-commits.ts
+++ b/src/graphql-to-commits.ts
@@ -34,19 +34,11 @@ export interface Commit {
 
 interface CommitHistoryGraphQLResponse {
   repository: {
-    refs: {
-      edges: RefNode[];
+    ref: {
+      target: {
+        history: CommitHistory;
+      };
     };
-  };
-}
-
-interface RefNode {
-  node: RefTarget;
-}
-
-interface RefTarget {
-  target: {
-    history: CommitHistory;
   };
 }
 
@@ -89,8 +81,7 @@ export async function graphqlToCommits(
   github: GitHub,
   response: CommitHistoryGraphQLResponse
 ): Promise<CommitsResponse> {
-  const commitHistory: CommitHistory =
-    response.repository.refs.edges[0].node.target.history;
+  const commitHistory: CommitHistory = response.repository.ref.target.history;
   const commits: CommitsResponse = {
     endCursor: commitHistory.pageInfo.endCursor,
     hasNextPage: commitHistory.pageInfo.hasNextPage,

--- a/test/github.ts
+++ b/test/github.ts
@@ -193,6 +193,37 @@ describe('GitHub', () => {
       },
     ];
 
+    it('handles monorepo composite branch names properly', async () => {
+      const sampleResults = [
+        {
+          base: {
+            label: 'fake:main',
+          },
+          head: {
+            label: 'fake:release-complex-package_name-v1-v1.1.0',
+          },
+          merged_at: new Date().toISOString(),
+        },
+        {
+          base: {
+            label: 'fake:main',
+          },
+          head: {
+            label: 'fake:release-complex-package_name-v2.1-v2.0.0-beta',
+          },
+          merged_at: new Date().toISOString(),
+        },
+      ];
+      req
+        .get(
+          '/repos/fake/fake/pulls?state=closed&per_page=100&sort=updated&direction=desc'
+        )
+        .reply(200, sampleResults);
+      const latestTag = await github.latestTag();
+      expect(latestTag!.version).to.equal('1.1.0');
+      req.done();
+    });
+
     it('returns the latest tag on the main branch, based on PR date', async () => {
       req
         .get(


### PR DESCRIPTION
Using `refs` in conjunction with `history` seems to result in undefined search results from `history`, this is likely due to the composite query.

We can apparently specify a ref name directly.