### PR TITLE
fix: pagination logic broken in merge

### DIFF
--- a/src/github.ts
+++ b/src/github.ts
@@ -291,12 +291,12 @@ export class GitHub {
                         }
                       }
                     }
+                    pageInfo {
+                      endCursor
+                      hasNextPage
+                    }
                   }
                 }
-              }
-              pageInfo {
-                endCursor
-                hasNextPage
               }
             }
           }
@@ -307,7 +307,7 @@ export class GitHub {
         path,
         perPage,
         repo: this.repo,
-        baseBranch,
+        baseRef: `refs/heads/${baseBranch}`,
       });
       return graphqlToCommits(this, response);
     } catch (err) {


### PR DESCRIPTION
When merging @feywind's logic with my logic for pagination, it looks like the pagination and branch info were left in the wrong portion of the graphql query.