### PR TITLE
fix(graphql): graphql query requested pagination at wrong level/did n…

### DIFF
--- a/__snapshots__/java-yoshi.js
+++ b/__snapshots__/java-yoshi.js
@@ -118,3 +118,15 @@ exports['JavaYoshi creates a snapshot PR if an explicit release is requested, bu
   ]
 ]
 `
+
+exports['graphql-body-java-release'] = {
+  'query': 'query commitsWithLabels($cursor: String, $owner: String!, $repo: String!, $baseRef: String!, $perPage: Int, $maxLabels: Int, $path: String) {\n          repository(owner: $owner, name: $repo) {\n            ref(qualifiedName: $baseRef) {\n              target {\n                ... on Commit {\n                  history(first: $perPage, after: $cursor, path: $path) {\n                    edges {\n                      node {\n                        ... on Commit {\n                          message\n                          oid\n                          associatedPullRequests(first: 1) {\n                            edges {\n                              node {\n                                ... on PullRequest {\n                                  number\n                                  mergeCommit {\n                                    oid\n                                  }\n                                  labels(first: $maxLabels) {\n                                    edges {\n                                      node {\n                                        name\n                                      }\n                                    }\n                                  }\n                                }\n                              }\n                            }\n                          }\n                        }\n                      }\n                    }\n                    pageInfo {\n                      endCursor\n                      hasNextPage\n                    }\n                  }\n                }\n              }\n            }\n          }\n        }',
+  'variables': {
+    'maxLabels': 16,
+    'owner': 'googleapis',
+    'path': null,
+    'perPage': 100,
+    'repo': 'java-trace',
+    'baseRef': 'refs/heads/master'
+  }
+}

--- a/__snapshots__/node.js
+++ b/__snapshots__/node.js
@@ -79,3 +79,39 @@ exports['Node run creates release PR relative to a path 1'] = `
   ]
 ]
 `
+
+exports['graphql-body-'] = {
+  'query': 'query commitsWithFiles($cursor: String, $owner: String!, $repo: String!, $baseRef: String!, $perPage: Int, $maxFilesChanged: Int, $path: String) {\n          repository(owner: $owner, name: $repo) {\n            ref(qualifiedName: $baseRef) {\n              target {\n                ... on Commit {\n                  history(first: $perPage, after: $cursor, path: $path) {\n                    edges {\n                      node {\n                        ... on Commit {\n                          message\n                          oid\n                          associatedPullRequests(first: 1) {\n                            edges {\n                              node {\n                                ... on PullRequest {\n                                  number\n                                  mergeCommit {\n                                    oid\n                                  }\n                                  files(first: $maxFilesChanged) {\n                                    edges {\n                                      node {\n                                        path\n                                      }\n                                    }\n                                    pageInfo {\n                                      endCursor\n                                      hasNextPage\n                                    }\n                                  }\n                                }\n                              }\n                            }\n                          }\n                        }\n                      }\n                    }\n                    pageInfo {\n                      endCursor\n                      hasNextPage\n                    }\n                  }\n                }\n              }\n            }\n          }\n        }',
+  'variables': {
+    'maxFilesChanged': 64,
+    'owner': 'googleapis',
+    'path': null,
+    'perPage': 100,
+    'repo': 'node-test-repo',
+    'baseRef': 'refs/heads/master'
+  }
+}
+
+exports['graphql-body-with-package-lock'] = {
+  'query': 'query commitsWithFiles($cursor: String, $owner: String!, $repo: String!, $baseRef: String!, $perPage: Int, $maxFilesChanged: Int, $path: String) {\n          repository(owner: $owner, name: $repo) {\n            ref(qualifiedName: $baseRef) {\n              target {\n                ... on Commit {\n                  history(first: $perPage, after: $cursor, path: $path) {\n                    edges {\n                      node {\n                        ... on Commit {\n                          message\n                          oid\n                          associatedPullRequests(first: 1) {\n                            edges {\n                              node {\n                                ... on PullRequest {\n                                  number\n                                  mergeCommit {\n                                    oid\n                                  }\n                                  files(first: $maxFilesChanged) {\n                                    edges {\n                                      node {\n                                        path\n                                      }\n                                    }\n                                    pageInfo {\n                                      endCursor\n                                      hasNextPage\n                                    }\n                                  }\n                                }\n                              }\n                            }\n                          }\n                        }\n                      }\n                    }\n                    pageInfo {\n                      endCursor\n                      hasNextPage\n                    }\n                  }\n                }\n              }\n            }\n          }\n        }',
+  'variables': {
+    'maxFilesChanged': 64,
+    'owner': 'googleapis',
+    'path': null,
+    'perPage': 100,
+    'repo': 'node-test-repo',
+    'baseRef': 'refs/heads/master'
+  }
+}
+
+exports['graphql-body-with-path'] = {
+  'query': 'query commitsWithFiles($cursor: String, $owner: String!, $repo: String!, $baseRef: String!, $perPage: Int, $maxFilesChanged: Int, $path: String) {\n          repository(owner: $owner, name: $repo) {\n            ref(qualifiedName: $baseRef) {\n              target {\n                ... on Commit {\n                  history(first: $perPage, after: $cursor, path: $path) {\n                    edges {\n                      node {\n                        ... on Commit {\n                          message\n                          oid\n                          associatedPullRequests(first: 1) {\n                            edges {\n                              node {\n                                ... on PullRequest {\n                                  number\n                                  mergeCommit {\n                                    oid\n                                  }\n                                  files(first: $maxFilesChanged) {\n                                    edges {\n                                      node {\n                                        path\n                                      }\n                                    }\n                                    pageInfo {\n                                      endCursor\n                                      hasNextPage\n                                    }\n                                  }\n                                }\n                              }\n                            }\n                          }\n                        }\n                      }\n                    }\n                    pageInfo {\n                      endCursor\n                      hasNextPage\n                    }\n                  }\n                }\n              }\n            }\n          }\n        }',
+  'variables': {
+    'maxFilesChanged': 64,
+    'owner': 'googleapis',
+    'path': 'packages/foo',
+    'perPage': 100,
+    'repo': 'node-test-repo',
+    'baseRef': 'refs/heads/master'
+  }
+}

--- a/src/github.ts
+++ b/src/github.ts
@@ -371,12 +371,12 @@ export class GitHub {
                         }
                       }
                     }
+                    pageInfo {
+                      endCursor
+                      hasNextPage
+                    }
                   }
                 }
-              }
-              pageInfo {
-                endCursor
-                hasNextPage
               }
             }
           }
@@ -387,7 +387,7 @@ export class GitHub {
         path,
         perPage,
         repo: this.repo,
-        baseBranch,
+        baseRef: `refs/heads/${baseBranch}`,
       });
       return graphqlToCommits(this, response);
     } catch (err) {

--- a/test/releasers/java-yoshi.ts
+++ b/test/releasers/java-yoshi.ts
@@ -90,7 +90,10 @@ describe('JavaYoshi', () => {
           merged_at: new Date().toISOString(),
         },
       ])
-      .post('/graphql')
+      .post('/graphql', (body: object) => {
+        snapshot('graphql-body-java-release', body);
+        return true;
+      })
       .reply(200, {
         data: graphql,
       })

--- a/test/releasers/node.ts
+++ b/test/releasers/node.ts
@@ -69,7 +69,10 @@ function mockRequest(snapName: string, requestPrefix = '') {
         labels: [],
       },
     ])
-    .post('/graphql')
+    .post('/graphql', (body: object) => {
+      snapshot(`graphql-body-${snapName}`, body);
+      return true;
+    })
     .reply(200, {
       data: graphql,
     })


### PR DESCRIPTION
When the `graphql` logic was reverted to use `ref`, pagination was left at the wrong level in the graphql query.

The variable being set for baseRef was also incorrect.