### PR TITLE
feat: Support the Ruby releaser from the static ReleasePRFactory

### DIFF
--- a/src/release-pr-factory.ts
+++ b/src/release-pr-factory.ts
@@ -18,6 +18,7 @@ import {getReleasers} from './releasers';
 
 import {Node} from './releasers/node';
 import {Python} from './releasers/python';
+import {Ruby} from './releasers/ruby';
 import {Simple} from './releasers/simple';
 import {TerraformModule} from './releasers/terraform-module';
 
@@ -50,6 +51,8 @@ export class ReleasePRFactory {
         return new Node(releaseOptions);
       case 'python':
         return new Python(releaseOptions);
+      case 'ruby':
+        return new Ruby(releaseOptions);
       case 'simple':
         return new Simple(releaseOptions);
       case 'terraform-module':

--- a/src/release-pr-factory.ts
+++ b/src/release-pr-factory.ts
@@ -52,7 +52,7 @@ export class ReleasePRFactory {
       case 'python':
         return new Python(releaseOptions);
       case 'ruby':
-        return new Ruby(releaseOptions);
+        return new Ruby(releaseOptions as RubyReleasePROptions);
       case 'simple':
         return new Simple(releaseOptions);
       case 'terraform-module':

--- a/src/release-pr.ts
+++ b/src/release-pr.ts
@@ -52,6 +52,7 @@ export interface BuildOptions {
   snapshot?: boolean;
   lastPackageVersion?: string;
   octokitAPIs?: OctokitAPIs;
+  versionFile?: string;
 }
 
 export interface ReleasePROptions extends BuildOptions {


### PR DESCRIPTION
Needed so that the GitHub Action can invoke the Ruby releaser.