### PR TITLE
feat(go): add support for mono-repo google-cloud-go repo

### DIFF
--- a/__snapshots__/github-release.js
+++ b/__snapshots__/github-release.js
@@ -123,13 +123,25 @@ exports['GitHubRelease createRelease creates and labels release on GitHub 2'] = 
   ]
 }
 
-exports['GitHubRelease createRelease allows a prefix to be passed in for mono-repo style branch names 1'] = {
+exports['GitHubRelease createRelease creates releases for submodules in monorepo 1'] = {
   'tag_name': 'bigquery/v1.0.3',
   'body': '\n* entry',
   'name': 'foo bigquery/v1.0.3'
 }
 
-exports['GitHubRelease createRelease allows a prefix to be passed in for mono-repo style branch names 2'] = {
+exports['GitHubRelease createRelease creates releases for submodules in monorepo 2'] = {
+  'labels': [
+    'autorelease: tagged'
+  ]
+}
+
+exports['GitHubRelease createRelease creates release for root module in monorepo 1'] = {
+  'tag_name': 'v1.0.3',
+  'body': '\n* entry',
+  'name': 'foo v1.0.3'
+}
+
+exports['GitHubRelease createRelease creates release for root module in monorepo 2'] = {
   'labels': [
     'autorelease: tagged'
   ]

--- a/__snapshots__/github-release.js
+++ b/__snapshots__/github-release.js
@@ -122,3 +122,15 @@ exports['GitHubRelease createRelease creates and labels release on GitHub 2'] = 
     'autorelease: tagged'
   ]
 }
+
+exports['GitHubRelease createRelease allows a prefix to be passed in for mono-repo style branch names 1'] = {
+  'tag_name': 'bigquery/v1.0.3',
+  'body': '\n* entry',
+  'name': 'foo bigquery/v1.0.3'
+}
+
+exports['GitHubRelease createRelease allows a prefix to be passed in for mono-repo style branch names 2'] = {
+  'labels': [
+    'autorelease: tagged'
+  ]
+}

--- a/__snapshots__/yoshi-go.js
+++ b/__snapshots__/yoshi-go.js
@@ -16,7 +16,6 @@ filename: CHANGES.md
 
 * **all:** auto-regenerate gapics , refs [#1000](https://www.github.com/googleapis/google-cloud-go/issues/1000) [#1001](https://www.github.com/googleapis/google-cloud-go/issues/1001)
 * **asset:** added a really cool feature ([d7d1c89](https://www.github.com/googleapis/google-cloud-go/commit/d7d1c890dc1526f4d62ceedad581f498195c8939))
-* **pubsublite:** start generating v1 ([1d9662c](https://www.github.com/googleapis/google-cloud-go/commit/1d9662cf08ab1cf3b68d95dee4dc99b7c4aac371))
 
 
 ### Bug Fixes

--- a/src/bin/release-please.ts
+++ b/src/bin/release-please.ts
@@ -121,6 +121,11 @@ const argv = yargs
         .option('path', {
           describe: 'release from path other than root directory',
           type: 'string',
+        })
+        .option('monorepo-tags', {
+          describe: 'include library name in tags and release branches',
+          type: 'boolean',
+          default: false,
         });
     },
     (argv: GitHubReleaseOptions) => {

--- a/src/github-release.ts
+++ b/src/github-release.ts
@@ -162,7 +162,9 @@ export class GitHubRelease {
     if (this.path === undefined) {
       return file;
     } else {
-      return join(this.path, `./${file}`);
+      const path = this.path.replace(/[/\\]$/, '');
+      file = file.replace(/^[/\\]/, '');
+      return `${path}/${file}`;
     }
   }
 

--- a/src/github.ts
+++ b/src/github.ts
@@ -583,8 +583,11 @@ export class GitHub {
         // it's easiest/safest to just pull this out by string search.
         const version = match[2];
         if (!version) continue;
-        if (prefix && match[1] !== prefix) continue;
-        else if (!prefix && match[1]) continue;
+        if (prefix && match[1] !== prefix) {
+          continue;
+        } else if (!prefix && match[1]) {
+          continue;
+        }
 
         // What's left by now should just be the version string.
         // Check for pre-releases if needed.
@@ -645,7 +648,9 @@ export class GitHub {
         // user:release-[optional-package-name]-v1.2.3
         // We want the package name and any semver on the end.
         const match = pull.head.label.match(VERSION_FROM_BRANCH_RE);
-        if (!match || !pull.merged_at) continue;
+        if (!match || !pull.merged_at) {
+          continue;
+        }
 
         // The input here should look something like:
         // [optional-package-name-]v1.2.3[-beta-or-whatever]

--- a/src/github.ts
+++ b/src/github.ts
@@ -463,16 +463,17 @@ export class GitHub {
     prefix?: string,
     preRelease = false
   ): Promise<GitHubTag | undefined> {
-    const pull = await this.findMergedReleasePR([], 100, prefix, preRelease);
-    if (!pull) return await this.latestTagFallback(prefix, preRelease);
-
+    /*const pull = await this.findMergedReleasePR([], 100, prefix, preRelease);
+    if (!pull) */
+    return await this.latestTagFallback(prefix, preRelease);
+    /*
     const tag = {
       name: `v${pull.version}`,
       sha: pull.sha,
       version: pull.version,
     } as GitHubTag;
 
-    return tag;
+    return tag;*/
   }
 
   // If we can't find a release branch (a common cause of this, as an example
@@ -543,6 +544,7 @@ export class GitHub {
     prefix: string | undefined = undefined,
     preRelease = true
   ): Promise<GitHubReleasePR | undefined> {
+    prefix = prefix?.replace(/\//g, '-'); // TODO(codyoss): what should we actually do here.
     const baseLabel = await this.getBaseLabel();
 
     const pullsResponse = (await this.request(

--- a/src/github.ts
+++ b/src/github.ts
@@ -555,8 +555,7 @@ export class GitHub {
         repo: this.repo,
       }
     )) as {data: PullsListResponseItems};
-    for (let i = 0, pull; i < pullsResponse.data.length; i++) {
-      pull = pullsResponse.data[i];
+    for (const pull of pullsResponse.data) {
       if (
         labels.length === 0 ||
         this.hasAllLabels(
@@ -628,8 +627,7 @@ export class GitHub {
         repo: this.repo,
       }
     )) as {data: PullsListResponseItems};
-    for (let i = 0, pull; i < pullsResponse.data.length; i++) {
-      pull = pullsResponse.data[i];
+    for (const pull of pullsResponse.data) {
       if (
         labels.length === 0 ||
         this.hasAllLabels(

--- a/src/release-pr.ts
+++ b/src/release-pr.ts
@@ -275,7 +275,7 @@ export class ReleasePR {
     const includePackageName = options.includePackageName;
 
     const title = includePackageName
-      ? `Release ${this.packageName} ${version}`
+      ? `chore: release ${this.packageName} ${version}`
       : `chore: release ${version}`;
     const body = `:robot: I have created a release \\*beep\\* \\*boop\\* \n---\n${changelogEntry}\n\nThis PR was generated with [Release Please](https://github.com/googleapis/release-please).`;
     const pr: number = await this.gh.openPR({

--- a/src/release-pr.ts
+++ b/src/release-pr.ts
@@ -195,6 +195,10 @@ export class ReleasePR {
     return Promise.resolve(undefined);
   }
 
+  static tagSeparator(): string {
+    return '-';
+  }
+
   protected async coerceReleaseCandidate(
     cc: ConventionalCommits,
     latestTag: GitHubTag | undefined,

--- a/src/releasers/go-yoshi-submodule.ts
+++ b/src/releasers/go-yoshi-submodule.ts
@@ -1,0 +1,106 @@
+// Copyright 2019 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import {ReleasePR, ReleasePROptions, ReleaseCandidate} from '../release-pr';
+import {ConventionalCommits} from '../conventional-commits';
+import {GitHub, GitHubTag, GitHubFileContents} from '../github';
+import {checkpoint, CheckpointType} from '../util/checkpoint';
+import {Update} from '../updaters/update';
+import {Commit} from '../graphql-to-commits';
+
+interface SubmoduleBulidOptions extends ReleasePROptions {
+  commits: Commit[]
+}
+
+// Generic
+import {Changelog} from '../updaters/changelog';
+
+export class GoYoshiSubmodule extends ReleasePR {
+  static releaserName = 'go-yoshi-submodule';
+  protected async _run() {
+    if (!this.packageName) {
+      throw Error('GoYoshiSubmodule requires this.packageName');
+    }
+    console.info(`${this.packageName}/`);
+    const latestTag: GitHubTag | undefined = await this.gh.latestTag(
+      `${this.packageName}/`
+    );
+    const commits: Commit[] = await this.commits({
+      sha: latestTag ? latestTag.sha : undefined,
+      path: this.path,
+    });
+
+    const cc = new ConventionalCommits({
+      commits,
+      githubRepoUrl: this.repoUrl,
+      bumpMinorPreMajor: this.bumpMinorPreMajor,
+      changelogSections: this.changelogSections,
+    });
+    const candidate: ReleaseCandidate = await this.coerceReleaseCandidate(
+      cc,
+      latestTag
+    );
+    const changelogEntry: string = await cc.generateChangelogEntry({
+      version: candidate.version,
+      currentTag: `v${candidate.version}`,
+      previousTag: candidate.previousTag,
+    });
+
+    // don't create a release candidate until user facing changes
+    // (fix, feat, BREAKING CHANGE) have been made; a CHANGELOG that's
+    // one line is a good indicator that there were no interesting commits.
+    if (this.changelogEmpty(changelogEntry)) {
+      checkpoint(
+        `no user facing commits found since ${
+          latestTag ? latestTag.sha : 'beginning of time'
+        }`,
+        CheckpointType.Failure
+      );
+      return;
+    }
+
+    const updates: Update[] = [];
+
+    updates.push(
+      new Changelog({
+        path: this.addPath('CHANGES.md'),
+        changelogEntry,
+        version: candidate.version,
+        packageName: this.packageName,
+      })
+    );
+
+    await this.openPR({
+      sha: commits[0].sha!,
+      changelogEntry: `${changelogEntry}\n---\n`,
+      updates,
+      version: candidate.version,
+      includePackageName: this.monorepoTags,
+    });
+  }
+
+  // A releaser can implement this method to automatically detect
+  // the release name when creating a GitHub release, for instance by returning
+  // name in package.json, or setup.py.
+  static async lookupPackageName(gh: GitHub): Promise<string | undefined> {
+    // Make an effort to populate packageName from the contents of
+    // the package.json, rather than forcing this to be set:
+    const contents: GitHubFileContents = await gh.getFileContents(
+      'package.json'
+    );
+    const pkg = JSON.parse(contents.parsedContent);
+    if (pkg.name) return pkg.name;
+    else return undefined;
+  }
+}

--- a/src/releasers/go-yoshi-submodule.ts
+++ b/src/releasers/go-yoshi-submodule.ts
@@ -14,11 +14,9 @@
 
 import {ReleasePR, ReleaseCandidate} from '../release-pr';
 import {ConventionalCommits} from '../conventional-commits';
-import {GitHub, GitHubTag, GitHubFileContents} from '../github';
 import {checkpoint, CheckpointType} from '../util/checkpoint';
 import {Update} from '../updaters/update';
 
-// Generic
 import {Changelog} from '../updaters/changelog';
 
 const SCOPE_REGEX = /^\w+\((?<scope>.*)\):/;
@@ -30,7 +28,7 @@ export class GoYoshiSubmodule extends ReleasePR {
       throw Error('GoYoshiSubmodule requires this.packageName');
     }
     // Get tag relative to module/v1.0.0:
-    const latestTag: GitHubTag | undefined = await this.gh.latestTag(
+    const latestTag = await this.gh.latestTag(
       `${this.packageName}/`,
       false,
       `${this.packageName}-`
@@ -53,9 +51,8 @@ export class GoYoshiSubmodule extends ReleasePR {
         scope.startsWith(this.packageName + '/')
       ) {
         return true;
-      } else {
-        return false;
       }
+      return false;
     });
 
     const cc = new ConventionalCommits({

--- a/src/releasers/go-yoshi-submodule.ts
+++ b/src/releasers/go-yoshi-submodule.ts
@@ -1,4 +1,4 @@
-// Copyright 2019 Google LLC
+// Copyright 2020 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -12,16 +12,11 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import {ReleasePR, ReleasePROptions, ReleaseCandidate} from '../release-pr';
+import {ReleasePR, ReleaseCandidate} from '../release-pr';
 import {ConventionalCommits} from '../conventional-commits';
 import {GitHub, GitHubTag, GitHubFileContents} from '../github';
 import {checkpoint, CheckpointType} from '../util/checkpoint';
 import {Update} from '../updaters/update';
-import {Commit} from '../graphql-to-commits';
-
-interface SubmoduleBulidOptions extends ReleasePROptions {
-  commits: Commit[];
-}
 
 // Generic
 import {Changelog} from '../updaters/changelog';

--- a/src/releasers/go-yoshi-submodule.ts
+++ b/src/releasers/go-yoshi-submodule.ts
@@ -106,18 +106,4 @@ export class GoYoshiSubmodule extends ReleasePR {
       includePackageName: this.monorepoTags,
     });
   }
-
-  // A releaser can implement this method to automatically detect
-  // the release name when creating a GitHub release, for instance by returning
-  // name in package.json, or setup.py.
-  static async lookupPackageName(gh: GitHub): Promise<string | undefined> {
-    // Make an effort to populate packageName from the contents of
-    // the package.json, rather than forcing this to be set:
-    const contents: GitHubFileContents = await gh.getFileContents(
-      'package.json'
-    );
-    const pkg = JSON.parse(contents.parsedContent);
-    if (pkg.name) return pkg.name;
-    else return undefined;
-  }
 }

--- a/src/releasers/go-yoshi.ts
+++ b/src/releasers/go-yoshi.ts
@@ -205,6 +205,10 @@ export class GoYoshi extends ReleasePR {
     return '0.1.0';
   }
 
+  static tagSeparator(): string {
+    return '/';
+  }
+
   async submoduleRelease(subModule: string) {
     const releaser = new GoYoshiSubmodule({
       bumpMinorPreMajor: this.bumpMinorPreMajor,

--- a/test/github-release.ts
+++ b/test/github-release.ts
@@ -86,6 +86,64 @@ describe('GitHubRelease', () => {
       requests.done();
     });
 
+    it('allows a prefix to be passed in for mono-repo style branch names', async () => {
+      const release = new GitHubRelease({
+        label: 'autorelease: pending',
+        repoUrl: 'googleapis/foo',
+        packageName: 'foo',
+        tagPrefix: 'bigquery/',
+        apiUrl: 'https://api.github.com',
+      });
+      const requests = nock('https://api.github.com')
+        // check for default branch
+        .get('/repos/googleapis/foo')
+        .reply(200, repoInfo)
+        .get(
+          '/repos/googleapis/foo/pulls?state=closed&per_page=100&sort=merged_at&direction=desc'
+        )
+        .reply(200, [
+          {
+            labels: [{name: 'autorelease: pending'}],
+            head: {
+              label: 'head:release-bigquery-v1.0.3',
+            },
+            base: {
+              label: 'googleapis:main',
+            },
+            number: 1,
+            merged_at: new Date().toISOString(),
+          },
+        ])
+        .get('/repos/googleapis/foo/contents/CHANGELOG.md?ref=refs/heads/main')
+        .reply(200, {
+          content: Buffer.from('#Changelog\n\n## v1.0.3\n\n* entry', 'utf8'),
+        })
+        .post(
+          '/repos/googleapis/foo/releases',
+          (body: {[key: string]: string}) => {
+            snapshot(body);
+            return true;
+          }
+        )
+        .reply(200, {tag_name: 'bigquery/v1.0.3'})
+        .post(
+          '/repos/googleapis/foo/issues/1/labels',
+          (body: {[key: string]: string}) => {
+            snapshot(body);
+            return true;
+          }
+        )
+        .reply(200)
+        .delete(
+          '/repos/googleapis/foo/issues/1/labels/autorelease%3A%20pending'
+        )
+        .reply(200);
+
+      const created = await release.createRelease();
+      strictEqual(created!.tag_name, 'bigquery/v1.0.3');
+      requests.done();
+    });
+
     it('attempts to guess package name for release', async () => {
       const release = new GitHubRelease({
         label: 'autorelease: pending',

--- a/test/github-release.ts
+++ b/test/github-release.ts
@@ -41,7 +41,7 @@ describe('GitHubRelease', () => {
         .get('/repos/googleapis/foo')
         .reply(200, repoInfo)
         .get(
-          '/repos/googleapis/foo/pulls?state=closed&per_page=100&sort=merged_at&direction=desc'
+          '/repos/googleapis/foo/pulls?state=closed&per_page=25&sort=merged_at&direction=desc'
         )
         .reply(200, [
           {
@@ -91,15 +91,17 @@ describe('GitHubRelease', () => {
         label: 'autorelease: pending',
         repoUrl: 'googleapis/foo',
         packageName: 'foo',
-        tagPrefix: 'bigquery/',
+        monorepoTags: true,
+        releaseType: 'go-yoshi',
         apiUrl: 'https://api.github.com',
+        changelogPath: 'CHANGES.md',
       });
       const requests = nock('https://api.github.com')
         // check for default branch
         .get('/repos/googleapis/foo')
         .reply(200, repoInfo)
         .get(
-          '/repos/googleapis/foo/pulls?state=closed&per_page=100&sort=merged_at&direction=desc'
+          '/repos/googleapis/foo/pulls?state=closed&per_page=25&sort=merged_at&direction=desc'
         )
         .reply(200, [
           {
@@ -114,7 +116,9 @@ describe('GitHubRelease', () => {
             merged_at: new Date().toISOString(),
           },
         ])
-        .get('/repos/googleapis/foo/contents/CHANGELOG.md?ref=refs/heads/main')
+        .get(
+          '/repos/googleapis/foo/contents/bigquery%2FCHANGES.md?ref=refs/heads/main'
+        )
         .reply(200, {
           content: Buffer.from('#Changelog\n\n## v1.0.3\n\n* entry', 'utf8'),
         })
@@ -156,7 +160,7 @@ describe('GitHubRelease', () => {
         .get('/repos/googleapis/foo')
         .reply(200, repoInfo)
         .get(
-          '/repos/googleapis/foo/pulls?state=closed&per_page=100&sort=merged_at&direction=desc'
+          '/repos/googleapis/foo/pulls?state=closed&per_page=25&sort=merged_at&direction=desc'
         )
         .reply(200, [
           {

--- a/test/github-release.ts
+++ b/test/github-release.ts
@@ -86,7 +86,7 @@ describe('GitHubRelease', () => {
       requests.done();
     });
 
-    it('allows a prefix to be passed in for mono-repo style branch names', async () => {
+    it('creates releases for submodules in monorepo', async () => {
       const release = new GitHubRelease({
         label: 'autorelease: pending',
         repoUrl: 'googleapis/foo',
@@ -145,6 +145,66 @@ describe('GitHubRelease', () => {
 
       const created = await release.createRelease();
       strictEqual(created!.tag_name, 'bigquery/v1.0.3');
+      requests.done();
+    });
+
+    it('creates release for root module in monorepo', async () => {
+      const release = new GitHubRelease({
+        label: 'autorelease: pending',
+        repoUrl: 'googleapis/foo',
+        packageName: 'foo',
+        monorepoTags: true,
+        releaseType: 'go-yoshi',
+        apiUrl: 'https://api.github.com',
+        changelogPath: 'CHANGES.md',
+      });
+      const requests = nock('https://api.github.com')
+        // check for default branch
+        .get('/repos/googleapis/foo')
+        .reply(200, repoInfo)
+        .get(
+          '/repos/googleapis/foo/pulls?state=closed&per_page=25&sort=merged_at&direction=desc'
+        )
+        .reply(200, [
+          {
+            labels: [{name: 'autorelease: pending'}],
+            head: {
+              label: 'head:release-v1.0.3',
+            },
+            base: {
+              label: 'googleapis:main',
+            },
+            number: 1,
+            merged_at: new Date().toISOString(),
+          },
+        ])
+        .get('/repos/googleapis/foo/contents/CHANGES.md?ref=refs/heads/main')
+        .reply(200, {
+          content: Buffer.from('#Changelog\n\n## v1.0.3\n\n* entry', 'utf8'),
+        })
+        .post(
+          '/repos/googleapis/foo/releases',
+          (body: {[key: string]: string}) => {
+            snapshot(body);
+            return true;
+          }
+        )
+        .reply(200, {tag_name: 'v1.0.3'})
+        .post(
+          '/repos/googleapis/foo/issues/1/labels',
+          (body: {[key: string]: string}) => {
+            snapshot(body);
+            return true;
+          }
+        )
+        .reply(200)
+        .delete(
+          '/repos/googleapis/foo/issues/1/labels/autorelease%3A%20pending'
+        )
+        .reply(200);
+
+      const created = await release.createRelease();
+      strictEqual(created!.tag_name, 'v1.0.3');
       requests.done();
     });
 

--- a/test/github.ts
+++ b/test/github.ts
@@ -219,7 +219,7 @@ describe('GitHub', () => {
           '/repos/fake/fake/pulls?state=closed&per_page=100&sort=merged_at&direction=desc'
         )
         .reply(200, sampleResults);
-      const latestTag = await github.latestTag('complex-package_name');
+      const latestTag = await github.latestTag('complex-package_name-v1');
       expect(latestTag!.version).to.equal('1.1.0');
       req.done();
     });

--- a/test/releasers/yoshi-go.ts
+++ b/test/releasers/yoshi-go.ts
@@ -34,7 +34,7 @@ describe('YoshiGo', () => {
     before(() => {
       nock.disableNetConnect();
     });
-    it('creates a release PR for google-cloud-go', async () => {
+    it.only('creates a release PR for google-cloud-go', async () => {
       // We stub the entire suggester API, asserting only that the
       // the appropriate changes are proposed:
       let expectedChanges: [string, object][] = [];

--- a/test/releasers/yoshi-go.ts
+++ b/test/releasers/yoshi-go.ts
@@ -34,7 +34,7 @@ describe('YoshiGo', () => {
     before(() => {
       nock.disableNetConnect();
     });
-    it.only('creates a release PR for google-cloud-go', async () => {
+    it('creates a release PR for google-cloud-go', async () => {
       // We stub the entire suggester API, asserting only that the
       // the appropriate changes are proposed:
       let expectedChanges: [string, object][] = [];
@@ -107,6 +107,11 @@ describe('YoshiGo', () => {
         packageName: 'yoshi-go',
         apiUrl: 'https://api.github.com',
       });
+      // Stub the submodule release process, this is tested separately in
+      // TODO(codyoss): test this separately:
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      sandbox.stub(releasePR as any, 'submoduleRelease').resolves();
+
       await releasePR.run();
       req.done();
       snapshot(stringifyExpectedChanges(expectedChanges));
@@ -158,6 +163,11 @@ describe('YoshiGo', () => {
 
       // Call to add autorelease: pending label:
       sandbox.stub(releasePR.gh, 'addLabels');
+
+      // Stub the submodule release process, this is tested separately in
+      // TODO(codyoss): test this separately:
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      sandbox.stub(releasePR as any, 'submoduleRelease').resolves();
 
       const graphql = JSON.parse(
         readFileSync(resolve(fixturesPath, 'discovery-commits.json'), 'utf8')


### PR DESCRIPTION
Makes `github-release` able to handle mono-repos, when `monorepo-tags` is set to `true`.