### PR TITLE
fix(go): we should not include - in the suffix

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,8 +37,6 @@
   },
   "homepage": "https://github.com/googleapis/release-please#readme",
   "devDependencies": {
-    "@microsoft/api-documenter": "^7.8.10",
-    "@microsoft/api-extractor": "^7.8.10",
     "@octokit/types": "^5.0.0",
     "@types/chai": "^4.1.7",
     "@types/mocha": "^8.0.0",

--- a/src/releasers/go-yoshi-submodule.ts
+++ b/src/releasers/go-yoshi-submodule.ts
@@ -31,7 +31,7 @@ export class GoYoshiSubmodule extends ReleasePR {
     const latestTag = await this.gh.latestTag(
       `${this.packageName}/`,
       false,
-      `${this.packageName}-`
+      `${this.packageName}`
     );
     const commits = (
       await this.commits({

--- a/src/releasers/go-yoshi.ts
+++ b/src/releasers/go-yoshi.ts
@@ -176,7 +176,7 @@ export class GoYoshi extends ReleasePR {
       changelogEntry,
       updates,
       version: candidate.version,
-      includePackageName: this.monorepoTags,
+      includePackageName: false,
     });
   }
 


### PR DESCRIPTION
We were looking for a `-` suffix in the go releaser and should not be.