### PR TITLE
fix(nodejs): do not include org in branch name

### DIFF
--- a/src/github.ts
+++ b/src/github.ts
@@ -109,7 +109,7 @@ export interface GitHubFileContents {
   parsedContent: string;
 }
 
-interface GitHubPR {
+export interface GitHubPR {
   branch: string;
   fork: boolean;
   version: string;

--- a/src/release-pr.ts
+++ b/src/release-pr.ts
@@ -72,7 +72,7 @@ interface GetCommitsOptions {
   path?: string;
 }
 
-interface OpenPROptions {
+export interface OpenPROptions {
   sha: string;
   changelogEntry: string;
   updates: Update[];
@@ -277,6 +277,10 @@ export class ReleasePR {
     const updates = options.updates;
     const version = options.version;
     const includePackageName = options.includePackageName;
+    // Do not include npm style @org/ prefixes in the branch name:
+    const branchPrefix = this.packageName.match(/^@[\w-]+\//)
+      ? this.packageName.split('/')[1]
+      : this.packageName;
 
     const title = includePackageName
       ? `chore: release ${this.packageName} ${version}`
@@ -284,7 +288,7 @@ export class ReleasePR {
     const body = `:robot: I have created a release \\*beep\\* \\*boop\\* \n---\n${changelogEntry}\n\nThis PR was generated with [Release Please](https://github.com/googleapis/release-please).`;
     const pr: number = await this.gh.openPR({
       branch: includePackageName
-        ? `release-${this.packageName}-v${version}`
+        ? `release-${branchPrefix}-v${version}`
         : `release-v${version}`,
       version,
       sha,


### PR DESCRIPTION
Do not include the `@foo/` prefix in the branch name selected for Node.js monorepos.