### PR TITLE
fix: include multi-line breaking changes

### DIFF
--- a/__snapshots__/conventional-commits.js
+++ b/__snapshots__/conventional-commits.js
@@ -15,3 +15,21 @@ exports['ConventionalCommits generateChangelogEntry does not include content two
 
 * upgrade to Node 7 ([abc345](https://www.github.com/bcoe/release-please/commit/abc345))
 `
+
+exports['ConventionalCommits generateChangelogEntry includes multi-line breaking changes 1'] = `
+## v1.0.0 (1665-10-10)
+
+
+### ⚠ BREAKING CHANGES
+
+* we were on Node 6 second line third line
+
+### Features
+
+* awesome feature ([abc678](https://www.github.com/bcoe/release-please/commit/abc678))
+
+
+### Miscellaneous Chores
+
+* upgrade to Node 7 ([abc345](https://www.github.com/bcoe/release-please/commit/abc345))
+`

--- a/src/conventional-commits.ts
+++ b/src/conventional-commits.ts
@@ -93,7 +93,12 @@ class PostProcessCommits extends Transform {
     done: Function
   ) {
     chunk.notes.forEach(note => {
-      note.text = note.text.split(/\r?\n/)[0];
+      let text = '';
+      for (const chunk of note.text.split(/\r?\n/)) {
+        if (chunk === '') break;
+        else text += `${chunk} `;
+      }
+      note.text = text.trim();
     });
     this.push(JSON.stringify(chunk, null, 4) + '\n');
     done();

--- a/test/conventional-commits.ts
+++ b/test/conventional-commits.ts
@@ -46,6 +46,26 @@ describe('ConventionalCommits', () => {
   });
 
   describe('generateChangelogEntry', () => {
+    it('includes multi-line breaking changes', async () => {
+      const cc = new ConventionalCommits({
+        commits: [
+          {
+            message:
+              'chore: upgrade to Node 7\n\nBREAKING CHANGE: we were on Node 6\nsecond line\nthird line',
+            sha: 'abc345',
+            files: [],
+          },
+          {message: 'feat: awesome feature', sha: 'abc678', files: []},
+        ],
+        githubRepoUrl: 'https://github.com/bcoe/release-please.git',
+        bumpMinorPreMajor: true,
+      });
+      const cl = await cc.generateChangelogEntry({
+        version: 'v1.0.0',
+      });
+      snapshot(cl.replace(/[0-9]{4}-[0-9]{2}-[0-9]{2}/g, '1665-10-10'));
+    });
+
     // See: https://github.com/googleapis/nodejs-logging/commit/ce29b498ebb357403c093053d1b9989f1a56f5af
     it('does not include content two newlines after BREAKING CHANGE', async () => {
       const cc = new ConventionalCommits({


### PR DESCRIPTION
Include multiline breaking changes, unless separated by two lines.

Fixes #440 