### PR TITLE
fix: pass gh instance to submodule

### DIFF
--- a/src/releasers/go-yoshi.ts
+++ b/src/releasers/go-yoshi.ts
@@ -224,6 +224,9 @@ export class GoYoshi extends ReleasePR {
       releaseType: 'go-yoshi-submodule',
       changelogSections: this.changelogSections,
     });
+    // This GitHub instance has potentially been instantiated with
+    // credentials from probot, make sure to chain it through:
+    releaser.gh = this.gh;
     await releaser.run();
   }
 }


### PR DESCRIPTION
This crops up in the GitHub APP, which passes in the authenticated instance from probbot.