### PR TITLE
feat(monorepos): support submodules in nested folders

### DIFF
--- a/__snapshots__/github-release.js
+++ b/__snapshots__/github-release.js
@@ -146,3 +146,15 @@ exports['GitHubRelease createRelease creates release for root module in monorepo
     'autorelease: tagged'
   ]
 }
+
+exports['GitHubRelease createRelease supports submodules in nested folders 1'] = {
+  'tag_name': 'bigquery/v1.0.3',
+  'body': '\n* entry',
+  'name': 'foo bigquery/v1.0.3'
+}
+
+exports['GitHubRelease createRelease supports submodules in nested folders 2'] = {
+  'labels': [
+    'autorelease: tagged'
+  ]
+}

--- a/src/github-release.ts
+++ b/src/github-release.ts
@@ -101,7 +101,8 @@ export class GitHubRelease {
       // e.g., release-bigquery-v1.0.0, then assume we are releasing a
       // module from within the "bigquery" folder:
       if (this.monorepoTags && gitHubReleasePR.packageName) {
-        this.path = gitHubReleasePR.packageName;
+        this.path = rootPath;
+        this.path = this.addPath(gitHubReleasePR.packageName);
       } else {
         // As in the case of google-cloud-go, a repo may contain both a
         // top level module, and submodules. If no submodule is found in
@@ -149,7 +150,7 @@ export class GitHubRelease {
       const release = await this.gh.createRelease(
         this.packageName,
         this.monorepoTags && this.path
-          ? `${this.path}${tagSeparator}${version}`
+          ? `${gitHubReleasePR.packageName}${tagSeparator}${version}`
           : version,
         gitHubReleasePR.sha,
         latestReleaseNotes


### PR DESCRIPTION
Allow path to be provided in conjunction with `monorepoTags`, indicating that submodules are released from a nested path, e.g.,

`src/apis/*`