### PR TITLE
feat!: return major/minor/patch when creating GitHub release

### DIFF
--- a/src/github-release.ts
+++ b/src/github-release.ts
@@ -17,7 +17,6 @@ import {checkpoint, CheckpointType} from './util/checkpoint';
 import {ReleasePRFactory} from './release-pr-factory';
 import {GitHub, OctokitAPIs} from './github';
 import {parse} from 'semver';
-import { string } from 'yargs';
 
 // eslint-disable-next-line @typescript-eslint/no-var-requires
 const parseGithubRepoUrl = require('parse-github-repo-url');

--- a/src/github-release.ts
+++ b/src/github-release.ts
@@ -15,11 +15,24 @@
 import chalk = require('chalk');
 import {checkpoint, CheckpointType} from './util/checkpoint';
 import {ReleasePRFactory} from './release-pr-factory';
-import {GitHub, OctokitAPIs, ReleaseCreateResponse} from './github';
+import {GitHub, OctokitAPIs} from './github';
+import {parse} from 'semver';
+import { string } from 'yargs';
 
 // eslint-disable-next-line @typescript-eslint/no-var-requires
 const parseGithubRepoUrl = require('parse-github-repo-url');
 const GITHUB_RELEASE_LABEL = 'autorelease: tagged';
+
+interface ReleaseResponse {
+  major: number;
+  minor: number;
+  patch: number;
+  version: string;
+  sha: string;
+  html_url: string;
+  tag_name: string;
+  pr: number;
+}
 
 export interface GitHubReleaseOptions {
   label: string;
@@ -64,7 +77,7 @@ export class GitHubRelease {
     this.gh = this.gitHubInstance(options.octokitAPIs);
   }
 
-  async createRelease(): Promise<ReleaseCreateResponse | undefined> {
+  async createRelease(): Promise<ReleaseResponse | undefined> {
     // In most configurations, createRelease() should be called close to when
     // a release PR is merged, e.g., a GitHub action that kicks off this
     // workflow on merge. For tis reason, we can pull a fairly small number of PRs:
@@ -131,7 +144,23 @@ export class GitHubRelease {
     // Remove 'autorelease: pending' which indicates a GitHub release
     // has not yet been created.
     await this.gh.removeLabels(this.labels, gitHubReleasePR.number);
-    return release;
+
+    const parsedVersion = parse(version, {loose: true});
+    if (parsedVersion) {
+      return {
+        major: parsedVersion.major,
+        minor: parsedVersion.minor,
+        patch: parsedVersion.patch,
+        sha: gitHubReleasePR.sha,
+        version,
+        pr: gitHubReleasePR.number,
+        html_url: release.html_url,
+        tag_name: release.tag_name,
+      };
+    } else {
+      console.warn(`failed to parse version informatino from ${version}`);
+      return undefined;
+    }
   }
 
   addPath(file: string) {

--- a/test/github-release.ts
+++ b/test/github-release.ts
@@ -67,7 +67,7 @@ describe('GitHubRelease', () => {
             return true;
           }
         )
-        .reply(200, {tag_name: 'v1.0.2'})
+        .reply(200, {tag_name: 'v1.0.3'})
         .post(
           '/repos/googleapis/foo/issues/1/labels',
           (body: {[key: string]: string}) => {
@@ -82,7 +82,10 @@ describe('GitHubRelease', () => {
         .reply(200);
 
       const created = await release.createRelease();
-      strictEqual(created!.tag_name, 'v1.0.2');
+      strictEqual(created!.tag_name, 'v1.0.3');
+      strictEqual(created!.major, 1);
+      strictEqual(created!.minor, 0);
+      strictEqual(created!.patch, 3);
       requests.done();
     });
 
@@ -146,6 +149,9 @@ describe('GitHubRelease', () => {
 
       const created = await release.createRelease();
       strictEqual(created!.tag_name, 'bigquery/v1.0.3');
+      strictEqual(created!.major, 1);
+      strictEqual(created!.minor, 0);
+      strictEqual(created!.patch, 3);
       requests.done();
     });
 


### PR DESCRIPTION
Return major/minor/patch information in output from creating a GitHub release, this can in turn be chained into another action which pushes a tag.

Refs https://github.com/google-github-actions/release-please-action/issues/91