### PR TITLE
feat: allow cleanup steps to be turned off

### DIFF
--- a/src/bin/release-please.ts
+++ b/src/bin/release-please.ts
@@ -86,6 +86,11 @@ const argv = yargs
           describe: 'include library name in tags and release branches',
           type: 'boolean',
           default: false,
+        })
+        .option('clean', {
+          describe: 'should stale release PRs be cleaned post run?',
+          default: true,
+          type: 'boolean',
         });
     },
     (argv: ReleasePROptions) => {

--- a/src/release-pr.ts
+++ b/src/release-pr.ts
@@ -53,6 +53,7 @@ export interface BuildOptions {
   lastPackageVersion?: string;
   octokitAPIs?: OctokitAPIs;
   versionFile?: string;
+  clean?: boolean;
 }
 
 export interface ReleasePROptions extends BuildOptions {
@@ -86,6 +87,7 @@ export class ReleasePR {
   static releaserName = 'base';
 
   apiUrl: string;
+  clean: boolean;
   defaultBranch?: string;
   labels: string[];
   fork: boolean;
@@ -122,6 +124,7 @@ export class ReleasePR {
     this.lastPackageVersion = options.lastPackageVersion
       ? options.lastPackageVersion.replace(/^v/, '')
       : undefined;
+    this.clean = options.clean ?? true;
 
     this.gh = this.gitHubInstance(options.octokitAPIs);
 
@@ -304,7 +307,9 @@ export class ReleasePR {
         `${this.repoUrl} find stale PRs with label "${this.labels.join(',')}"`,
         CheckpointType.Success
       );
-      await this.closeStaleReleasePRs(pr, includePackageName);
+      if (this.clean) {
+        await this.closeStaleReleasePRs(pr, includePackageName);
+      }
     }
     return pr;
   }


### PR DESCRIPTION
This will allow the forking version of relese-please to run with less permissions enabled.