### PR TITLE
fix: do not add labels when running on fork

### DIFF
--- a/src/release-pr.ts
+++ b/src/release-pr.ts
@@ -302,12 +302,21 @@ export class ReleasePR {
     });
     // a return of undefined indicates that PR was not updated.
     if (pr) {
-      await this.gh.addLabels(this.labels, pr);
+      // If the PR is being created from a fork, it will not have permission
+      // to add nd remove labels from the PR:
+      if (!this.fork) {
+        await this.gh.addLabels(this.labels, pr);
+      } else {
+        checkpoint(
+          'release labels were not added, due to PR being created from fork',
+          CheckpointType.Failure
+        );
+      }
       checkpoint(
         `${this.repoUrl} find stale PRs with label "${this.labels.join(',')}"`,
         CheckpointType.Success
       );
-      if (this.clean) {
+      if (this.clean && !this.fork) {
         await this.closeStaleReleasePRs(pr, includePackageName);
       }
     }


### PR DESCRIPTION
Forks do not have permission to label.