### PR TITLE
feat(conventional-commits): support googleapis extension

### DIFF
--- a/__snapshots__/conventional-commits.js
+++ b/__snapshots__/conventional-commits.js
@@ -33,3 +33,43 @@ exports['ConventionalCommits generateChangelogEntry includes multi-line breaking
 
 * upgrade to Node 7 ([abc345](https://www.github.com/bcoe/release-please/commit/abc345))
 `
+
+exports['ConventionalCommits generateChangelogEntry supports additional markdown for breaking change, if prefixed with fourth-level header 1'] = `
+## v1.0.0 (1665-10-10)
+
+
+### ⚠ BREAKING CHANGES
+
+* we were on Node 6
+    #### deleted APIs
+    - deleted API
+
+### Features
+
+* awesome feature ([abc678](https://www.github.com/bcoe/release-please/commit/abc678))
+
+
+### Miscellaneous Chores
+
+* upgrade to Node 7 ([abc345](https://www.github.com/bcoe/release-please/commit/abc345))
+`
+
+exports['ConventionalCommits generateChangelogEntry supports additional markdown for breaking change, if prefixed with list 1'] = `
+## v1.0.0 (1665-10-10)
+
+
+### ⚠ BREAKING CHANGES
+
+* we were on Node 6
+    - deleted API foo
+    - deleted API bar
+
+### Features
+
+* awesome feature ([abc678](https://www.github.com/bcoe/release-please/commit/abc678))
+
+
+### Miscellaneous Chores
+
+* upgrade to Node 7 ([abc345](https://www.github.com/bcoe/release-please/commit/abc345))
+`

--- a/src/conventional-commits.ts
+++ b/src/conventional-commits.ts
@@ -94,15 +94,42 @@ class PostProcessCommits extends Transform {
   ) {
     chunk.notes.forEach(note => {
       let text = '';
+      let i = 0;
+      let extendedContext = false;
       for (const chunk of note.text.split(/\r?\n/)) {
+        if (i > 0 && hasExtendedContext(chunk) && !extendedContext) {
+          text = `${text.trim()}\n`;
+          extendedContext = true;
+        }
         if (chunk === '') break;
-        else text += `${chunk} `;
+        else if (extendedContext) {
+          text += `    ${chunk}\n`;
+        } else {
+          text += `${chunk} `;
+        }
+        i++;
       }
       note.text = text.trim();
     });
     this.push(JSON.stringify(chunk, null, 4) + '\n');
     done();
   }
+}
+
+// If someone wishes to include additional contextual information for a
+// BREAKING CHANGE, they can do so by starting the line after the initial
+// breaking change description with either:
+//
+// 1. a fourth-level header.
+// 2. a bulleted list (using either '*' or '-').
+//
+// BREAKING CHANGE: there were breaking changes
+// #### Deleted Endpoints
+// - endpoint 1
+// - endpoint 2
+function hasExtendedContext(line: string) {
+  if (line.match(/^#### |^[*-] /)) return true;
+  return false;
 }
 
 export class ConventionalCommits {

--- a/src/conventional-commits.ts
+++ b/src/conventional-commits.ts
@@ -117,7 +117,7 @@ class PostProcessCommits extends Transform {
 }
 
 // If someone wishes to include additional contextual information for a
-// BREAKING CHANGE, they can do so by starting the line after the initial
+// BREAKING CHANGE using markdown, they can do so by starting the line after the initial
 // breaking change description with either:
 //
 // 1. a fourth-level header.

--- a/test/conventional-commits.ts
+++ b/test/conventional-commits.ts
@@ -66,6 +66,46 @@ describe('ConventionalCommits', () => {
       snapshot(cl.replace(/[0-9]{4}-[0-9]{2}-[0-9]{2}/g, '1665-10-10'));
     });
 
+    it('supports additional markdown for breaking change, if prefixed with fourth-level header', async () => {
+      const cc = new ConventionalCommits({
+        commits: [
+          {
+            message:
+              'chore: upgrade to Node 7\n\nBREAKING CHANGE: we were on Node 6\n#### deleted APIs\n- deleted API',
+            sha: 'abc345',
+            files: [],
+          },
+          {message: 'feat: awesome feature', sha: 'abc678', files: []},
+        ],
+        githubRepoUrl: 'https://github.com/bcoe/release-please.git',
+        bumpMinorPreMajor: true,
+      });
+      const cl = await cc.generateChangelogEntry({
+        version: 'v1.0.0',
+      });
+      snapshot(cl.replace(/[0-9]{4}-[0-9]{2}-[0-9]{2}/g, '1665-10-10'));
+    });
+
+    it('supports additional markdown for breaking change, if prefixed with list', async () => {
+      const cc = new ConventionalCommits({
+        commits: [
+          {
+            message:
+              'chore: upgrade to Node 7\n\nBREAKING CHANGE: we were on Node 6\n- deleted API foo\n- deleted API bar',
+            sha: 'abc345',
+            files: [],
+          },
+          {message: 'feat: awesome feature', sha: 'abc678', files: []},
+        ],
+        githubRepoUrl: 'https://github.com/bcoe/release-please.git',
+        bumpMinorPreMajor: true,
+      });
+      const cl = await cc.generateChangelogEntry({
+        version: 'v1.0.0',
+      });
+      snapshot(cl.replace(/[0-9]{4}-[0-9]{2}-[0-9]{2}/g, '1665-10-10'));
+    });
+
     // See: https://github.com/googleapis/nodejs-logging/commit/ce29b498ebb357403c093053d1b9989f1a56f5af
     it('does not include content two newlines after BREAKING CHANGE', async () => {
       const cc = new ConventionalCommits({


### PR DESCRIPTION
Adds support for the parsing extension proposed by the googleapis repository.

---

@JustinBeckwith I was mistaken about markdown being stripped out during rendering, I'm open to trying out this approach; if you think it's worth providing customers with the additional context?