### PR TITLE
revert!: reverts adding clean option

### DIFF
--- a/src/bin/release-please.ts
+++ b/src/bin/release-please.ts
@@ -86,11 +86,6 @@ const argv = yargs
           describe: 'include library name in tags and release branches',
           type: 'boolean',
           default: false,
-        })
-        .option('clean', {
-          describe: 'should stale release PRs be cleaned post run?',
-          default: true,
-          type: 'boolean',
         });
     },
     (argv: ReleasePROptions) => {

--- a/src/release-pr.ts
+++ b/src/release-pr.ts
@@ -53,7 +53,6 @@ export interface BuildOptions {
   lastPackageVersion?: string;
   octokitAPIs?: OctokitAPIs;
   versionFile?: string;
-  clean?: boolean;
 }
 
 export interface ReleasePROptions extends BuildOptions {
@@ -87,7 +86,6 @@ export class ReleasePR {
   static releaserName = 'base';
 
   apiUrl: string;
-  clean: boolean;
   defaultBranch?: string;
   labels: string[];
   fork: boolean;
@@ -124,7 +122,6 @@ export class ReleasePR {
     this.lastPackageVersion = options.lastPackageVersion
       ? options.lastPackageVersion.replace(/^v/, '')
       : undefined;
-    this.clean = options.clean ?? true;
 
     this.gh = this.gitHubInstance(options.octokitAPIs);
 
@@ -316,7 +313,7 @@ export class ReleasePR {
         `${this.repoUrl} find stale PRs with label "${this.labels.join(',')}"`,
         CheckpointType.Success
       );
-      if (this.clean && !this.fork) {
+      if (!this.fork) {
         await this.closeStaleReleasePRs(pr, includePackageName);
       }
     }


### PR DESCRIPTION
The reason for clean was to avoid running certain operations from a fork, we can use the fork option for this instead.
