### PR TITLE
fix: logic was throwing out merge commits

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
   },
   "homepage": "https://github.com/googleapis/release-please#readme",
   "devDependencies": {
-    "@octokit/types": "^6.0.0",
+    "@octokit/types": "^5.5.0",
     "@types/chai": "^4.1.7",
     "@types/mocha": "^8.0.0",
     "@types/node": "^11.13.6",

--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
   },
   "homepage": "https://github.com/googleapis/release-please#readme",
   "devDependencies": {
-    "@octokit/types": "^5.5.0",
+    "@octokit/types": "^6.1.0",
     "@types/chai": "^4.1.7",
     "@types/mocha": "^8.0.0",
     "@types/node": "^11.13.6",

--- a/src/github.ts
+++ b/src/github.ts
@@ -559,7 +559,9 @@ export class GitHub {
         labels.length === 0 ||
         this.hasAllLabels(
           labels,
-          pull.labels.map(l => l.name)
+          pull.labels.map(l => {
+            return l.name + '';
+          })
         )
       ) {
         // it's expected that a release PR will have a
@@ -683,7 +685,7 @@ export class GitHub {
         })
       )) {
         for (let i = 0; response.data[i] !== undefined; i++) {
-          const issue = response.data[i] as IssuesListResponseItem;
+          const issue = response.data[i] as {title: string; state: string};
           if (issue.title.indexOf(title) !== -1 && issue.state === 'open') {
             return issue;
           }
@@ -833,8 +835,8 @@ export class GitHub {
         Authorization: `${this.proxyKey ? '' : 'token '}${this.token}`,
       },
     });
-    this.defaultBranch = data.default_branch;
-    return this.defaultBranch;
+    this.defaultBranch = (data as {default_branch: string}).default_branch;
+    return this.defaultBranch as string;
   }
 
   async closePR(prNumber: number) {

--- a/src/graphql-to-commits.ts
+++ b/src/graphql-to-commits.ts
@@ -126,18 +126,7 @@ async function graphqlToCommit(
 
   let prEdge: PREdge = commitEdge.node.associatedPullRequests.edges[0];
 
-  // if the commit.sha and mergeCommit.oid do not match, assume that this
-  // was a push directly to the default branch.
-  //
-  // TODO: investigate our motivations for skipping commits when
-  // commitEdge.node.oid and prEdge.node.mergeCommit.oid do not match (this
-  // caused issues for the legitimate use-case of merge commits.
-  if (
-    !commit.sha ||
-    !prEdge.node.mergeCommit ||
-    (commit.sha !== prEdge.node.mergeCommit.oid &&
-      !observedSHAs.has(prEdge.node.mergeCommit.oid))
-  ) {
+  if (!commit.sha) {
     return undefined;
   }
   observedSHAs.add(commit.sha);


### PR DESCRIPTION
I no longer remember why we were throwing out commits if their oid did not match the top level oid, and this was breaking repos that use a merge commit flow.