### PR TITLE
fix(ruby): use same tagging scheme as go

### DIFF
--- a/src/github.ts
+++ b/src/github.ts
@@ -544,6 +544,7 @@ export class GitHub {
     prefix: string | undefined = undefined,
     preRelease = true
   ): Promise<GitHubReleasePR | undefined> {
+    prefix = prefix?.endsWith('-') ? prefix.replace(/-$/, '') : prefix;
     const baseLabel = await this.getBaseLabel();
     const pullsResponse = (await this.request(
       `GET /repos/:owner/:repo/pulls?state=closed&per_page=${perPage}${

--- a/src/releasers/ruby.ts
+++ b/src/releasers/ruby.ts
@@ -43,7 +43,7 @@ export class Ruby extends ReleasePR {
     const latestTag: GitHubTag | undefined = await this.gh.latestTag(
       this.monorepoTags ? `${this.packageName}/` : undefined,
       false,
-      this.monorepoTags ? `${this.packageName}` : undefined
+      this.monorepoTags ? `${this.packageName}-` : undefined
     );
     const commits: Commit[] = await this.commits({
       sha: latestTag ? latestTag.sha : undefined,

--- a/src/releasers/ruby.ts
+++ b/src/releasers/ruby.ts
@@ -41,7 +41,9 @@ export class Ruby extends ReleasePR {
   }
   protected async _run(): Promise<number | undefined> {
     const latestTag: GitHubTag | undefined = await this.gh.latestTag(
-      this.monorepoTags ? `${this.packageName}-` : undefined
+      this.monorepoTags ? `${this.packageName}/` : undefined,
+      false,
+      this.monorepoTags ? `${this.packageName}` : undefined
     );
     const commits: Commit[] = await this.commits({
       sha: latestTag ? latestTag.sha : undefined,
@@ -105,6 +107,10 @@ export class Ruby extends ReleasePR {
       version: candidate.version,
       includePackageName: this.monorepoTags,
     });
+  }
+
+  static tagSeparator(): string {
+    return '/';
   }
 }
 

--- a/test/github.ts
+++ b/test/github.ts
@@ -219,7 +219,7 @@ describe('GitHub', () => {
           '/repos/fake/fake/pulls?state=closed&per_page=100&sort=merged_at&direction=desc'
         )
         .reply(200, sampleResults);
-      const latestTag = await github.latestTag('complex-package_name-v1');
+      const latestTag = await github.latestTag('complex-package_name-v1-');
       expect(latestTag!.version).to.equal('1.1.0');
       req.done();
     });


### PR DESCRIPTION
This switches to the same tagging scheme as go for ruby monorepos, which is what [google-api-ruby-client](https://github.com/googleapis/google-api-ruby-client) was assuming.