### PR TITLE
fix(go): pass monorepo-tags to open-pr; omit commits when publishing gapic submodule

### DIFF
--- a/__snapshots__/yoshi-go.js
+++ b/__snapshots__/yoshi-go.js
@@ -46,3 +46,17 @@ filename: CHANGES.md
 * **pubsub:** this commit should be included ([dcd1c89](https://www.github.com/googleapis/google-api-go-client/commit/dcd1c890dc1526f4d62ceedad581f498195c8939))
 * this commit should be included ([ecd1c89](https://www.github.com/googleapis/google-api-go-client/commit/ecd1c890dc1526f4d62ceedad581f489195c8939))
 `
+
+exports['YoshiGo supports releasing submodule from google-cloud-go 1'] = `
+
+filename: pubsublite/CHANGES.md
+
+
+
+
+
+# Changelog
+## [0.124.0](https://www.github.com/googleapis/google-cloud-go/compare/v0.123.4...v0.124.0) (1983-10-10)
+### Features
+* **pubsublite:** start generating v1 ([1d9662c](https://www.github.com/googleapis/google-cloud-go/commit/1d9662cf08ab1cf3b68d95dee4dc99b7c4aac371))
+`

--- a/src/releasers/go-yoshi.ts
+++ b/src/releasers/go-yoshi.ts
@@ -84,6 +84,19 @@ export class GoYoshi extends ReleasePR {
             }
           }
         }
+
+        // In the gapic repo, it's required that commits are prefixed with
+        // the packageName scope, in order for the commit to count towards
+        // a release:
+        if (this.monorepoTags) {
+          if (
+            scope === this.packageName ||
+            scope.startsWith(this.packageName + '/')
+          ) {
+            return true;
+          }
+          return false;
+        }
       }
 
       // Store the very first SHA returned, this represents the HEAD of the

--- a/src/releasers/go-yoshi.ts
+++ b/src/releasers/go-yoshi.ts
@@ -83,19 +83,15 @@ export class GoYoshi extends ReleasePR {
               return false;
             }
           }
-        }
-
-        // In the gapic repo, it's required that commits are prefixed with
-        // the packageName scope, in order for the commit to count towards
-        // a release:
-        if (this.monorepoTags) {
+        } else {
           if (
-            scope === this.packageName ||
-            scope.startsWith(this.packageName + '/')
+            !(
+              scope === this.packageName ||
+              scope.startsWith(this.packageName + '/')
+            )
           ) {
-            return true;
+            return false;
           }
-          return false;
         }
       }
 

--- a/src/releasers/go-yoshi.ts
+++ b/src/releasers/go-yoshi.ts
@@ -166,7 +166,7 @@ export class GoYoshi extends ReleasePR {
       changelogEntry,
       updates,
       version: candidate.version,
-      includePackageName: false,
+      includePackageName: this.monorepoTags,
     });
   }
 


### PR DESCRIPTION
we were skipping passing `monorepoTags` with our more complicated approach.