### PR TITLE
fix(go): submodules should bump patch

### DIFF
--- a/__snapshots__/yoshi-go.js
+++ b/__snapshots__/yoshi-go.js
@@ -56,7 +56,7 @@ filename: pubsublite/CHANGES.md
 
 
 # Changelog
-## [0.124.0](https://www.github.com/googleapis/google-cloud-go/compare/v0.123.4...v0.124.0) (1983-10-10)
-### Features
+### Bug Fixes
+### [0.123.5](https://www.github.com/googleapis/google-cloud-go/compare/v0.123.4...v0.123.5) (1983-10-10)
 * **pubsublite:** start generating v1 ([1d9662c](https://www.github.com/googleapis/google-cloud-go/commit/1d9662cf08ab1cf3b68d95dee4dc99b7c4aac371))
 `

--- a/src/releasers/go-yoshi.ts
+++ b/src/releasers/go-yoshi.ts
@@ -129,10 +129,11 @@ export class GoYoshi extends ReleasePR {
       githubRepoUrl: this.repoUrl,
       bumpMinorPreMajor: this.bumpMinorPreMajor,
     });
-    const candidate: ReleaseCandidate = await this.coerceReleaseCandidate(
-      cc,
-      latestTag
-    );
+    const candidate: ReleaseCandidate = this.monorepoTags
+      ? // Submodules use conventional commits to bump major/minor/patch:
+        await super.coerceReleaseCandidate(cc, latestTag)
+      : // Root module always bumps minor:
+        await this.coerceReleaseCandidate(cc, latestTag);
 
     // "closes" is a little presumptuous, let's just indicate that the
     // PR references these other commits:

--- a/src/releasers/go-yoshi.ts
+++ b/src/releasers/go-yoshi.ts
@@ -129,11 +129,13 @@ export class GoYoshi extends ReleasePR {
       githubRepoUrl: this.repoUrl,
       bumpMinorPreMajor: this.bumpMinorPreMajor,
     });
-    const candidate: ReleaseCandidate = this.monorepoTags
-      ? // Submodules use conventional commits to bump major/minor/patch:
-        await super.coerceReleaseCandidate(cc, latestTag)
-      : // Root module always bumps minor:
-        await this.coerceReleaseCandidate(cc, latestTag);
+    const candidate: ReleaseCandidate =
+      this.monorepoTags ||
+      !(this.isMultiClientRepo(repo) || this.isGapicRepo(repo))
+        ? // Submodules use conventional commits to bump major/minor/patch:
+          await super.coerceReleaseCandidate(cc, latestTag)
+        : // Root module always bumps minor:
+          await this.coerceReleaseCandidate(cc, latestTag);
 
     // "closes" is a little presumptuous, let's just indicate that the
     // PR references these other commits:

--- a/test/releasers/fixtures/yoshi-go/cloud-go-commits.json
+++ b/test/releasers/fixtures/yoshi-go/cloud-go-commits.json
@@ -195,7 +195,7 @@
             },
             {
               "node": {
-                "message": "feat(pubsublite): start generating v1",
+                "message": "fix(pubsublite): start generating v1",
                 "oid": "1d9662cf08ab1cf3b68d95dee4dc99b7c4aac371",
                 "associatedPullRequests": {
                   "edges": [


### PR DESCRIPTION
* GAPIC/Apiary should always bump `minor`.
* submodules should bump `fix`, if only fixes have occurred.

☝️ we should probably break this out into a separate setting eventually, if we want this to be useful to more generic go repositories.