### PR TITLE
feat(go): support pseudo context aware commits

### DIFF
--- a/__snapshots__/yoshi-go.js
+++ b/__snapshots__/yoshi-go.js
@@ -14,13 +14,16 @@ filename: CHANGES.md
 
 ### Features
 
-* **all:** auto-regenerate gapics , refs [#1000](https://www.github.com/googleapis/google-cloud-go/issues/1000) [#1001](https://www.github.com/googleapis/google-cloud-go/issues/1001)
 * **asset:** added a really cool feature ([d7d1c89](https://www.github.com/googleapis/google-cloud-go/commit/d7d1c890dc1526f4d62ceedad581f498195c8939))
+* **container:** contained it ([1f9663c](https://www.github.com/googleapis/google-cloud-go/commit/1f9663cf08ab1cf3b68d95dee4dc99b7c4aac371))
+* **oslogin:** a critical feature ([2f9663c](https://www.github.com/googleapis/google-cloud-go/commit/2f9663cf08ab1cf3b68d95dee4dc99b7c4aac372))
 
 
 ### Bug Fixes
 
 * **automl:** fixed a really bad bug ([d7d1c89](https://www.github.com/googleapis/google-cloud-go/commit/d7d1c890dc1526f4d62ceedad581f498195c8939))
+* **dialogflow:** fixed the cadence ([1f9663c](https://www.github.com/googleapis/google-cloud-go/commit/1f9663cf08ab1cf3b68d95dee4dc99b7c4aac371))
+* **securitycenter:** security things ([2f9663c](https://www.github.com/googleapis/google-cloud-go/commit/2f9663cf08ab1cf3b68d95dee4dc99b7c4aac372))
 
 `
 

--- a/test/releasers/fixtures/yoshi-go/cloud-go-commits.json
+++ b/test/releasers/fixtures/yoshi-go/cloud-go-commits.json
@@ -141,7 +141,7 @@
             },
             {
               "node": {
-                "message": "feat(all): auto-regenerate gapics (#1000)",
+                "message": "feat(all): auto-regenerate gapics (#1000)\n\nCommit Body\n\nChanges:\n-feat(oslogin): a critical feature\n\nPiperOrigin-RevId: 9999999\nSource-Link: somewhere\n\n-chore(oslogin): a random chore\n\nPiperOrigin-RevId: 9999999\nSource-Link: somewhere\n\n-fix(securitycenter): security things\n\nPiperOrigin-RevId: 9999999\nSource-Link: somewhere\n\n",
                 "oid": "2f9663cf08ab1cf3b68d95dee4dc99b7c4aac372",
                 "associatedPullRequests": {
                   "edges": [
@@ -168,7 +168,7 @@
             },
             {
               "node": {
-                "message": "feat(all): auto-regenerate gapics (#1001)\n\nCommit Body",
+                "message": "feat(all): auto-regenerate gapics (#1001)\n\nCommit Body\n\nChanges:\n-chore(trace): traced lines\n\nPiperOrigin-RevId: 9999999\nSource-Link: somewhere\n\n-feat(container): contained it\n\nPiperOrigin-RevId: 9999999\nSource-Link: somewhere\n\n-fix(dialogflow): fixed the cadence\n\nPiperOrigin-RevId: 9999999\nSource-Link: somewhere\n\n",
                 "oid": "1f9663cf08ab1cf3b68d95dee4dc99b7c4aac371",
                 "associatedPullRequests": {
                   "edges": [


### PR DESCRIPTION
Go regen PRs now enumerate all of the changes they contain. This
adds logic to parse those changes so individual entries appear in
the changelog. Example PR: googleapis/google-cloud-go#3391