### PR TITLE
fix(monorepos): github-release not created

### DIFF
--- a/__snapshots__/github-release.js
+++ b/__snapshots__/github-release.js
@@ -146,3 +146,15 @@ exports['GitHubRelease createRelease creates releases for submodule in monorepo 
     'autorelease: tagged'
   ]
 }
+
+exports['GitHubRelease createRelease attempts to guess package name for submodule release 1'] = {
+  'tag_name': '@google-cloud/foo-v1.0.3',
+  'body': '\n* entry',
+  'name': '@google-cloud/foo @google-cloud/foo-v1.0.3'
+}
+
+exports['GitHubRelease createRelease attempts to guess package name for submodule release 2'] = {
+  'labels': [
+    'autorelease: tagged'
+  ]
+}

--- a/src/github.ts
+++ b/src/github.ts
@@ -551,10 +551,12 @@ export class GitHub {
   async findMergedReleasePR(
     labels: string[],
     perPage = 100,
-    prefix: string | undefined = undefined,
+    branchPrefix: string | undefined = undefined,
     preRelease = true
   ): Promise<GitHubReleasePR | undefined> {
-    prefix = prefix?.endsWith('-') ? prefix.replace(/-$/, '') : prefix;
+    branchPrefix = branchPrefix?.endsWith('-')
+      ? branchPrefix.replace(/-$/, '')
+      : branchPrefix;
     const baseLabel = await this.getBaseLabel();
     const pullsResponse = (await this.request(
       `GET /repos/:owner/:repo/pulls?state=closed&per_page=${perPage}${
@@ -594,9 +596,9 @@ export class GitHub {
         // it's easiest/safest to just pull this out by string search.
         const version = match[2];
         if (!version) continue;
-        if (prefix && match[1] !== prefix) {
+        if (branchPrefix && match[1] !== branchPrefix) {
           continue;
-        } else if (!prefix && match[1]) {
+        } else if (!branchPrefix && match[1]) {
           continue;
         }
 

--- a/src/release-pr.ts
+++ b/src/release-pr.ts
@@ -23,6 +23,7 @@ type PullsListResponseItems = PromiseValue<
 import * as semver from 'semver';
 
 import {checkpoint, CheckpointType} from './util/checkpoint';
+import {packageBranchPrefix} from './util/package-branch-prefix';
 import {ConventionalCommits} from './conventional-commits';
 import {GitHub, GitHubTag, OctokitAPIs} from './github';
 import {Commit} from './graphql-to-commits';
@@ -98,6 +99,7 @@ export class ReleasePR {
   snapshot?: boolean;
   lastPackageVersion?: string;
   changelogSections?: [];
+  releaseType: string;
 
   constructor(options: ReleasePROptions) {
     this.bumpMinorPreMajor = options.bumpMinorPreMajor || false;
@@ -123,6 +125,7 @@ export class ReleasePR {
     this.gh = this.gitHubInstance(options.octokitAPIs);
 
     this.changelogSections = options.changelogSections;
+    this.releaseType = options.releaseType;
   }
 
   async run(): Promise<number | undefined> {
@@ -186,8 +189,12 @@ export class ReleasePR {
   // A releaser can implement this method to automatically detect
   // the release name when creating a GitHub release, for instance by returning
   // name in package.json, or setup.py.
-  // eslint-disable-next-line @typescript-eslint/no-unused-vars
-  static async lookupPackageName(gh: GitHub): Promise<string | undefined> {
+  static async lookupPackageName(
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
+    gh: GitHub,
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
+    path?: string
+  ): Promise<string | undefined> {
     return Promise.resolve(undefined);
   }
 
@@ -273,11 +280,10 @@ export class ReleasePR {
     const updates = options.updates;
     const version = options.version;
     const includePackageName = options.includePackageName;
-    // Do not include npm style @org/ prefixes in the branch name:
-    const branchPrefix = this.packageName.match(/^@[\w-]+\//)
-      ? this.packageName.split('/')[1]
-      : this.packageName;
-
+    const branchPrefix = packageBranchPrefix(
+      this.packageName,
+      this.releaseType
+    );
     const title = includePackageName
       ? `chore: release ${this.packageName} ${version}`
       : `chore: release ${version}`;
@@ -321,13 +327,17 @@ export class ReleasePR {
     return changelogEntry.split('\n').length === 1;
   }
 
-  addPath(file: string) {
-    if (this.path === undefined) {
+  static addPathStatic(file: string, path?: string) {
+    if (path === undefined) {
       return file;
     } else {
-      const path = this.path.replace(/[/\\]$/, '');
+      path = path.replace(/[/\\]$/, '');
       file = file.replace(/^[/\\]/, '');
       return `${path}/${file}`;
     }
+  }
+
+  addPath(file: string) {
+    return ReleasePR.addPathStatic(file, this.path);
   }
 }

--- a/src/util/package-branch-prefix.ts
+++ b/src/util/package-branch-prefix.ts
@@ -1,0 +1,30 @@
+// Copyright 2021 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// map from a packageName to the prefix used in release branch creation.
+export function packageBranchPrefix(packageName: string, releaseType?: string) {
+  let branchPrefix: string;
+  switch (releaseType) {
+    case 'node': {
+      branchPrefix = packageName.match(/^@[\w-]+\//)
+        ? packageName.split('/')[1]
+        : packageName;
+      break;
+    }
+    default: {
+      branchPrefix = packageName;
+    }
+  }
+  return branchPrefix;
+}

--- a/test/release-pr.ts
+++ b/test/release-pr.ts
@@ -415,4 +415,12 @@ describe('Release-PR', () => {
       expect(rp.openPROpts?.branch).to.equal('release-nodejs-v1.3.0');
     });
   });
+
+  describe('lookupPackageName', () => {
+    it('noop, child releasers need to implement', async () => {
+      const github = new GitHub({owner: 'googleapis', repo: 'node-test-repo'});
+      const name = await ReleasePR.lookupPackageName(github);
+      expect(name).to.be.undefined;
+    });
+  });
 });

--- a/test/util/package-branch-prefix.ts
+++ b/test/util/package-branch-prefix.ts
@@ -1,0 +1,43 @@
+// Copyright 2021 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import {packageBranchPrefix} from '../../src/util/package-branch-prefix';
+import {describe, it} from 'mocha';
+import {expect} from 'chai';
+
+describe('packageBranchPrefix', () => {
+  const inputs = [
+    // for 'node' releaseType, npm style package names get '@scope/' removed
+    {releaseType: 'node', packageName: '@foo/bar', branchPrefix: 'bar'},
+    {releaseType: 'node', packageName: '@foo-baz/bar', branchPrefix: 'bar'},
+    // currently anything else goes untouched
+    {releaseType: 'node', packageName: 'foo/bar', branchPrefix: 'foo/bar'},
+    {releaseType: 'node', packageName: 'foobar', branchPrefix: 'foobar'},
+    {releaseType: 'node', packageName: '', branchPrefix: ''},
+    {releaseType: 'python', packageName: 'foo/bar', branchPrefix: 'foo/bar'},
+    {releaseType: 'python', packageName: 'foobar', branchPrefix: 'foobar'},
+    {releaseType: 'python', packageName: '', branchPrefix: ''},
+    {releaseType: undefined, packageName: 'foo/bar', branchPrefix: 'foo/bar'},
+    {releaseType: undefined, packageName: 'foobar', branchPrefix: 'foobar'},
+    {releaseType: undefined, packageName: '', branchPrefix: ''},
+  ];
+  inputs.forEach(input => {
+    const {releaseType, packageName, branchPrefix} = input;
+    it(`maps packageName(${packageName}) to branchPrefix(${branchPrefix}) for releaseType(${releaseType})`, async () => {
+      expect(packageBranchPrefix(packageName, releaseType)).to.equal(
+        branchPrefix
+      );
+    });
+  });
+});


### PR DESCRIPTION
fixes a couple of issues:
1. if node releaser doesn't specify packageName then github-release
wasn't filtering merged PRs correctly.
2. when solving the above, we need to be consistent about the
relationship between packageName and the release branch name.


Fixes #668
