### PR TITLE
fix(webpack): make release-please webpackable

### DIFF
--- a/src/release-pr-factory.ts
+++ b/src/release-pr-factory.ts
@@ -16,13 +16,6 @@ import {BuildOptions, ReleasePR, ReleasePROptions} from './release-pr';
 import {RubyReleasePROptions} from './releasers/ruby';
 import {getReleasers} from './releasers';
 
-import {Node} from './releasers/node';
-import {Python} from './releasers/python';
-import {Ruby} from './releasers/ruby';
-import {Simple} from './releasers/simple';
-import {GoYoshi} from './releasers/go-yoshi';
-import {TerraformModule} from './releasers/terraform-module';
-
 export class ReleasePRFactory {
   static build(releaseType: string, options: BuildOptions): ReleasePR {
     const releaseOptions: ReleasePROptions | RubyReleasePROptions = {
@@ -40,28 +33,9 @@ export class ReleasePRFactory {
     }
     return releaser;
   }
-  // For the benefit of WebPack, we provide a static factory for a subset
-  // of the releasers available in the release please GitHub action:
+  // TODO(bcoe): this function is deprecated and should be removed in the
+  // next major;
   static buildStatic(releaseType: string, options: BuildOptions) {
-    const releaseOptions: ReleasePROptions = {
-      ...options,
-      ...{releaseType},
-    };
-    switch (releaseType) {
-      case 'node':
-        return new Node(releaseOptions);
-      case 'python':
-        return new Python(releaseOptions);
-      case 'ruby':
-        return new Ruby(releaseOptions as RubyReleasePROptions);
-      case 'simple':
-        return new Simple(releaseOptions);
-      case 'terraform-module':
-        return new TerraformModule(releaseOptions);
-      case 'go':
-        return new GoYoshi(releaseOptions);
-      default:
-        throw Error('unknown release type');
-    }
+    return this.build(releaseType, options);
   }
 }

--- a/src/releasers/index.ts
+++ b/src/releasers/index.ts
@@ -14,28 +14,34 @@
 
 import {ReleasePR} from '../release-pr';
 
-import {readdirSync} from 'fs';
-import {dirname} from 'path';
+import {GoYoshi} from './go-yoshi';
+import {JavaAuthYoshi} from './java-auth-yoshi';
+import {JavaBom} from './java-bom';
+import {JavaYoshi} from './java-yoshi';
+import {Node} from './node';
+import {PHPYoshi} from './php-yoshi';
+import {Python} from './python';
+import {RubyYoshi} from './ruby-yoshi';
+import {Ruby} from './ruby';
+import {Simple} from './simple';
+import {TerraformModule} from './terraform-module';
 
-// dynamically load all the releasers in the folder, and index based on their
-// releaserName property:
+// TODO: add any new releasers you create to this list:
 export function getReleasers(): {[key: string]: typeof ReleasePR} {
-  const releasers: {[key: string]: typeof ReleasePR} = {};
-  const root = dirname(require.resolve('./'));
-  for (const file of readdirSync(root, {withFileTypes: true})) {
-    if (
-      file.isFile() &&
-      !file.name.match(/.*\.ts.*/) &&
-      !file.name.match(/.*\.map$/) &&
-      !file.name.match(/index\.js/)
-    ) {
-      const obj = require(`./${file.name}`) as {
-        [key: string]: typeof ReleasePR;
-      };
-      const releaser = obj[Object.keys(obj)[0]];
-      releasers[releaser.releaserName] = releaser;
-    }
-  }
+  const releasers = {
+    go: GoYoshi, // TODO(codyoss): refactor this into a more generic go strategy.
+    'go-yoshi': GoYoshi,
+    'java-auth-yoshi': JavaAuthYoshi,
+    'java-bom': JavaBom,
+    'java-yoshi': JavaYoshi,
+    node: Node,
+    'php-yoshi': PHPYoshi,
+    python: Python,
+    'ruby-yoshi': RubyYoshi,
+    ruby: Ruby,
+    simple: Simple,
+    'terraform-module': TerraformModule,
+  };
   return releasers;
 }
 


### PR DESCRIPTION
Our approach of dynamically loading releasers does not work well for webpack, and therefore can break the GitHub actions which uses rollup.