### PR TITLE
feat: support @ and / when falling back to tags

### DIFF
--- a/src/github.ts
+++ b/src/github.ts
@@ -456,17 +456,8 @@ export class GitHub {
   async latestTag(
     prefix?: string,
     preRelease = false,
-    // Allow a branch prefix to differ from a tag prefix. This was required
-    // for google-cloud-go, which uses the tag prefix library/vx.y.z.
-    // this is a requirement in the go community.
-    branchPrefix?: string
   ): Promise<GitHubTag | undefined> {
-    const pull = await this.findMergedReleasePR(
-      [],
-      100,
-      branchPrefix ?? prefix,
-      preRelease
-    );
+    const pull = await this.findMergedReleasePR([], 100, prefix, preRelease);
     if (!pull) return await this.latestTagFallback(prefix, preRelease);
     const tag = {
       name: `v${pull.version}`,
@@ -514,6 +505,16 @@ export class GitHub {
   private async allTags(
     prefix?: string
   ): Promise<{[version: string]: GitHubTag}> {
+    // If we've fallen back to using allTags, support "-", "@", and "/" as a
+    // suffix separating the library name from the version #. This allows
+    // a repository to be seamlessly be migrated from a tool like lerna:
+    const prefixes: string[] = [];
+    if (prefix) {
+      prefix = prefix.substring(0, prefix.length - 1)
+      for (const suffix of ['-', '@', '/']) {
+        prefixes.push(`${prefix}${suffix}`);
+      }
+    }
     const tags: {[version: string]: GitHubTag} = {};
     for await (const response of this.octokit.paginate.iterator(
       this.decoratePaginateOpts({
@@ -526,8 +527,17 @@ export class GitHub {
       response.data.forEach((data: ReposListTagsResponseItems) => {
         // For monorepos, a prefix can be provided, indicating that only tags
         // matching the prefix should be returned:
-        if (prefix && !data.name.startsWith(prefix)) return;
-        let version = data.name.replace(prefix, '');
+        let version = data.name
+        if (prefix) {
+          let match = false;
+          for (prefix of prefixes) {
+            if (data.name.startsWith(prefix)) {
+              version = data.name.replace(prefix, '');
+              match = true;
+            }
+          }
+          if (!match) return;
+        }
         if ((version = semver.valid(version))) {
           tags[version] = {sha: data.commit.sha, name: data.name, version};
         }

--- a/src/github.ts
+++ b/src/github.ts
@@ -455,7 +455,7 @@ export class GitHub {
   // the branch we're configured for.
   async latestTag(
     prefix?: string,
-    preRelease = false,
+    preRelease = false
   ): Promise<GitHubTag | undefined> {
     const pull = await this.findMergedReleasePR([], 100, prefix, preRelease);
     if (!pull) return await this.latestTagFallback(prefix, preRelease);
@@ -510,7 +510,7 @@ export class GitHub {
     // a repository to be seamlessly be migrated from a tool like lerna:
     const prefixes: string[] = [];
     if (prefix) {
-      prefix = prefix.substring(0, prefix.length - 1)
+      prefix = prefix.substring(0, prefix.length - 1);
       for (const suffix of ['-', '@', '/']) {
         prefixes.push(`${prefix}${suffix}`);
       }
@@ -527,7 +527,7 @@ export class GitHub {
       response.data.forEach((data: ReposListTagsResponseItems) => {
         // For monorepos, a prefix can be provided, indicating that only tags
         // matching the prefix should be returned:
-        let version = data.name
+        let version = data.name;
         if (prefix) {
           let match = false;
           for (prefix of prefixes) {

--- a/src/releasers/go-yoshi.ts
+++ b/src/releasers/go-yoshi.ts
@@ -54,9 +54,8 @@ export class GoYoshi extends ReleasePR {
   static releaserName = 'go-yoshi';
   protected async _run(): Promise<number | undefined> {
     const latestTag = await this.gh.latestTag(
-      this.monorepoTags ? `${this.packageName}/` : undefined,
-      false,
-      this.monorepoTags ? `${this.packageName}` : undefined
+      this.monorepoTags ? `${this.packageName}-` : undefined,
+      false
     );
     // eslint-disable-next-line @typescript-eslint/no-unused-vars
     const [_owner, repo] = parseGithubRepoUrl(this.repoUrl);

--- a/src/releasers/ruby.ts
+++ b/src/releasers/ruby.ts
@@ -41,9 +41,8 @@ export class Ruby extends ReleasePR {
   }
   protected async _run(): Promise<number | undefined> {
     const latestTag: GitHubTag | undefined = await this.gh.latestTag(
-      this.monorepoTags ? `${this.packageName}/` : undefined,
-      false,
-      this.monorepoTags ? `${this.packageName}-` : undefined
+      this.monorepoTags ? `${this.packageName}-` : undefined,
+      false
     );
     const commits: Commit[] = await this.commits({
       sha: latestTag ? latestTag.sha : undefined,


### PR DESCRIPTION
Investigating moving a lerna project over to release-please, I noticed that tags have the `@` suffix rather than `-`. There have been a couple other languages that use releasa-please where the tags use `/`, rather than `-`.

Instead of making each of these a special case, this PR checks each suffix, this will make it easier to migrate to release-please from other tools.