### PR TITLE
fix(monorepo): remove package scope before matching merged PR

### DIFF
--- a/__snapshots__/github-release.js
+++ b/__snapshots__/github-release.js
@@ -146,3 +146,15 @@ exports['GitHubRelease createRelease creates releases for submodule in monorepo 
     'autorelease: tagged'
   ]
 }
+
+exports['GitHubRelease createRelease supports scoped node packages in a monorepo 1'] = {
+  'tag_name': '@googleapis/foo-v1.0.3',
+  'body': '\n* entry',
+  'name': '@googleapis/foo @googleapis/foo-v1.0.3'
+}
+
+exports['GitHubRelease createRelease supports scoped node packages in a monorepo 2'] = {
+  'labels': [
+    'autorelease: tagged'
+  ]
+}

--- a/src/github.ts
+++ b/src/github.ts
@@ -66,6 +66,7 @@ import {
   PREdge,
 } from './graphql-to-commits';
 import {Update} from './updaters/update';
+import {branchPrefix} from './util/branch-prefix';
 
 // Short explanation of this regex:
 // - skip the owner tag (e.g. googleapis)
@@ -584,7 +585,7 @@ export class GitHub {
         // it's easiest/safest to just pull this out by string search.
         const version = match[2];
         if (!version) continue;
-        if (prefix && match[1] !== prefix) {
+        if (prefix && match[1] !== branchPrefix(prefix)) {
           continue;
         } else if (!prefix && match[1]) {
           continue;

--- a/src/release-pr.ts
+++ b/src/release-pr.ts
@@ -22,6 +22,7 @@ type PullsListResponseItems = PromiseValue<
 
 import * as semver from 'semver';
 
+import {branchPrefix} from './util/branch-prefix';
 import {checkpoint, CheckpointType} from './util/checkpoint';
 import {ConventionalCommits} from './conventional-commits';
 import {GitHub, GitHubTag, OctokitAPIs} from './github';
@@ -273,10 +274,6 @@ export class ReleasePR {
     const updates = options.updates;
     const version = options.version;
     const includePackageName = options.includePackageName;
-    // Do not include npm style @org/ prefixes in the branch name:
-    const branchPrefix = this.packageName.match(/^@[\w-]+\//)
-      ? this.packageName.split('/')[1]
-      : this.packageName;
 
     const title = includePackageName
       ? `chore: release ${this.packageName} ${version}`
@@ -284,7 +281,7 @@ export class ReleasePR {
     const body = `:robot: I have created a release \\*beep\\* \\*boop\\* \n---\n${changelogEntry}\n\nThis PR was generated with [Release Please](https://github.com/googleapis/release-please). See [documentation](https://github.com/googleapis/release-please#release-please).`;
     const pr: number | undefined = await this.gh.openPR({
       branch: includePackageName
-        ? `release-${branchPrefix}-v${version}`
+        ? `release-${branchPrefix(this.packageName)}-v${version}`
         : `release-v${version}`,
       version,
       sha,

--- a/src/util/branch-prefix.ts
+++ b/src/util/branch-prefix.ts
@@ -1,0 +1,20 @@
+// Copyright 2021 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+export function branchPrefix(packageName: string) {
+  // Do not include npm style @org/ prefixes in the branch name:
+  return packageName.match(/^@[\w-]+\//)
+    ? packageName.split('/')[1]
+    : packageName;
+}

--- a/test/util/branch-prefix.ts
+++ b/test/util/branch-prefix.ts
@@ -1,0 +1,27 @@
+// Copyright 2021 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import {branchPrefix} from '../../src/util/branch-prefix';
+import {describe, it} from 'mocha';
+import {expect} from 'chai';
+
+describe('branchPrefix', () => {
+  it('should return package name when not scoped', () => {
+    expect(branchPrefix('package')).to.equal('package');
+  });
+
+  it('should remove scope from scoped package', () => {
+    expect(branchPrefix('@scope/package')).to.equal('package');
+  });
+});


### PR DESCRIPTION
- [x] Make sure to open an issue as a [bug/issue](https://github.com/googleapis/release-please/issues/new/choose) before writing your code!  That way we can discuss the change, evaluate designs, and agree on the general idea
- [x] Ensure the tests and linter pass
- [x] Code coverage does not decrease (if any source code was changed)
- [x] Appropriate docs were updated (if necessary)

Fixes #668 🦕

This is an attempt to reduce the scope of https://github.com/googleapis/release-please/pull/669 to make it easier to review and publish a fix to a blocking bug (happy to close this one if https://github.com/googleapis/release-please/pull/669 is close to being merged).
I think we should be able to add the logic to infer `packageName` in another PR (for me the priority for that fix is lower as there is a workaround of specifying it).
