### PR TITLE
fix(github-release): increasae page size finding release

### DIFF
--- a/src/github-release.ts
+++ b/src/github-release.ts
@@ -94,8 +94,8 @@ export class GitHubRelease {
 
     // In most configurations, createRelease() should be called close to when
     // a release PR is merged, e.g., a GitHub action that kicks off this
-    // workflow on merge. For tis reason, we can pull a fairly small number of PRs:
-    const pageSize = 25;
+    // workflow on merge. For this reason, we can pull a fairly small number of PRs:
+    const pageSize = 50;
     const gitHubReleasePR = await this.gh.findMergedReleasePR(
       this.labels,
       pageSize,

--- a/test/github-release.ts
+++ b/test/github-release.ts
@@ -42,7 +42,7 @@ describe('GitHubRelease', () => {
         .get('/repos/googleapis/foo')
         .reply(200, repoInfo)
         .get(
-          '/repos/googleapis/foo/pulls?state=closed&per_page=25&sort=merged_at&direction=desc'
+          '/repos/googleapis/foo/pulls?state=closed&per_page=50&sort=merged_at&direction=desc'
         )
         .reply(200, [
           {
@@ -106,7 +106,7 @@ describe('GitHubRelease', () => {
         .get('/repos/googleapis/foo')
         .reply(200, repoInfo)
         .get(
-          '/repos/googleapis/foo/pulls?state=closed&per_page=25&sort=merged_at&direction=desc'
+          '/repos/googleapis/foo/pulls?state=closed&per_page=50&sort=merged_at&direction=desc'
         )
         .reply(200, [
           {
@@ -172,7 +172,7 @@ describe('GitHubRelease', () => {
         .get('/repos/googleapis/foo')
         .reply(200, repoInfo)
         .get(
-          '/repos/googleapis/foo/pulls?state=closed&per_page=25&sort=merged_at&direction=desc'
+          '/repos/googleapis/foo/pulls?state=closed&per_page=50&sort=merged_at&direction=desc'
         )
         .reply(200, [
           {
@@ -233,7 +233,7 @@ describe('GitHubRelease', () => {
         .get('/repos/googleapis/foo')
         .reply(200, repoInfo)
         .get(
-          '/repos/googleapis/foo/pulls?state=closed&per_page=25&sort=merged_at&direction=desc'
+          '/repos/googleapis/foo/pulls?state=closed&per_page=50&sort=merged_at&direction=desc'
         )
         .reply(200, [
           {
@@ -297,7 +297,7 @@ describe('GitHubRelease', () => {
         .get('/repos/googleapis/foo')
         .reply(200, repoInfo)
         .get(
-          '/repos/googleapis/foo/pulls?state=closed&per_page=25&sort=merged_at&direction=desc'
+          '/repos/googleapis/foo/pulls?state=closed&per_page=50&sort=merged_at&direction=desc'
         )
         .reply(200, [
           {


### PR DESCRIPTION
In monorepos there's enough traffic on PRs that looking at the last 25 didn't catch a release.