### PR TITLE
fix(pagination): when tagging release, use updated, vs., created

### DIFF
--- a/src/github-release.ts
+++ b/src/github-release.ts
@@ -101,7 +101,9 @@ export class GitHubRelease {
       pageSize,
       this.monorepoTags
         ? packageBranchPrefix(this.packageName, this.releaseType)
-        : undefined
+        : undefined,
+      true,
+      'updated'
     );
     if (!gitHubReleasePR) {
       checkpoint('no recent release PRs found', CheckpointType.Failure);

--- a/src/github.ts
+++ b/src/github.ts
@@ -552,7 +552,8 @@ export class GitHub {
     labels: string[],
     perPage = 100,
     branchPrefix: string | undefined = undefined,
-    preRelease = true
+    preRelease = true,
+    sort = 'created'
   ): Promise<GitHubReleasePR | undefined> {
     branchPrefix = branchPrefix?.endsWith('-')
       ? branchPrefix.replace(/-$/, '')
@@ -561,7 +562,7 @@ export class GitHub {
     const pullsResponse = (await this.request(
       `GET /repos/:owner/:repo/pulls?state=closed&per_page=${perPage}${
         this.proxyKey ? `&key=${this.proxyKey}` : ''
-      }&sort=updated&direction=desc`,
+      }&sort=${sort}&direction=desc`,
       {
         owner: this.owner,
         repo: this.repo,

--- a/test/github.ts
+++ b/test/github.ts
@@ -298,7 +298,7 @@ describe('GitHub', () => {
       ];
       req
         .get(
-          '/repos/fake/fake/pulls?state=closed&per_page=100&sort=updated&direction=desc'
+          '/repos/fake/fake/pulls?state=closed&per_page=100&sort=created&direction=desc'
         )
         .reply(200, sampleResults);
       const latestTag = await github.latestTag('complex-package_name-v1-');
@@ -338,7 +338,7 @@ describe('GitHub', () => {
       ];
       req
         .get(
-          '/repos/fake/fake/pulls?state=closed&per_page=100&sort=updated&direction=desc'
+          '/repos/fake/fake/pulls?state=closed&per_page=100&sort=created&direction=desc'
         )
         .reply(200, sampleResults);
       const latestTag = await github.latestTag();
@@ -349,7 +349,7 @@ describe('GitHub', () => {
     it('returns the latest tag on the main branch, based on PR date', async () => {
       req
         .get(
-          '/repos/fake/fake/pulls?state=closed&per_page=100&sort=updated&direction=desc'
+          '/repos/fake/fake/pulls?state=closed&per_page=100&sort=created&direction=desc'
         )
         .reply(200, samplePrReturn);
       const latestTag = await github.latestTag();
@@ -367,7 +367,7 @@ describe('GitHub', () => {
 
       req
         .get(
-          '/repos/fake/fake/pulls?state=closed&per_page=100&sort=updated&direction=desc'
+          '/repos/fake/fake/pulls?state=closed&per_page=100&sort=created&direction=desc'
         )
         .reply(200, samplePrReturn);
       const latestTag = await github.latestTag();
@@ -378,7 +378,7 @@ describe('GitHub', () => {
     it('does not return pre-releases as latest tag', async () => {
       req
         .get(
-          '/repos/fake/fake/pulls?state=closed&per_page=100&sort=updated&direction=desc'
+          '/repos/fake/fake/pulls?state=closed&per_page=100&sort=created&direction=desc'
         )
         .reply(200, samplePrReturn);
       const latestTag = await github.latestTag();
@@ -389,7 +389,7 @@ describe('GitHub', () => {
     it('returns pre-releases on the main branch as latest, when preRelease is true', async () => {
       req
         .get(
-          '/repos/fake/fake/pulls?state=closed&per_page=100&sort=updated&direction=desc'
+          '/repos/fake/fake/pulls?state=closed&per_page=100&sort=created&direction=desc'
         )
         .reply(200, samplePrReturn);
       const latestTag = await github.latestTag(undefined, true);
@@ -407,7 +407,7 @@ describe('GitHub', () => {
 
       req
         .get(
-          '/repos/fake/fake/pulls?state=closed&per_page=100&sort=updated&direction=desc'
+          '/repos/fake/fake/pulls?state=closed&per_page=100&sort=created&direction=desc'
         )
         .reply(200, samplePrReturn);
       const latestTag = await github.latestTag(undefined, true);
@@ -417,7 +417,7 @@ describe('GitHub', () => {
     it('falls back to using tags, for simple case', async () => {
       req
         .get(
-          '/repos/fake/fake/pulls?state=closed&per_page=100&sort=updated&direction=desc'
+          '/repos/fake/fake/pulls?state=closed&per_page=100&sort=created&direction=desc'
         )
         .reply(200, [])
         .get('/repos/fake/fake/tags?per_page=100')
@@ -438,7 +438,7 @@ describe('GitHub', () => {
     it('falls back to using tags, when prefix is provided', async () => {
       req
         .get(
-          '/repos/fake/fake/pulls?state=closed&per_page=100&sort=updated&direction=desc'
+          '/repos/fake/fake/pulls?state=closed&per_page=100&sort=created&direction=desc'
         )
         .reply(200, [])
         .get('/repos/fake/fake/tags?per_page=100')
@@ -467,7 +467,7 @@ describe('GitHub', () => {
     it('allows for "@" rather than "-" when fallback used', async () => {
       req
         .get(
-          '/repos/fake/fake/pulls?state=closed&per_page=100&sort=updated&direction=desc'
+          '/repos/fake/fake/pulls?state=closed&per_page=100&sort=created&direction=desc'
         )
         .reply(200, [])
         .get('/repos/fake/fake/tags?per_page=100')
@@ -500,7 +500,7 @@ describe('GitHub', () => {
     it('allows for "/" rather than "-" when fallback used', async () => {
       req
         .get(
-          '/repos/fake/fake/pulls?state=closed&per_page=100&sort=updated&direction=desc'
+          '/repos/fake/fake/pulls?state=closed&per_page=100&sort=created&direction=desc'
         )
         .reply(200, [])
         .get('/repos/fake/fake/tags?per_page=100')

--- a/test/release-pr-factory.ts
+++ b/test/release-pr-factory.ts
@@ -53,13 +53,13 @@ describe('ReleasePRFactory', () => {
       );
       const req = nock('https://api.github.com')
         .get(
-          '/repos/googleapis/simple-test-repo/pulls?state=closed&per_page=100&sort=updated&direction=desc'
+          '/repos/googleapis/simple-test-repo/pulls?state=closed&per_page=100&sort=created&direction=desc'
         )
         .reply(200, undefined)
         // fetch semver tags, this will be used to determine
         // the delta since the last release.
         .get(
-          '/repos/googleapis/simple-test-repo/pulls?state=closed&per_page=100&sort=updated&direction=desc'
+          '/repos/googleapis/simple-test-repo/pulls?state=closed&per_page=100&sort=created&direction=desc'
         )
         .reply(200, [
           {
@@ -146,13 +146,13 @@ describe('ReleasePRFactory', () => {
       );
       const req = nock('https://api.github.com')
         .get(
-          '/repos/googleapis/simple-test-repo/pulls?state=closed&per_page=100&sort=updated&direction=desc'
+          '/repos/googleapis/simple-test-repo/pulls?state=closed&per_page=100&sort=created&direction=desc'
         )
         .reply(200, undefined)
         // fetch semver tags, this will be used to determine
         // the delta since the last release.
         .get(
-          '/repos/googleapis/simple-test-repo/pulls?state=closed&per_page=100&sort=updated&direction=desc'
+          '/repos/googleapis/simple-test-repo/pulls?state=closed&per_page=100&sort=created&direction=desc'
         )
         .reply(200, [
           {

--- a/test/release-pr.ts
+++ b/test/release-pr.ts
@@ -81,13 +81,13 @@ describe('Release-PR', () => {
         // check to see if this PR was already landed and we're
         // just waiting on the autorelease.
         .get(
-          '/repos/googleapis/release-please/pulls?state=closed&per_page=100&sort=updated&direction=desc'
+          '/repos/googleapis/release-please/pulls?state=closed&per_page=100&sort=created&direction=desc'
         )
         .reply(200, undefined)
         // fetch semver tags, this will be used to determine
         // the delta since the last release.
         .get(
-          '/repos/googleapis/release-please/pulls?state=closed&per_page=100&sort=updated&direction=desc'
+          '/repos/googleapis/release-please/pulls?state=closed&per_page=100&sort=created&direction=desc'
         )
         .reply(200, [
           {

--- a/test/releasers/java-bom.ts
+++ b/test/releasers/java-bom.ts
@@ -60,7 +60,7 @@ describe('JavaBom', () => {
       );
       const req = nock('https://api.github.com')
         .get(
-          '/repos/googleapis/java-cloud-bom/pulls?state=closed&per_page=100&sort=updated&direction=desc'
+          '/repos/googleapis/java-cloud-bom/pulls?state=closed&per_page=100&sort=created&direction=desc'
         )
         .reply(200, undefined)
         .get(
@@ -76,7 +76,7 @@ describe('JavaBom', () => {
         // fetch semver tags, this will be used to determine
         // the delta since the last release.
         .get(
-          '/repos/googleapis/java-cloud-bom/pulls?state=closed&per_page=100&sort=updated&direction=desc'
+          '/repos/googleapis/java-cloud-bom/pulls?state=closed&per_page=100&sort=created&direction=desc'
         )
         .reply(200, [
           {
@@ -188,7 +188,7 @@ describe('JavaBom', () => {
       );
       const req = nock('https://api.github.com')
         .get(
-          '/repos/googleapis/java-cloud-bom/pulls?state=closed&per_page=100&sort=updated&direction=desc'
+          '/repos/googleapis/java-cloud-bom/pulls?state=closed&per_page=100&sort=created&direction=desc'
         )
         .reply(200, undefined)
         .get(
@@ -209,7 +209,7 @@ describe('JavaBom', () => {
         // fetch semver tags, this will be used to determine
         // the delta since the last release.
         .get(
-          '/repos/googleapis/java-cloud-bom/pulls?state=closed&per_page=100&sort=updated&direction=desc'
+          '/repos/googleapis/java-cloud-bom/pulls?state=closed&per_page=100&sort=created&direction=desc'
         )
         .reply(200, [
           {
@@ -291,7 +291,7 @@ describe('JavaBom', () => {
           default_branch: 'master',
         })
         .get(
-          '/repos/googleapis/java-cloud-bom/pulls?state=closed&per_page=100&sort=updated&direction=desc'
+          '/repos/googleapis/java-cloud-bom/pulls?state=closed&per_page=100&sort=created&direction=desc'
         )
         .reply(200, undefined)
         .get(
@@ -338,7 +338,7 @@ describe('JavaBom', () => {
       );
       const req = nock('https://api.github.com')
         .get(
-          '/repos/googleapis/java-cloud-bom/pulls?state=closed&per_page=100&sort=updated&direction=desc'
+          '/repos/googleapis/java-cloud-bom/pulls?state=closed&per_page=100&sort=created&direction=desc'
         )
         .reply(200, undefined)
         .get(
@@ -359,7 +359,7 @@ describe('JavaBom', () => {
         // fetch semver tags, this will be used to determine
         // the delta since the last release.
         .get(
-          '/repos/googleapis/java-cloud-bom/pulls?state=closed&per_page=100&sort=updated&direction=desc'
+          '/repos/googleapis/java-cloud-bom/pulls?state=closed&per_page=100&sort=created&direction=desc'
         )
         .reply(200, [
           {
@@ -459,7 +459,7 @@ describe('JavaBom', () => {
       );
       const req = nock('https://api.github.com')
         .get(
-          '/repos/googleapis/java-cloud-bom/pulls?state=closed&per_page=100&sort=updated&direction=desc'
+          '/repos/googleapis/java-cloud-bom/pulls?state=closed&per_page=100&sort=created&direction=desc'
         )
         .reply(200, undefined)
         .get(
@@ -475,7 +475,7 @@ describe('JavaBom', () => {
         // fetch semver tags, this will be used to determine
         // the delta since the last release.
         .get(
-          '/repos/googleapis/java-cloud-bom/pulls?state=closed&per_page=100&sort=updated&direction=desc'
+          '/repos/googleapis/java-cloud-bom/pulls?state=closed&per_page=100&sort=created&direction=desc'
         )
         .reply(200, [
           {

--- a/test/releasers/java-yoshi.ts
+++ b/test/releasers/java-yoshi.ts
@@ -63,7 +63,7 @@ describe('JavaYoshi', () => {
       .get('/repos/googleapis/java-trace/pulls?state=open&per_page=100')
       .reply(200, [])
       .get(
-        '/repos/googleapis/java-trace/pulls?state=closed&per_page=100&sort=updated&direction=desc'
+        '/repos/googleapis/java-trace/pulls?state=closed&per_page=100&sort=created&direction=desc'
       )
       .reply(200, undefined)
       .get(
@@ -76,7 +76,7 @@ describe('JavaYoshi', () => {
       // fetch semver tags, this will be used to determine
       // the delta since the last release.
       .get(
-        '/repos/googleapis/java-trace/pulls?state=closed&per_page=100&sort=updated&direction=desc'
+        '/repos/googleapis/java-trace/pulls?state=closed&per_page=100&sort=created&direction=desc'
       )
       .reply(200, [
         {
@@ -206,7 +206,7 @@ describe('JavaYoshi', () => {
     const pomContents = readFileSync(resolve(fixturesPath, 'pom.xml'), 'utf8');
     const req = nock('https://api.github.com')
       .get(
-        '/repos/googleapis/java-trace/pulls?state=closed&per_page=100&sort=updated&direction=desc'
+        '/repos/googleapis/java-trace/pulls?state=closed&per_page=100&sort=created&direction=desc'
       )
       .reply(200, undefined)
       // This step looks for release PRs that are already open:
@@ -222,7 +222,7 @@ describe('JavaYoshi', () => {
       // fetch semver tags, this will be used to determine
       // the delta since the last release.
       .get(
-        '/repos/googleapis/java-trace/pulls?state=closed&per_page=100&sort=updated&direction=desc'
+        '/repos/googleapis/java-trace/pulls?state=closed&per_page=100&sort=created&direction=desc'
       )
       .reply(200, [
         {
@@ -326,7 +326,7 @@ describe('JavaYoshi', () => {
     const pomContents = readFileSync(resolve(fixturesPath, 'pom.xml'), 'utf8');
     const req = nock('https://api.github.com')
       .get(
-        '/repos/googleapis/java-trace/pulls?state=closed&per_page=100&sort=updated&direction=desc'
+        '/repos/googleapis/java-trace/pulls?state=closed&per_page=100&sort=created&direction=desc'
       )
       .reply(200, undefined)
       // This step looks for release PRs that are already open:
@@ -342,7 +342,7 @@ describe('JavaYoshi', () => {
       // fetch semver tags, this will be used to determine
       // the delta since the last release.
       .get(
-        '/repos/googleapis/java-trace/pulls?state=closed&per_page=100&sort=updated&direction=desc'
+        '/repos/googleapis/java-trace/pulls?state=closed&per_page=100&sort=created&direction=desc'
       )
       .reply(200, [
         {
@@ -439,7 +439,7 @@ describe('JavaYoshi', () => {
         default_branch: 'master',
       })
       .get(
-        '/repos/googleapis/java-trace/pulls?state=closed&per_page=100&sort=updated&direction=desc'
+        '/repos/googleapis/java-trace/pulls?state=closed&per_page=100&sort=created&direction=desc'
       )
       .reply(200, undefined)
       .get(
@@ -480,7 +480,7 @@ describe('JavaYoshi', () => {
     const pomContents = readFileSync(resolve(fixturesPath, 'pom.xml'), 'utf8');
     const req = nock('https://api.github.com')
       .get(
-        '/repos/googleapis/java-trace/pulls?state=closed&per_page=100&sort=updated&direction=desc'
+        '/repos/googleapis/java-trace/pulls?state=closed&per_page=100&sort=created&direction=desc'
       )
       .reply(200, undefined)
       // This step looks for release PRs that are already open:
@@ -496,7 +496,7 @@ describe('JavaYoshi', () => {
       // fetch semver tags, this will be used to determine
       // the delta since the last release.
       .get(
-        '/repos/googleapis/java-trace/pulls?state=closed&per_page=100&sort=updated&direction=desc'
+        '/repos/googleapis/java-trace/pulls?state=closed&per_page=100&sort=created&direction=desc'
       )
       .reply(200, [
         {
@@ -614,7 +614,7 @@ describe('JavaYoshi', () => {
       .get('/repos/googleapis/java-trace/pulls?state=open&per_page=100')
       .reply(200, [])
       .get(
-        '/repos/googleapis/java-trace/pulls?state=closed&per_page=100&sort=updated&direction=desc'
+        '/repos/googleapis/java-trace/pulls?state=closed&per_page=100&sort=created&direction=desc'
       )
       .reply(200, undefined)
       .get(
@@ -627,7 +627,7 @@ describe('JavaYoshi', () => {
       // fetch semver tags, this will be used to determine
       // the delta since the last release.
       .get(
-        '/repos/googleapis/java-trace/pulls?state=closed&per_page=100&sort=updated&direction=desc'
+        '/repos/googleapis/java-trace/pulls?state=closed&per_page=100&sort=created&direction=desc'
       )
       .reply(200, [
         {

--- a/test/releasers/node.ts
+++ b/test/releasers/node.ts
@@ -44,7 +44,7 @@ function mockRequest(snapName: string, requestPrefix = '') {
     // eslint-disable-next-line @typescript-eslint/no-var-requires
     .reply(200, require('../../../test/fixtures/repo-get-1.json'))
     .get(
-      '/repos/googleapis/node-test-repo/pulls?state=closed&per_page=100&sort=updated&direction=desc'
+      '/repos/googleapis/node-test-repo/pulls?state=closed&per_page=100&sort=created&direction=desc'
     )
     .reply(200, undefined)
     .get(
@@ -57,7 +57,7 @@ function mockRequest(snapName: string, requestPrefix = '') {
     // fetch semver tags, this will be used to determine
     // the delta since the last release.
     .get(
-      '/repos/googleapis/node-test-repo/pulls?state=closed&per_page=100&sort=updated&direction=desc'
+      '/repos/googleapis/node-test-repo/pulls?state=closed&per_page=100&sort=created&direction=desc'
     )
     .reply(200, [
       {

--- a/test/releasers/yoshi-go.ts
+++ b/test/releasers/yoshi-go.ts
@@ -53,7 +53,7 @@ describe('YoshiGo', () => {
       const req = nock('https://api.github.com')
         // Check for in progress, merged release PRs:
         .get(
-          '/repos/googleapis/google-cloud-go/pulls?state=closed&per_page=100&sort=updated&direction=desc'
+          '/repos/googleapis/google-cloud-go/pulls?state=closed&per_page=100&sort=created&direction=desc'
         )
         .reply(200, undefined)
         // Check for existing open release PRs.
@@ -62,7 +62,7 @@ describe('YoshiGo', () => {
         // fetch semver tags, this will be used to determine
         // the delta since the last release.
         .get(
-          '/repos/googleapis/google-cloud-go/pulls?state=closed&per_page=100&sort=updated&direction=desc'
+          '/repos/googleapis/google-cloud-go/pulls?state=closed&per_page=100&sort=created&direction=desc'
         )
         .reply(200, [
           {


### PR DESCRIPTION
There's a danger that someone comments on an old merged release PR, brining it earlier in chronological order, this would mean that we attempt to re-release the same version given how last release is calculated.

This is not a problem when tagging a release, which only occurs once after a PR is merged.