### PR TITLE
fix: use the GitHub release label to help find the correct PR

### DIFF
--- a/src/github-release.ts
+++ b/src/github-release.ts
@@ -16,12 +16,11 @@ import chalk = require('chalk');
 import {checkpoint, CheckpointType} from './util/checkpoint';
 import {packageBranchPrefix} from './util/package-branch-prefix';
 import {ReleasePRFactory} from './release-pr-factory';
-import {GitHub, OctokitAPIs} from './github';
+import {GitHub, GITHUB_RELEASE_LABEL, OctokitAPIs} from './github';
 import {parse} from 'semver';
 
 // eslint-disable-next-line @typescript-eslint/no-var-requires
 const parseGithubRepoUrl = require('parse-github-repo-url');
-const GITHUB_RELEASE_LABEL = 'autorelease: tagged';
 
 interface ReleaseResponse {
   major: number;

--- a/test/github-release.ts
+++ b/test/github-release.ts
@@ -26,7 +26,7 @@ import {GitHubRelease} from '../src/github-release';
 const fixturesPath = './test/fixtures';
 
 // eslint-disable-next-line @typescript-eslint/no-var-requires
-const repoInfo = require('../../test/fixtures/repo-get-2.json');
+const repoInfo = require(resolve('./test/fixtures/repo-get-2.json'));
 
 describe('GitHubRelease', () => {
   describe('createRelease', () => {

--- a/test/github.ts
+++ b/test/github.ts
@@ -227,6 +227,7 @@ describe('GitHub', () => {
           label: 'fake:release-v3.0.0-rc1',
         },
         merged_at: new Date().toISOString(),
+        labels: [{name: 'autorelease: tagged'}],
       },
       {
         base: {
@@ -236,6 +237,7 @@ describe('GitHub', () => {
           label: 'fake:release-v2.0.0-rc1',
         },
         merged_at: new Date().toISOString(),
+        labels: [{name: 'autorelease: tagged'}],
       },
       {
         base: {
@@ -245,6 +247,7 @@ describe('GitHub', () => {
           label: 'fake:release-v1.1.5',
         },
         merged_at: new Date().toISOString(),
+        labels: [{name: 'autorelease: tagged'}],
       },
       {
         base: {
@@ -254,6 +257,7 @@ describe('GitHub', () => {
           label: 'fake:release-v1.3.0',
         },
         merged_at: new Date().toISOString(),
+        labels: [{name: 'autorelease: tagged'}],
       },
       {
         base: {
@@ -263,6 +267,7 @@ describe('GitHub', () => {
           label: 'fake:release-v1.2.0',
         },
         merged_at: new Date().toISOString(),
+        labels: [{name: 'autorelease: tagged'}],
       },
       {
         base: {
@@ -272,6 +277,7 @@ describe('GitHub', () => {
           label: 'fake:release-v1.1.0',
         },
         merged_at: new Date().toISOString(),
+        labels: [{name: 'autorelease: tagged'}],
       },
     ];
 
@@ -285,6 +291,7 @@ describe('GitHub', () => {
             label: 'fake:release-complex-package_name-v1-v1.1.0',
           },
           merged_at: new Date().toISOString(),
+          labels: [{name: 'autorelease: tagged'}],
         },
         {
           base: {
@@ -294,6 +301,7 @@ describe('GitHub', () => {
             label: 'fake:release-complex-package_name-v2.1-v2.0.0-beta',
           },
           merged_at: new Date().toISOString(),
+          labels: [{name: 'autorelease: tagged'}],
         },
       ];
       req
@@ -316,6 +324,7 @@ describe('GitHub', () => {
             label: 'fake:release-complex-package_name-v1-v1.1.0',
           },
           merged_at: new Date().toISOString(),
+          labels: [{name: 'autorelease: tagged'}],
         },
         {
           base: {
@@ -325,6 +334,7 @@ describe('GitHub', () => {
             label: 'fake:release-complex-package_name-v2.1-v2.0.0-beta',
           },
           merged_at: new Date().toISOString(),
+          labels: [{name: 'autorelease: tagged'}],
         },
         {
           base: {
@@ -334,6 +344,7 @@ describe('GitHub', () => {
             label: 'fake:release-v1.3.0',
           },
           merged_at: new Date().toISOString(),
+          labels: [{name: 'autorelease: tagged'}],
         },
       ];
       req

--- a/test/release-pr-factory.ts
+++ b/test/release-pr-factory.ts
@@ -70,6 +70,7 @@ describe('ReleasePRFactory', () => {
               label: 'googleapis:release-v0.123.4',
             },
             merged_at: new Date().toISOString(),
+            labels: [{name: 'autorelease: tagged'}],
           },
         ])
         .post('/graphql')
@@ -95,7 +96,7 @@ describe('ReleasePRFactory', () => {
         // check for default branch
         .get('/repos/googleapis/simple-test-repo')
         // eslint-disable-next-line @typescript-eslint/no-var-requires
-        .reply(200, require('../../test/fixtures/repo-get-2.json'))
+        .reply(200, require(resolve('./test/fixtures/repo-get-2.json')))
         // this step tries to close any existing PRs; just return an empty list.
         .get('/repos/googleapis/simple-test-repo/pulls?state=open&per_page=100')
         .reply(200, [])
@@ -164,6 +165,7 @@ describe('ReleasePRFactory', () => {
             },
             merge_commit_sha: 'da6e52d956c1e35d19e75e0f2fdba439739ba364',
             merged_at: new Date().toISOString(),
+            labels: [{name: 'autorelease: tagged'}],
           },
         ])
         .post('/graphql')
@@ -189,7 +191,7 @@ describe('ReleasePRFactory', () => {
         // check for default branch
         .get('/repos/googleapis/simple-test-repo')
         // eslint-disable-next-line @typescript-eslint/no-var-requires
-        .reply(200, require('../../test/fixtures/repo-get-2.json'))
+        .reply(200, require(resolve('./test/fixtures/repo-get-2.json')))
         // this step tries to close any existing PRs; just return an empty list.
         .get('/repos/googleapis/simple-test-repo/pulls?state=open&per_page=100')
         .reply(200, [])

--- a/test/release-pr.ts
+++ b/test/release-pr.ts
@@ -99,6 +99,7 @@ describe('Release-PR', () => {
             },
             merged_at: new Date().toISOString(),
             merge_commit_sha: 'bf69d0f204474b88b3f8b5a72a392129d16a3929',
+            labels: [{name: 'autorelease: tagged'}],
           },
         ])
         // now we fetch the commits via the graphql API;
@@ -230,7 +231,7 @@ describe('Release-PR', () => {
         // check for default branch
         .get('/repos/googleapis/release-please')
         // eslint-disable-next-line @typescript-eslint/no-var-requires
-        .reply(200, require('../../test/fixtures/repo-get-1.json'))
+        .reply(200, require(resolve('./test/fixtures/repo-get-1.json')))
         // this step tries to close any existing PRs; just return an empty list.
         .get('/repos/googleapis/release-please/pulls?state=open&per_page=100')
         .reply(200, []);

--- a/test/releasers/java-bom.ts
+++ b/test/releasers/java-bom.ts
@@ -88,6 +88,7 @@ describe('JavaBom', () => {
               sha: 'da6e52d956c1e35d19e75e0f2fdba439739ba364',
             },
             merged_at: new Date().toISOString(),
+            labels: [{name: 'autorelease: tagged'}],
           },
         ])
         .post('/graphql')
@@ -133,7 +134,7 @@ describe('JavaBom', () => {
         // check for default branch
         .get('/repos/googleapis/java-cloud-bom')
         // eslint-disable-next-line @typescript-eslint/no-var-requires
-        .reply(200, require('../../../test/fixtures/repo-get-2.json'))
+        .reply(200, require(resolve('./test/fixtures/repo-get-2.json')))
         // create release
         .post(
           '/repos/googleapis/java-cloud-bom/issues/22/labels',
@@ -221,6 +222,7 @@ describe('JavaBom', () => {
               sha: 'da6e52d956c1e35d19e75e0f2fdba439739ba364',
             },
             merged_at: new Date().toISOString(),
+            labels: [{name: 'autorelease: tagged'}],
           },
         ])
         // finding pom.xml files
@@ -250,7 +252,7 @@ describe('JavaBom', () => {
         // check for default branch
         .get('/repos/googleapis/java-cloud-bom')
         // eslint-disable-next-line @typescript-eslint/no-var-requires
-        .reply(200, require('../../../test/fixtures/repo-get-2.json'))
+        .reply(200, require(resolve('./test/fixtures/repo-get-2.json')))
         .post(
           '/repos/googleapis/java-cloud-bom/issues/22/labels',
           (req: {[key: string]: string}) => {
@@ -371,6 +373,7 @@ describe('JavaBom', () => {
               sha: 'da6e52d956c1e35d19e75e0f2fdba439739ba364',
             },
             merged_at: new Date().toISOString(),
+            labels: [{name: 'autorelease: tagged'}],
           },
         ])
         // finding pom.xml files
@@ -400,7 +403,7 @@ describe('JavaBom', () => {
         // check for default branch
         .get('/repos/googleapis/java-cloud-bom')
         // eslint-disable-next-line @typescript-eslint/no-var-requires
-        .reply(200, require('../../../test/fixtures/repo-get-2.json'))
+        .reply(200, require(resolve('./test/fixtures/repo-get-2.json')))
         .post(
           '/repos/googleapis/java-cloud-bom/issues/22/labels',
           (req: {[key: string]: string}) => {
@@ -487,6 +490,7 @@ describe('JavaBom', () => {
               sha: 'da6e52d956c1e35d19e75e0f2fdba439739ba364',
             },
             merged_at: new Date().toISOString(),
+            labels: [{name: 'autorelease: tagged'}],
           },
         ])
         .post('/graphql')
@@ -532,7 +536,7 @@ describe('JavaBom', () => {
         // check for default branch
         .get('/repos/googleapis/java-cloud-bom')
         // eslint-disable-next-line @typescript-eslint/no-var-requires
-        .reply(200, require('../../../test/fixtures/repo-get-1.json'))
+        .reply(200, require(resolve('./test/fixtures/repo-get-1.json')))
         .post(
           '/repos/googleapis/java-cloud-bom/issues/22/labels',
           (req: {[key: string]: string}) => {

--- a/test/releasers/java-yoshi.ts
+++ b/test/releasers/java-yoshi.ts
@@ -88,6 +88,7 @@ describe('JavaYoshi', () => {
             sha: 'da6e52d956c1e35d19e75e0f2fdba439739ba364',
           },
           merged_at: new Date().toISOString(),
+          labels: [{name: 'autorelease: tagged'}],
         },
       ])
       .post('/graphql', (body: object) => {
@@ -158,7 +159,7 @@ describe('JavaYoshi', () => {
       // check for default branch
       .get('/repos/googleapis/java-trace')
       // eslint-disable-next-line @typescript-eslint/no-var-requires
-      .reply(200, require('../../../test/fixtures/repo-get-1.json'))
+      .reply(200, require(resolve('./test/fixtures/repo-get-1.json')))
       .post(
         '/repos/googleapis/java-trace/issues/22/labels',
         (req: {[key: string]: string}) => {
@@ -234,6 +235,7 @@ describe('JavaYoshi', () => {
             sha: 'da6e52d956c1e35d19e75e0f2fdba439739ba364',
           },
           merged_at: new Date().toISOString(),
+          labels: [{name: 'autorelease: tagged'}],
         },
       ])
       // finding pom.xml files
@@ -277,7 +279,7 @@ describe('JavaYoshi', () => {
       // check for default branch
       .get('/repos/googleapis/java-trace')
       // eslint-disable-next-line @typescript-eslint/no-var-requires
-      .reply(200, require('../../../test/fixtures/repo-get-2.json'))
+      .reply(200, require(resolve('./test/fixtures/repo-get-2.json')))
       .post(
         '/repos/googleapis/java-trace/issues/22/labels',
         (req: {[key: string]: string}) => {
@@ -354,7 +356,7 @@ describe('JavaYoshi', () => {
             sha: 'da6e52d956c1e35d19e75e0f2fdba439739ba364',
           },
           merged_at: new Date().toISOString(),
-          labels: [],
+          labels: [{name: 'autorelease: tagged'}],
         },
       ])
       // finding pom.xml files
@@ -398,7 +400,7 @@ describe('JavaYoshi', () => {
       // check for default branch
       .get('/repos/googleapis/java-trace')
       // eslint-disable-next-line @typescript-eslint/no-var-requires
-      .reply(200, require('../../../test/fixtures/repo-get-2.json'))
+      .reply(200, require(resolve('./test/fixtures/repo-get-2.json')))
       .post(
         '/repos/googleapis/java-trace/issues/22/labels',
         (req: {[key: string]: string}) => {
@@ -508,6 +510,7 @@ describe('JavaYoshi', () => {
             sha: 'da6e52d956c1e35d19e75e0f2fdba439739ba364',
           },
           merged_at: new Date().toISOString(),
+          labels: [{name: 'autorelease: tagged'}],
         },
       ])
       // finding pom.xml files
@@ -551,7 +554,7 @@ describe('JavaYoshi', () => {
       // check for default branch
       .get('/repos/googleapis/java-trace')
       // eslint-disable-next-line @typescript-eslint/no-var-requires
-      .reply(200, require('../../../test/fixtures/repo-get-2.json'))
+      .reply(200, require(resolve('./test/fixtures/repo-get-2.json')))
       .post(
         '/repos/googleapis/java-trace/issues/22/labels',
         (req: {[key: string]: string}) => {
@@ -639,6 +642,7 @@ describe('JavaYoshi', () => {
             sha: 'da6e52d956c1e35d19e75e0f2fdba439739ba364',
           },
           merged_at: new Date().toISOString(),
+          labels: [{name: 'autorelease: tagged'}],
         },
       ])
       .post('/graphql')
@@ -706,7 +710,7 @@ describe('JavaYoshi', () => {
       // check for default branch
       .get('/repos/googleapis/java-trace')
       // eslint-disable-next-line @typescript-eslint/no-var-requires
-      .reply(200, require('../../../test/fixtures/repo-get-1.json'))
+      .reply(200, require(resolve('./test/fixtures/repo-get-1.json')))
       .post(
         '/repos/googleapis/java-trace/issues/22/labels',
         (req: {[key: string]: string}) => {

--- a/test/releasers/node.ts
+++ b/test/releasers/node.ts
@@ -42,7 +42,7 @@ function mockRequest(snapName: string, requestPrefix = '') {
     // check for default branch
     .get('/repos/googleapis/node-test-repo')
     // eslint-disable-next-line @typescript-eslint/no-var-requires
-    .reply(200, require('../../../test/fixtures/repo-get-1.json'))
+    .reply(200, require(resolve('test/fixtures/repo-get-1.json')))
     .get(
       '/repos/googleapis/node-test-repo/pulls?state=closed&per_page=100&sort=created&direction=desc'
     )
@@ -69,7 +69,7 @@ function mockRequest(snapName: string, requestPrefix = '') {
           sha: 'da6e52d956c1e35d19e75e0f2fdba439739ba364',
         },
         merged_at: new Date().toISOString(),
-        labels: [],
+        labels: [{name: 'autorelease: tagged'}],
       },
     ])
     .post('/graphql', (body: object) => {
@@ -251,7 +251,7 @@ describe('Node', () => {
       const req = nock('https://api.github.com')
         .get('/repos/googleapis/node-test-repo')
         // eslint-disable-next-line @typescript-eslint/no-var-requires
-        .reply(200, require('../../../test/fixtures/repo-get-1.json'))
+        .reply(200, require(resolve('./test/fixtures/repo-get-1.json')))
         .get(
           '/repos/googleapis/node-test-repo/contents/package.json?ref=refs/heads/master'
         )
@@ -273,7 +273,7 @@ describe('Node', () => {
       const req = nock('https://api.github.com')
         .get('/repos/googleapis/node-test-repo')
         // eslint-disable-next-line @typescript-eslint/no-var-requires
-        .reply(200, require('../../../test/fixtures/repo-get-1.json'))
+        .reply(200, require(resolve('./test/fixtures/repo-get-1.json')))
         .get(
           '/repos/googleapis/node-test-repo/contents/some-path%2Fpackage.json?ref=refs/heads/master'
         )

--- a/test/releasers/yoshi-go.ts
+++ b/test/releasers/yoshi-go.ts
@@ -74,6 +74,7 @@ describe('YoshiGo', () => {
               sha: 'da6e52d956c1e35d19e75e0f2fdba439739ba364',
             },
             merged_at: new Date().toISOString(),
+            labels: [{name: 'autorelease: tagged'}],
           },
         ])
         .post('/graphql')
@@ -88,7 +89,7 @@ describe('YoshiGo', () => {
         // check for default branch
         .get('/repos/googleapis/google-cloud-go')
         // eslint-disable-next-line @typescript-eslint/no-var-requires
-        .reply(200, require('../../../test/fixtures/repo-get-1.json'))
+        .reply(200, require(resolve('./test/fixtures/repo-get-1.json')))
         // create release
         .post(
           '/repos/googleapis/google-cloud-go/issues/22/labels',
@@ -178,7 +179,7 @@ describe('YoshiGo', () => {
         // check for default branch
         .get('/repos/googleapis/google-api-go-client')
         // eslint-disable-next-line @typescript-eslint/no-var-requires
-        .reply(200, require('../../../test/fixtures/repo-get-1.json'));
+        .reply(200, require(resolve('./test/fixtures/repo-get-1.json')));
 
       const pr = await releasePR.run();
       assert.strictEqual(pr, 22);
@@ -254,7 +255,7 @@ describe('YoshiGo', () => {
       // check for default branch
       .get('/repos/googleapis/google-cloud-go')
       // eslint-disable-next-line @typescript-eslint/no-var-requires
-      .reply(200, require('../../../test/fixtures/repo-get-1.json'));
+      .reply(200, require(resolve('./test/fixtures/repo-get-1.json')));
 
     const pr = await releasePR.run();
     assert.strictEqual(pr, 22);


### PR DESCRIPTION
Looks for PRs with the `autorelease: tagged` label when considering release PRs. This helps prevent
creating release PRs that include every change in the repository as opposed to changes since the
last release when the main branch has been rebased or has had other issues.

The change to `findMergedReleasePR` means it is possible to manually update the tags on merged PRs
to either have them included or excluded from the list of candidates used to find the last release.

This also changes test imports to use `resolve` so that they can be run more easily from IDEs and
tools such as wallaby.js.

Based on my testing, this looks like a safe change to make, but perhaps it should be placed behind a
command line/feature flag?

Fixes #713