### PR TITLE
test(java): convert Java releaser tests to use sinon

### DIFF
--- a/__snapshots__/github.js
+++ b/__snapshots__/github.js
@@ -205,3 +205,21 @@ exports['GitHub findFilesByExtension returns files matching the requested patter
   "oauth2_http/pom.xml",
   "pom.xml"
 ]
+
+exports['GitHub commitsSinceSha prefixes commits with labels from associated pull requests 1'] = [
+  {
+    "sha": "fcd1c890dc1526f4d62ceedad561f498195c8939",
+    "message": "Refactor shared IAM-based signing (#292)\n\n* Extract IAM signing into its own class\r\n\r\n* Refactor into IamUtils package private class\r\n\r\n* Remove unnecessary class\r\n\r\n* Remove unused code\r\n\r\n* Cleanup imports\r\n\r\n* Fill out javadoc for IamUtils\r\n\r\n* Failing tests for impersonated credentials\r\n\r\n* Fix credentials used for signing\r\n\r\n* Fix providing delegates to signing request\r\n\r\n* Disallow null additionalFields, remove jsr305 annotation\r\n\r\n* Remove usued imports",
+    "files": []
+  },
+  {
+    "sha": "1f9663cf08ab1cf3b68d95dee4dc99b7c4aac373",
+    "message": "Update allowed header format (#301)\n\n* Update copyright format  \r\n\r\n@chingor13\r\n\r\n* Update java.header\r\n\r\n* add legacy copyright\r\n\r\n* remove spurious $",
+    "files": []
+  },
+  {
+    "sha": "3006009a2b1b2cb4bd5108c0f469c410759f3a6a",
+    "message": "Upgrade Guava to 28.0-android (#300)",
+    "files": []
+  }
+]

--- a/__snapshots__/java-bom.js
+++ b/__snapshots__/java-bom.js
@@ -3,7 +3,7 @@ exports['JavaBom run creates a release PR 1'] = `
   [
     "CHANGELOG.md",
     {
-      "content": "# Changelog\\n\\n## [0.124.0](https://www.github.com/googleapis/java-cloud-bom/compare/0.123.4...v0.124.0) (1983-10-10)\\n\\n\\n### Dependencies\\n\\n* update dependency com.google.cloud:google-cloud-spanner to v1.50.0 ([1f9663c](https://www.github.com/googleapis/java-cloud-bom/commit/1f9663cf08ab1cf3b68d95dee4dc99b7c4aac373))\\n* update dependency com.google.cloud:google-cloud-storage to v1.120.0 ([fcd1c89](https://www.github.com/googleapis/java-cloud-bom/commit/fcd1c890dc1526f4d62ceedad561f498195c8939))\\n",
+      "content": "# Changelog\\n\\n## [0.124.0](https://www.github.com/googleapis/java-cloud-bom/compare/0.123.4...v0.124.0) (1983-10-10)\\n\\n\\n### Dependencies\\n\\n* update dependency com.google.cloud:google-cloud-spanner to v1.50.0 ([cff63d6](https://www.github.com/googleapis/java-cloud-bom/commit/cff63d6a37871ed689d160f5e0ce3049))\\n* update dependency com.google.cloud:google-cloud-storage to v1.120.0 ([333b994](https://www.github.com/googleapis/java-cloud-bom/commit/333b994dfc5c831a74c9f597349d4b62))\\n",
       "mode": "100644"
     }
   ],
@@ -74,7 +74,7 @@ exports['JavaBom run merges conventional commit messages 1'] = `
   [
     "CHANGELOG.md",
     {
-      "content": "# Changelog\\n\\n## [0.124.0](https://www.github.com/googleapis/java-cloud-bom/compare/0.123.4...v0.124.0) (1983-10-10)\\n\\n\\n### Features\\n\\n* import google-cloud-game-servers ([1f9663c](https://www.github.com/googleapis/java-cloud-bom/commit/1f9663cf08ab1cf3b68d95dee4dc99b7c4aac373))\\n\\n\\n### Dependencies\\n\\n* update dependency com.google.cloud:google-cloud-storage to v1.120.1 ([fcd1c89](https://www.github.com/googleapis/java-cloud-bom/commit/fcd1c890dc1526f4d62ceedad561f498195c8939))\\n",
+      "content": "# Changelog\\n\\n## [0.124.0](https://www.github.com/googleapis/java-cloud-bom/compare/0.123.4...v0.124.0) (1983-10-10)\\n\\n\\n### Features\\n\\n* import google-cloud-game-servers ([3ec8138](https://www.github.com/googleapis/java-cloud-bom/commit/3ec8138bb1ce60b060411fb179ab1755))\\n\\n\\n### Dependencies\\n\\n* update dependency com.google.cloud:google-cloud-storage to v1.120.1 ([62ea60b](https://www.github.com/googleapis/java-cloud-bom/commit/62ea60ba424a832710e87eb266ca854b))\\n",
       "mode": "100644"
     }
   ],

--- a/__snapshots__/java-bom.js
+++ b/__snapshots__/java-bom.js
@@ -1,9 +1,3 @@
-exports['labels-bom'] = {
-  "labels": [
-    "autorelease: pending"
-  ]
-}
-
 exports['JavaBom run creates a release PR 1'] = `
 [
   [
@@ -37,12 +31,6 @@ exports['JavaBom run creates a release PR 1'] = `
 ]
 `
 
-exports['labels-bom-snapshot'] = {
-  "labels": [
-    "type: process"
-  ]
-}
-
 exports['JavaBom run creates a snapshot PR 1'] = `
 [
   [
@@ -62,12 +50,6 @@ exports['JavaBom run creates a snapshot PR 1'] = `
 ]
 `
 
-exports['labels-bom-snapshot-release'] = {
-  "labels": [
-    "type: process"
-  ]
-}
-
 exports['JavaBom run creates a snapshot PR if an explicit release is requested, but a snapshot is needed 1'] = `
 [
   [
@@ -86,12 +68,6 @@ exports['JavaBom run creates a snapshot PR if an explicit release is requested, 
   ]
 ]
 `
-
-exports['labels-bom-feature'] = {
-  "labels": [
-    "autorelease: pending"
-  ]
-}
 
 exports['JavaBom run merges conventional commit messages 1'] = `
 [

--- a/__snapshots__/java-yoshi.js
+++ b/__snapshots__/java-yoshi.js
@@ -3,7 +3,7 @@ exports['JavaYoshi creates a release PR 1'] = `
   [
     "CHANGELOG.md",
     {
-      "content": "# Changelog\\n\\n### [0.20.4](https://www.github.com/googleapis/java-trace/compare/v0.20.3...v0.20.4) (1983-10-10)\\n\\n\\n### Bug Fixes\\n\\n* Fix declared dependencies from merge issue ([#291](https://www.github.com/googleapis/java-trace/issues/291)) ([35abf13](https://www.github.com/googleapis/java-trace/commit/35abf13fa8acb3988aa086f3eb23f5ce1483cc5d))\\n",
+      "content": "# Changelog\\n\\n### [0.20.4](https://www.github.com/googleapis/java-trace/compare/v0.20.3...v0.20.4) (1983-10-10)\\n\\n\\n### Bug Fixes\\n\\n* Fix declared dependencies from merge issue ([#291](https://www.github.com/googleapis/java-trace/issues/291)) ([4af82b3](https://www.github.com/googleapis/java-trace/commit/4af82b3a0399386f68484da753a975b5))\\n",
       "mode": "100644"
     }
   ],
@@ -100,7 +100,7 @@ exports['JavaYoshi handles promotion to 1.0.0 1'] = `
   [
     "CHANGELOG.md",
     {
-      "content": "# Changelog\\n\\n## [1.0.0](https://www.github.com/googleapis/java-trace/compare/v0.20.3...v1.0.0) (1983-10-10)\\n\\n\\n### Features\\n\\n* promote to 1.0.0 ([#292](https://www.github.com/googleapis/java-trace/issues/292)) ([fcd1c89](https://www.github.com/googleapis/java-trace/commit/fcd1c890dc1526f4d62ceedad561f498195c8939))\\n",
+      "content": "# Changelog\\n\\n## [1.0.0](https://www.github.com/googleapis/java-trace/compare/v0.20.3...v1.0.0) (1983-10-10)\\n\\n\\n### Features\\n\\n* promote to 1.0.0 ([#292](https://www.github.com/googleapis/java-trace/issues/292)) ([7fe1778](https://www.github.com/googleapis/java-trace/commit/7fe1778d9a6f9e16c410a0947241df0a))\\n",
       "mode": "100644"
     }
   ],
@@ -140,7 +140,7 @@ exports['JavaYoshi creates a release PR against a feature branch 1'] = `
   [
     "CHANGELOG.md",
     {
-      "content": "# Changelog\\n\\n### [0.20.4](https://www.github.com/googleapis/java-trace/compare/v0.20.3...v0.20.4) (1983-10-10)\\n\\n\\n### Bug Fixes\\n\\n* Fix declared dependencies from merge issue ([#291](https://www.github.com/googleapis/java-trace/issues/291)) ([35abf13](https://www.github.com/googleapis/java-trace/commit/35abf13fa8acb3988aa086f3eb23f5ce1483cc5d))\\n",
+      "content": "# Changelog\\n\\n### [0.20.4](https://www.github.com/googleapis/java-trace/compare/v0.20.3...v0.20.4) (1983-10-10)\\n\\n\\n### Bug Fixes\\n\\n* Fix declared dependencies from merge issue ([#291](https://www.github.com/googleapis/java-trace/issues/291)) ([4af82b3](https://www.github.com/googleapis/java-trace/commit/4af82b3a0399386f68484da753a975b5))\\n",
       "mode": "100644"
     }
   ],
@@ -181,7 +181,7 @@ exports['JavaYoshi creates a release PR against a feature branch 2'] = `
   "upstreamRepo": "java-trace",
   "title": "chore: release 0.20.4",
   "branch": "release-v0.20.4",
-  "description": ":robot: I have created a release \\\\*beep\\\\* \\\\*boop\\\\* \\n---\\n### [0.20.4](https://www.github.com/googleapis/java-trace/compare/v0.20.3...v0.20.4) (1983-10-10)\\n\\n\\n### Bug Fixes\\n\\n* Fix declared dependencies from merge issue ([#291](https://www.github.com/googleapis/java-trace/issues/291)) ([35abf13](https://www.github.com/googleapis/java-trace/commit/35abf13fa8acb3988aa086f3eb23f5ce1483cc5d))\\n---\\n\\n\\nThis PR was generated with [Release Please](https://github.com/googleapis/release-please). See [documentation](https://github.com/googleapis/release-please#release-please).",
+  "description": ":robot: I have created a release \\\\*beep\\\\* \\\\*boop\\\\* \\n---\\n### [0.20.4](https://www.github.com/googleapis/java-trace/compare/v0.20.3...v0.20.4) (1983-10-10)\\n\\n\\n### Bug Fixes\\n\\n* Fix declared dependencies from merge issue ([#291](https://www.github.com/googleapis/java-trace/issues/291)) ([4af82b3](https://www.github.com/googleapis/java-trace/commit/4af82b3a0399386f68484da753a975b5))\\n---\\n\\n\\nThis PR was generated with [Release Please](https://github.com/googleapis/release-please). See [documentation](https://github.com/googleapis/release-please#release-please).",
   "primary": "1.x",
   "force": true,
   "fork": false,

--- a/__snapshots__/java-yoshi.js
+++ b/__snapshots__/java-yoshi.js
@@ -1,21 +1,3 @@
-exports['labels'] = {
-  "labels": [
-    "autorelease: pending"
-  ]
-}
-
-exports['labels-snapshot'] = {
-  "labels": [
-    "type: process"
-  ]
-}
-
-exports['labels-snapshot-empty'] = {
-  "labels": [
-    "type: process"
-  ]
-}
-
 exports['JavaYoshi creates a release PR 1'] = `
 [
   [
@@ -94,12 +76,6 @@ exports['JavaYoshi creates a snapshot PR, when latest release sha is head 1'] = 
 ]
 `
 
-exports['labels-snapshot-release'] = {
-  "labels": [
-    "type: process"
-  ]
-}
-
 exports['JavaYoshi creates a snapshot PR if an explicit release is requested, but a snapshot is needed 1'] = `
 [
   [
@@ -118,24 +94,6 @@ exports['JavaYoshi creates a snapshot PR if an explicit release is requested, bu
   ]
 ]
 `
-
-exports['graphql-body-java-release'] = {
-  "query": "query commitsWithLabels($cursor: String, $owner: String!, $repo: String!, $baseRef: String!, $perPage: Int, $maxLabels: Int, $path: String) {\n          repository(owner: $owner, name: $repo) {\n            ref(qualifiedName: $baseRef) {\n              target {\n                ... on Commit {\n                  history(first: $perPage, after: $cursor, path: $path) {\n                    edges {\n                      node {\n                        ... on Commit {\n                          message\n                          oid\n                          associatedPullRequests(first: 1) {\n                            edges {\n                              node {\n                                ... on PullRequest {\n                                  number\n                                  mergeCommit {\n                                    oid\n                                  }\n                                  labels(first: $maxLabels) {\n                                    edges {\n                                      node {\n                                        name\n                                      }\n                                    }\n                                  }\n                                }\n                              }\n                            }\n                          }\n                        }\n                      }\n                    }\n                    pageInfo {\n                      endCursor\n                      hasNextPage\n                    }\n                  }\n                }\n              }\n            }\n          }\n        }",
-  "variables": {
-    "maxLabels": 16,
-    "owner": "googleapis",
-    "path": null,
-    "perPage": 100,
-    "repo": "java-trace",
-    "baseRef": "refs/heads/master"
-  }
-}
-
-exports['promotion labels'] = {
-  "labels": [
-    "autorelease: pending"
-  ]
-}
 
 exports['JavaYoshi handles promotion to 1.0.0 1'] = `
 [
@@ -176,24 +134,6 @@ exports['JavaYoshi handles promotion to 1.0.0 1'] = `
   ]
 ]
 `
-
-exports['graphql-body-java-release-feature-branch'] = {
-  "query": "query commitsWithLabels($cursor: String, $owner: String!, $repo: String!, $baseRef: String!, $perPage: Int, $maxLabels: Int, $path: String) {\n          repository(owner: $owner, name: $repo) {\n            ref(qualifiedName: $baseRef) {\n              target {\n                ... on Commit {\n                  history(first: $perPage, after: $cursor, path: $path) {\n                    edges {\n                      node {\n                        ... on Commit {\n                          message\n                          oid\n                          associatedPullRequests(first: 1) {\n                            edges {\n                              node {\n                                ... on PullRequest {\n                                  number\n                                  mergeCommit {\n                                    oid\n                                  }\n                                  labels(first: $maxLabels) {\n                                    edges {\n                                      node {\n                                        name\n                                      }\n                                    }\n                                  }\n                                }\n                              }\n                            }\n                          }\n                        }\n                      }\n                    }\n                    pageInfo {\n                      endCursor\n                      hasNextPage\n                    }\n                  }\n                }\n              }\n            }\n          }\n        }",
-  "variables": {
-    "maxLabels": 16,
-    "owner": "googleapis",
-    "path": null,
-    "perPage": 100,
-    "repo": "java-trace",
-    "baseRef": "refs/heads/1.x"
-  }
-}
-
-exports['labels-feature-branch'] = {
-  "labels": [
-    "autorelease: pending"
-  ]
-}
 
 exports['JavaYoshi creates a release PR against a feature branch 1'] = `
 [

--- a/src/release-pr.ts
+++ b/src/release-pr.ts
@@ -303,7 +303,7 @@ export class ReleasePR {
     // a return of undefined indicates that PR was not updated.
     if (pr) {
       // If the PR is being created from a fork, it will not have permission
-      // to add nd remove labels from the PR:
+      // to add and remove labels from the PR:
       if (!this.fork) {
         await this.gh.addLabels(this.labels, pr);
       } else {

--- a/test/github.ts
+++ b/test/github.ts
@@ -64,6 +64,25 @@ describe('GitHub', () => {
       snapshot(commitsSinceSha);
       req.done();
     });
+
+    it('prefixes commits with labels from associated pull requests', async () => {
+      const graphql = JSON.parse(
+        readFileSync(
+          resolve(fixturesPath, 'commits-with-labels.json'),
+          'utf8'
+        )
+      );
+      req.post('/graphql').reply(200, {
+        data: graphql,
+      });
+      const commitsSinceSha = await github.commitsSinceSha(
+        '35abf13fa8acb3988aa086f3eb23f5ce1483cc5d',
+        100,
+        true,
+      );
+      snapshot(commitsSinceSha);
+      req.done();
+    });
   });
 
   describe('normalizePrefix', () => {
@@ -560,15 +579,14 @@ describe('GitHub', () => {
           'utf8'
         )
       );
-      const req1 = nock('https://api.github.com/')
+
+      req
         .get(
           '/repos/fake/fake/contents/package-lock.json?ref=refs%2Fheads%2Fmain'
         )
-        .reply(403, simpleAPIResponse);
-      const req2 = nock('https://api.github.com/')
+        .reply(403, simpleAPIResponse)
         .get('/repos/fake/fake/git/trees/main')
-        .reply(200, dataAPITreesResponse);
-      const req3 = nock('https://api.github.com/')
+        .reply(200, dataAPITreesResponse)
         .get(
           '/repos/fake/fake/git/blobs/2f3d2c47bf49f81aca0df9ffc49524a213a2dc33'
         )
@@ -581,9 +599,7 @@ describe('GitHub', () => {
         .to.have.property('sha')
         .equal('2f3d2c47bf49f81aca0df9ffc49524a213a2dc33');
       snapshot(fileContents);
-      req1.done();
-      req2.done();
-      req3.done();
+      req.done();
     });
   });
 });

--- a/test/github.ts
+++ b/test/github.ts
@@ -67,10 +67,7 @@ describe('GitHub', () => {
 
     it('prefixes commits with labels from associated pull requests', async () => {
       const graphql = JSON.parse(
-        readFileSync(
-          resolve(fixturesPath, 'commits-with-labels.json'),
-          'utf8'
-        )
+        readFileSync(resolve(fixturesPath, 'commits-with-labels.json'), 'utf8')
       );
       req.post('/graphql').reply(200, {
         data: graphql,
@@ -78,7 +75,7 @@ describe('GitHub', () => {
       const commitsSinceSha = await github.commitsSinceSha(
         '35abf13fa8acb3988aa086f3eb23f5ce1483cc5d',
         100,
-        true,
+        true
       );
       snapshot(commitsSinceSha);
       req.done();

--- a/test/releasers/java-bom.ts
+++ b/test/releasers/java-bom.ts
@@ -29,7 +29,10 @@ const sandbox = sinon.createSandbox();
 const fixturesPath = './test/releasers/fixtures/java-bom';
 
 function buildFileContent(fixture: string): GitHubFileContents {
-  const content = readFileSync(resolve(fixturesPath, fixture), 'utf8');
+  const content = readFileSync(resolve(fixturesPath, fixture), 'utf8').replace(
+    /\r\n/g,
+    '\n'
+  );
   return {
     content: Buffer.from(content, 'utf8').toString('base64'),
     parsedContent: content,

--- a/test/releasers/java-yoshi.ts
+++ b/test/releasers/java-yoshi.ts
@@ -30,7 +30,10 @@ const sandbox = sinon.createSandbox();
 const fixturesPath = './test/releasers/fixtures/java-yoshi';
 
 function buildFileContent(fixture: string): GitHubFileContents {
-  const content = readFileSync(resolve(fixturesPath, fixture), 'utf8');
+  const content = readFileSync(resolve(fixturesPath, fixture), 'utf8').replace(
+    /\r\n/g,
+    '\n'
+  );
   return {
     content: Buffer.from(content, 'utf8').toString('base64'),
     parsedContent: content,

--- a/test/releasers/java-yoshi.ts
+++ b/test/releasers/java-yoshi.ts
@@ -24,6 +24,7 @@ import * as suggester from 'code-suggester';
 import * as sinon from 'sinon';
 import {GitHubFileContents} from '../../src/github';
 import * as crypto from 'crypto';
+import {Commit} from '../../src/graphql-to-commits';
 
 const sandbox = sinon.createSandbox();
 const fixturesPath = './test/releasers/fixtures/java-yoshi';
@@ -35,6 +36,14 @@ function buildFileContent(fixture: string): GitHubFileContents {
     parsedContent: content,
     // fake a consistent sha
     sha: crypto.createHash('md5').update(content).digest('hex'),
+  };
+}
+
+function buildMockCommit(message: string): Commit {
+  return {
+    sha: crypto.createHash('md5').update(message).digest('hex'),
+    message,
+    files: [],
   };
 }
 
@@ -108,14 +117,13 @@ describe('JavaYoshi', () => {
       Object.assign(Error('not found'), {status: 404})
     );
 
-    sandbox.stub(releasePR.gh, 'commitsSinceSha').resolves([
-      {
-        sha: '35abf13fa8acb3988aa086f3eb23f5ce1483cc5d',
-        message:
-          'fix: Fix declared dependencies from merge issue (#291)',
-        files: [],
-      },
-    ]);
+    sandbox
+      .stub(releasePR.gh, 'commitsSinceSha')
+      .resolves([
+        buildMockCommit(
+          'fix: Fix declared dependencies from merge issue (#291)'
+        ),
+      ]);
 
     // TODO: maybe assert which labels added
     sandbox.stub(releasePR.gh, 'addLabels');
@@ -207,14 +215,13 @@ describe('JavaYoshi', () => {
       Object.assign(Error('not found'), {status: 404})
     );
 
-    sandbox.stub(releasePR.gh, 'commitsSinceSha').resolves([
-      {
-        sha: 'fcd1c890dc1526f4d62ceedad561f498195c8939',
-        message:
-          'fix(deps): update dependency com.google.cloud:google-cloud-storage to v1.120.0',
-        files: [],
-      },
-    ]);
+    sandbox
+      .stub(releasePR.gh, 'commitsSinceSha')
+      .resolves([
+        buildMockCommit(
+          'fix(deps): update dependency com.google.cloud:google-cloud-storage to v1.120.0'
+        ),
+      ]);
 
     // TODO: maybe assert which labels added
     sandbox.stub(releasePR.gh, 'addLabels');
@@ -435,14 +442,13 @@ describe('JavaYoshi', () => {
       Object.assign(Error('not found'), {status: 404})
     );
 
-    sandbox.stub(releasePR.gh, 'commitsSinceSha').resolves([
-      {
-        sha: 'fcd1c890dc1526f4d62ceedad561f498195c8939',
-        message:
-          'fix(deps): update dependency com.google.cloud:google-cloud-storage to v1.120.0',
-        files: [],
-      },
-    ]);
+    sandbox
+      .stub(releasePR.gh, 'commitsSinceSha')
+      .resolves([
+        buildMockCommit(
+          'fix(deps): update dependency com.google.cloud:google-cloud-storage to v1.120.0'
+        ),
+      ]);
 
     // TODO: maybe assert which labels added
     sandbox.stub(releasePR.gh, 'addLabels');
@@ -533,13 +539,11 @@ describe('JavaYoshi', () => {
       Object.assign(Error('not found'), {status: 404})
     );
 
-    sandbox.stub(releasePR.gh, 'commitsSinceSha').resolves([
-      {
-        sha: 'fcd1c890dc1526f4d62ceedad561f498195c8939',
-        message: 'feat: promote to 1.0.0 (#292)\n\nRelease-As: 1.0.0',
-        files: [],
-      },
-    ]);
+    sandbox
+      .stub(releasePR.gh, 'commitsSinceSha')
+      .resolves([
+        buildMockCommit('feat: promote to 1.0.0 (#292)\n\nRelease-As: 1.0.0'),
+      ]);
 
     // TODO: maybe assert which labels added
     sandbox.stub(releasePR.gh, 'addLabels');
@@ -625,14 +629,13 @@ describe('JavaYoshi', () => {
       Object.assign(Error('not found'), {status: 404})
     );
 
-    sandbox.stub(releasePR.gh, 'commitsSinceSha').resolves([
-      {
-        sha: '35abf13fa8acb3988aa086f3eb23f5ce1483cc5d',
-        message:
-          'fix: Fix declared dependencies from merge issue (#291)',
-        files: [],
-      },
-    ]);
+    sandbox
+      .stub(releasePR.gh, 'commitsSinceSha')
+      .resolves([
+        buildMockCommit(
+          'fix: Fix declared dependencies from merge issue (#291)'
+        ),
+      ]);
 
     // TODO: maybe assert which labels added
     sandbox.stub(releasePR.gh, 'addLabels');


### PR DESCRIPTION
The nock mocks make it hard to follow and are deeply tied to the GitHub implementation.