### PR TITLE
feat: monorepo node package dependency updates with lerna

### DIFF
--- a/package.json
+++ b/package.json
@@ -56,9 +56,13 @@
   "dependencies": {
     "@conventional-commits/parser": "^0.4.1",
     "@iarna/toml": "^2.2.5",
+    "@lerna/package": "^3.16.0",
+    "@lerna/package-graph": "^3.18.5",
+    "@lerna/run-topologically": "^3.18.5",
     "@octokit/graphql": "^4.3.1",
     "@octokit/request": "^5.3.4",
     "@octokit/rest": "^18.0.4",
+    "@types/npm-package-arg": "^6.1.0",
     "chalk": "^4.0.0",
     "code-suggester": "^1.4.0",
     "conventional-changelog-conventionalcommits": "^4.4.0",

--- a/src/util/update-node-workspace-packages-dependencies.ts
+++ b/src/util/update-node-workspace-packages-dependencies.ts
@@ -1,0 +1,64 @@
+// Copyright 2021 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import Package = require('@lerna/package');
+import PackageGraph = require('@lerna/package-graph');
+import runTopologically = require('@lerna/run-topologically');
+
+export interface PackageJson {
+  name: string;
+  version: string;
+  dependencies?: Record<string, string>;
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  [key: string]: any;
+}
+
+export type PathPackages = Record<string, PackageJson>;
+
+// Inspired by https://github.com/lerna/lerna/blob/72414ec1c679cf8a7ae4bfcefce52d50a6120a70/commands/version/index.js#L495
+// Expected input is a mapping of 'path/to/dirContainingPkgJson' => JSON.parse(package.json)
+// It is also assumed that each package.json version is the new version.
+// Each package.json dependency on another package will be updated to "^pkg.latest.version"
+export async function updateNodeWorkspacePackagesDependencies(
+  packages: PathPackages
+): Promise<PathPackages> {
+  const lernaPkgs: Package[] = [];
+  const newVersions: Record<string, string> = {};
+  for (const path in packages) {
+    const pkg = packages[path];
+    lernaPkgs.push(new Package(pkg, path));
+    newVersions[pkg.name] = pkg.version;
+  }
+  const graph = new PackageGraph(lernaPkgs, 'dependencies');
+  const runner = async (pkg: Package): Promise<Package> => {
+    const graphPkg = graph.get(pkg.name);
+    for (const [depName, resolved] of graphPkg.localDependencies) {
+      const depVersion = newVersions[depName];
+      if (depVersion && resolved.type !== 'directory') {
+        pkg.updateLocalDependency(resolved, depVersion, '^');
+      }
+    }
+    return pkg;
+  };
+  const updatedPkgs: Package[] = await runTopologically(lernaPkgs, runner, {
+    graphType: 'dependencies',
+    concurrency: 1,
+    rejectCycles: false,
+  });
+  const ret: PathPackages = {};
+  for (const updated of updatedPkgs) {
+    ret[updated.location] = updated.toJSON();
+  }
+  return ret;
+}

--- a/test/util/update-node-workspace-packages-dependencies.ts
+++ b/test/util/update-node-workspace-packages-dependencies.ts
@@ -1,0 +1,75 @@
+// Copyright 2021 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import {
+  updateNodeWorkspacePackagesDependencies,
+  PathPackages,
+} from '../../src/util/update-node-workspace-packages-dependencies';
+import {describe, it} from 'mocha';
+import {expect} from 'chai';
+
+describe('updateNodeWorkspacePackagesDependencies', () => {
+  it('updates package dependencies', async () => {
+    function getPackages(updated: boolean): PathPackages {
+      return {
+        'packages/pkgA': {
+          name: '@here/pkgA',
+          version: '1.1.1',
+          dependencies: {'@there/foo': '^4.1.7'},
+        },
+        'packages/pkgB': {
+          name: '@here/pkgB',
+          version: '2.2.2',
+          dependencies: {
+            '@here/pkgA': `^${updated ? '1.1.1' : '1.1.0'}`,
+            someExternal: '^9.2.3',
+          },
+        },
+        'packages/pkgC': {
+          name: '@here/pkgC',
+          version: '3.3.3',
+          dependencies: {
+            '@here/pkgB': `^${updated ? '2.2.2' : '2.2.0'}`,
+            anotherExternal: '^4.3.1',
+          },
+        },
+        'packages/pkgD': {
+          name: 'pkgD',
+          version: '4.4.4',
+          dependencies: {
+            '@here/pkgA': `^${updated ? '1.1.1' : '1.0.0'}`,
+            '@here/pkgC': `^${updated ? '3.3.3' : '3.1.2'}`,
+            anotherExternal: '^4.3.1',
+          },
+        },
+        'packages/pkgE': {
+          name: '@here/pkgE',
+          version: '5.5.5',
+          dependencies: {
+            '@here/pkgA': `^${updated ? '1.1.1' : '1.1.0'}`,
+            '@here/pkgB': `^${updated ? '2.2.2' : '2.0.1'}`,
+            '@here/pkgC': `^${updated ? '3.3.3' : '3.1.2'}`,
+            pkgD: `^${updated ? '4.4.4' : '4.2.0'}`,
+            '@something/external': '^6.2.7',
+          },
+        },
+      };
+    }
+    const actual = await updateNodeWorkspacePackagesDependencies(
+      getPackages(false)
+    );
+    const expected = getPackages(true);
+    expect(actual).to.eql(expected);
+  });
+});

--- a/typings/lerna__package-graph.d.ts
+++ b/typings/lerna__package-graph.d.ts
@@ -1,0 +1,36 @@
+// Copyright 2021 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+/**
+ * skeleton only representing what we use.
+ */
+declare module '@lerna/package-graph' {
+  import Package = require('@lerna/package');
+  import npa = require('npm-package-arg');
+
+  class PackageGraphNode {
+    localDependencies: Map<string, npa.Result>;
+  }
+
+  class PackageGraph extends Map {
+    constructor(
+      packages: Package[],
+      graphType: 'allDependencies' | 'dependencies'
+    );
+
+    get(name: string): PackageGraphNode;
+  }
+
+  export = PackageGraph;
+}

--- a/typings/lerna__package.d.ts
+++ b/typings/lerna__package.d.ts
@@ -1,0 +1,44 @@
+// Copyright 2021 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+/**
+ * skeleton only representing what we use.
+ */
+declare module '@lerna/package' {
+  interface PackageJson {
+    name: string;
+    version: string;
+    dependencies?: Record<string, string>;
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    [key: string]: any;
+  }
+
+  import npa = require('npm-package-arg');
+
+  class Package {
+    location: string;
+    name: string;
+    constructor(pkg: PackageJson, location: string, rootPath?: string);
+
+    updateLocalDependency(
+      resolved: npa.Result,
+      depVersion: string,
+      savePrefix: string
+    ): void;
+
+    toJSON(): PackageJson;
+  }
+
+  export = Package;
+}

--- a/typings/lerna__run-topologically.d.ts
+++ b/typings/lerna__run-topologically.d.ts
@@ -1,0 +1,32 @@
+// Copyright 2021 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+/**
+ * skeleton only representing what we use.
+ */
+declare module '@lerna/run-topologically' {
+  import Package = require('@lerna/package');
+  interface Options {
+    concurrency: number;
+    graphType: 'allDependencies' | 'dependencies';
+    rejectCycles: boolean;
+  }
+  function runTopologically(
+    packages: Package[],
+    runner: (pkg: Package) => Promise<Package>,
+    opts: Options
+  ): Promise<Package[]>;
+
+  export = runTopologically;
+}


### PR DESCRIPTION
this is just a prototype PR to discuss the plumbing implementation - not intended to be merged

Note to readers: my domain experience in package management in general is slim to none. My experience configuring javascript monorepos with intra-repo dependencies is likewise very limited. I acknowledge that I'm operating off one way of setting this up: [yarn-classic workspaces in our sdk-codegen repo](https://github.com/looker-open-source/sdk-codegen/blob/20ca1915776b657f958cf3182843d72fc4ec1344/package.json#L7). please feel free to point out other approaches that this prototype might fail to address.