### PR TITLE
Revert "fix: use resolove to find imports in tests"

### DIFF
--- a/src/github.ts
+++ b/src/github.ts
@@ -66,7 +66,6 @@ import {
   PREdge,
 } from './graphql-to-commits';
 import {Update} from './updaters/update';
-import {resolve} from 'path';
 
 // Short explanation of this regex:
 // - skip the owner tag (e.g. googleapis)
@@ -154,7 +153,7 @@ export class GitHub {
         baseUrl: this.apiUrl,
         headers: {
           'user-agent': `release-please/${
-            require(resolve('package.json')).version
+            require('../../package.json').version
           }`,
           // some proxies do not require the token prefix.
           Authorization: `${this.proxyKey ? '' : 'token '}${this.token}`,

--- a/test/github-release.ts
+++ b/test/github-release.ts
@@ -26,7 +26,7 @@ import {GitHubRelease} from '../src/github-release';
 const fixturesPath = './test/fixtures';
 
 // eslint-disable-next-line @typescript-eslint/no-var-requires
-const repoInfo = require(resolve('./test/fixtures/repo-get-2.json'));
+const repoInfo = require('../../test/fixtures/repo-get-2.json');
 
 describe('GitHubRelease', () => {
   describe('createRelease', () => {

--- a/test/release-pr-factory.ts
+++ b/test/release-pr-factory.ts
@@ -95,7 +95,7 @@ describe('ReleasePRFactory', () => {
         // check for default branch
         .get('/repos/googleapis/simple-test-repo')
         // eslint-disable-next-line @typescript-eslint/no-var-requires
-        .reply(200, require(resolve('./test/fixtures/repo-get-2.json')))
+        .reply(200, require('../../test/fixtures/repo-get-2.json'))
         // this step tries to close any existing PRs; just return an empty list.
         .get('/repos/googleapis/simple-test-repo/pulls?state=open&per_page=100')
         .reply(200, [])
@@ -189,7 +189,7 @@ describe('ReleasePRFactory', () => {
         // check for default branch
         .get('/repos/googleapis/simple-test-repo')
         // eslint-disable-next-line @typescript-eslint/no-var-requires
-        .reply(200, require(resolve('./test/fixtures/repo-get-2.json')))
+        .reply(200, require('../../test/fixtures/repo-get-2.json'))
         // this step tries to close any existing PRs; just return an empty list.
         .get('/repos/googleapis/simple-test-repo/pulls?state=open&per_page=100')
         .reply(200, [])

--- a/test/release-pr.ts
+++ b/test/release-pr.ts
@@ -230,7 +230,7 @@ describe('Release-PR', () => {
         // check for default branch
         .get('/repos/googleapis/release-please')
         // eslint-disable-next-line @typescript-eslint/no-var-requires
-        .reply(200, require(resolve('./test/fixtures/repo-get-1.json')))
+        .reply(200, require('../../test/fixtures/repo-get-1.json'))
         // this step tries to close any existing PRs; just return an empty list.
         .get('/repos/googleapis/release-please/pulls?state=open&per_page=100')
         .reply(200, []);

--- a/test/releasers/node.ts
+++ b/test/releasers/node.ts
@@ -42,7 +42,7 @@ function mockRequest(snapName: string, requestPrefix = '') {
     // check for default branch
     .get('/repos/googleapis/node-test-repo')
     // eslint-disable-next-line @typescript-eslint/no-var-requires
-    .reply(200, require(resolve('test/fixtures/repo-get-1.json')))
+    .reply(200, require('../../../test/fixtures/repo-get-1.json'))
     .get(
       '/repos/googleapis/node-test-repo/pulls?state=closed&per_page=100&sort=created&direction=desc'
     )
@@ -251,7 +251,7 @@ describe('Node', () => {
       const req = nock('https://api.github.com')
         .get('/repos/googleapis/node-test-repo')
         // eslint-disable-next-line @typescript-eslint/no-var-requires
-        .reply(200, require(resolve('./test/fixtures/repo-get-1.json')))
+        .reply(200, require('../../../test/fixtures/repo-get-1.json'))
         .get(
           '/repos/googleapis/node-test-repo/contents/package.json?ref=refs/heads/master'
         )
@@ -273,7 +273,7 @@ describe('Node', () => {
       const req = nock('https://api.github.com')
         .get('/repos/googleapis/node-test-repo')
         // eslint-disable-next-line @typescript-eslint/no-var-requires
-        .reply(200, require(resolve('./test/fixtures/repo-get-1.json')))
+        .reply(200, require('../../../test/fixtures/repo-get-1.json'))
         .get(
           '/repos/googleapis/node-test-repo/contents/some-path%2Fpackage.json?ref=refs/heads/master'
         )

--- a/test/releasers/yoshi-go.ts
+++ b/test/releasers/yoshi-go.ts
@@ -88,7 +88,7 @@ describe('YoshiGo', () => {
         // check for default branch
         .get('/repos/googleapis/google-cloud-go')
         // eslint-disable-next-line @typescript-eslint/no-var-requires
-        .reply(200, require(resolve('./test/fixtures/repo-get-1.json')))
+        .reply(200, require('../../../test/fixtures/repo-get-1.json'))
         // create release
         .post(
           '/repos/googleapis/google-cloud-go/issues/22/labels',
@@ -178,7 +178,7 @@ describe('YoshiGo', () => {
         // check for default branch
         .get('/repos/googleapis/google-api-go-client')
         // eslint-disable-next-line @typescript-eslint/no-var-requires
-        .reply(200, require(resolve('./test/fixtures/repo-get-1.json')));
+        .reply(200, require('../../../test/fixtures/repo-get-1.json'));
 
       const pr = await releasePR.run();
       assert.strictEqual(pr, 22);
@@ -254,7 +254,7 @@ describe('YoshiGo', () => {
       // check for default branch
       .get('/repos/googleapis/google-cloud-go')
       // eslint-disable-next-line @typescript-eslint/no-var-requires
-      .reply(200, require(resolve('./test/fixtures/repo-get-1.json')));
+      .reply(200, require('../../../test/fixtures/repo-get-1.json'));
 
     const pr = await releasePR.run();
     assert.strictEqual(pr, 22);


### PR DESCRIPTION
This breaks the packaged version of the library.

Reverts googleapis/release-please#715