### PR TITLE
feat: add GitHub#commitsSince and GitHub#findMergeCommit

### DIFF
--- a/__snapshots__/github.js
+++ b/__snapshots__/github.js
@@ -529,3 +529,87 @@ exports['GitHub findMergedPullRequests finds merged pull requests with labels 1'
     "body": "(cherry picked from commit a03d7dcdd8458d5c3542ec2914a031afd69815cf)\r\n"
   }
 ]
+
+exports['GitHub commitsSince finds commits up until a condition 1'] = [
+  {
+    "sha": "e6daec403626c9987c7af0d97b34f324cd84320a",
+    "message": "Merge pull request #7 from chingor13/feature-branch-plain-merge\n\nfeat: feature that will be plain merged",
+    "files": []
+  }
+]
+
+exports['GitHub commitsSince paginates through commits 1'] = [
+  {
+    "sha": "e6daec403626c9987c7af0d97b34f324cd84320a",
+    "message": "Merge pull request #7 from chingor13/feature-branch-plain-merge\n\nfeat: feature that will be plain merged",
+    "files": []
+  },
+  {
+    "sha": "b29149f890e6f76ee31ed128585744d4c598924c",
+    "message": "feat: feature-branch-plain-merge commit 2",
+    "files": []
+  },
+  {
+    "sha": "27d7d7232e2e312d1380e906984f0823f5decf61",
+    "message": "feat: feature-branch-plain-merge commit 1",
+    "files": []
+  },
+  {
+    "sha": "2b4e0b3be2e231cd87cc44c411bd8f84b4587ab5",
+    "message": "fix: feature-branch-merge fix 1",
+    "files": []
+  },
+  {
+    "sha": "a257514a541d483425118d973674b1ce006a5489",
+    "message": "chore: feature-branch-merge lint",
+    "files": []
+  },
+  {
+    "sha": "b6a8ab1a50106cfb03f22c2cdaf7abfdcccce088",
+    "message": "feat: feature-branch-merge commit 2",
+    "files": []
+  },
+  {
+    "sha": "520b6f42551c86002197d033564a76a3f99b0019",
+    "message": "feat: feature-branch-merge commit 1",
+    "files": []
+  },
+  {
+    "sha": "9dda1a331d311d0a7643015cc9e6802548c8d943",
+    "message": "chore(main): release 0.1.1-SNAPSHOT (#3)",
+    "files": []
+  },
+  {
+    "sha": "e86984fb22ccc5eafb6c3d815851ade3463193da",
+    "message": "feat: feature-branch that will be squash merged (#2)\n\n* feat: feature-branch commit 1\r\n\r\n* feat: feature-branch commit 2\r\n\r\n* chore: fix lint\r\n\r\n* fix: feature-branch fix 1",
+    "files": []
+  },
+  {
+    "sha": "0cda26c2e7776748072ba5a24302474947b3ebbd",
+    "message": "build: add release-please bot",
+    "files": []
+  },
+  {
+    "sha": "959ee48c95f254300eb040c46ebdc8248317efe4",
+    "message": "Release v0.1.0 (#1)",
+    "files": []
+  }
+]
+
+exports['GitHub commitsSince finds first commit of a multi-commit merge pull request 1'] = [
+  {
+    "sha": "e6daec403626c9987c7af0d97b34f324cd84320a",
+    "message": "Merge pull request #7 from chingor13/feature-branch-plain-merge\n\nfeat: feature that will be plain merged",
+    "files": []
+  },
+  {
+    "sha": "b29149f890e6f76ee31ed128585744d4c598924c",
+    "message": "feat: feature-branch-plain-merge commit 2",
+    "files": []
+  },
+  {
+    "sha": "27d7d7232e2e312d1380e906984f0823f5decf61",
+    "message": "feat: feature-branch-plain-merge commit 1",
+    "files": []
+  }
+]

--- a/__snapshots__/github.js
+++ b/__snapshots__/github.js
@@ -613,6 +613,7 @@ exports['GitHub commitsSince finds first commit of a multi-commit merge pull req
     "files": []
   }
 ]
+
 exports['GitHub createRelease should create a release with a package prefix 1'] = {
   "tag_name": "v1.2.3",
   "target_commitish": "abc123",
@@ -628,3 +629,56 @@ exports['GitHub createRelease should create a release without a package prefix 1
   "name": "v1.2.3",
   "draft": false
 }
+
+exports['GitHub commitsSince limits pagination 1'] = [
+  {
+    "sha": "e6daec403626c9987c7af0d97b34f324cd84320a",
+    "message": "Merge pull request #7 from chingor13/feature-branch-plain-merge\n\nfeat: feature that will be plain merged",
+    "files": []
+  },
+  {
+    "sha": "b29149f890e6f76ee31ed128585744d4c598924c",
+    "message": "feat: feature-branch-plain-merge commit 2",
+    "files": []
+  },
+  {
+    "sha": "27d7d7232e2e312d1380e906984f0823f5decf61",
+    "message": "feat: feature-branch-plain-merge commit 1",
+    "files": []
+  },
+  {
+    "sha": "2b4e0b3be2e231cd87cc44c411bd8f84b4587ab5",
+    "message": "fix: feature-branch-merge fix 1",
+    "files": []
+  },
+  {
+    "sha": "a257514a541d483425118d973674b1ce006a5489",
+    "message": "chore: feature-branch-merge lint",
+    "files": []
+  },
+  {
+    "sha": "b6a8ab1a50106cfb03f22c2cdaf7abfdcccce088",
+    "message": "feat: feature-branch-merge commit 2",
+    "files": []
+  },
+  {
+    "sha": "520b6f42551c86002197d033564a76a3f99b0019",
+    "message": "feat: feature-branch-merge commit 1",
+    "files": []
+  },
+  {
+    "sha": "9dda1a331d311d0a7643015cc9e6802548c8d943",
+    "message": "chore(main): release 0.1.1-SNAPSHOT (#3)",
+    "files": []
+  },
+  {
+    "sha": "e86984fb22ccc5eafb6c3d815851ade3463193da",
+    "message": "feat: feature-branch that will be squash merged (#2)\n\n* feat: feature-branch commit 1\r\n\r\n* feat: feature-branch commit 2\r\n\r\n* chore: fix lint\r\n\r\n* fix: feature-branch fix 1",
+    "files": []
+  },
+  {
+    "sha": "0cda26c2e7776748072ba5a24302474947b3ebbd",
+    "message": "build: add release-please bot",
+    "files": []
+  }
+]

--- a/src/github.ts
+++ b/src/github.ts
@@ -583,7 +583,7 @@ export class GitHub {
     return tags;
   }
 
-  private async pullRequestsSinceGraphQL(
+  private async mergeCommitsGraphQL(
     cursor?: string
   ): Promise<PullRequestHistory> {
     const targetBranch = await this.getDefaultBranch();
@@ -674,7 +674,7 @@ export class GitHub {
     let cursor: string | undefined = undefined;
     let found: CommitWithPullRequest | undefined = undefined;
     while (!found) {
-      const response: PullRequestHistory = await this.pullRequestsSinceGraphQL(
+      const response: PullRequestHistory = await this.mergeCommitsGraphQL(
         cursor
       );
       found = response.data.find(commitWithPullRequest => {
@@ -693,8 +693,8 @@ export class GitHub {
   }
 
   /**
-   * Returns the unique list of pull requests merged to this commit after
-   * the provided filter query has been satified.
+   * Returns the list of commits to the default branch after the provided filter
+   * query has been satified.
    *
    * @param {CommitFilter} filter - Callback function that returns whether a
    *   commit/pull request matches certain criteria
@@ -705,7 +705,7 @@ export class GitHub {
     const commits: Commit[] = [];
     let found: CommitWithPullRequest | undefined = undefined;
     while (!found) {
-      const response: PullRequestHistory = await this.pullRequestsSinceGraphQL(
+      const response: PullRequestHistory = await this.mergeCommitsGraphQL(
         cursor
       );
       found = response.data.find(commitWithPullRequest => {
@@ -824,7 +824,18 @@ export class GitHub {
   }
 
   // The default matcher will rule out pre-releases.
-  // TODO: make this handle more than 100 results using async iterator.
+  /**
+   * Find the last merged pull request that targeted the default
+   * branch and looks like a release PR.
+   *
+   * @param {string[]} labels - If provided, ensure that the pull
+   *   request has all of the specified labels
+   * @param {string|undefined} branchPrefix - If provided, limit
+   *   release pull requests that contain the specified component
+   * @param {boolean} preRelease - Whether to include pre-release
+   *   versions in the response. Defaults to true.
+   * @returns {MergedGitHubPR|undefined}
+   */
   async findMergedReleasePR(
     labels: string[],
     branchPrefix: string | undefined = undefined,

--- a/test/fixtures/commits-since-page-1.json
+++ b/test/fixtures/commits-since-page-1.json
@@ -10,6 +10,7 @@
                   {
                     "number": 7,
                     "title": "feat: feature that will be plain merged",
+                    "baseRefName": "main",
                     "headRefName": "feature-branch-plain-merge",
                     "labels": {
                       "nodes": []
@@ -27,6 +28,7 @@
                   {
                     "number": 7,
                     "title": "feat: feature that will be plain merged",
+                    "baseRefName": "main",
                     "headRefName": "feature-branch-plain-merge",
                     "labels": {
                       "nodes": []
@@ -44,6 +46,7 @@
                   {
                     "number": 7,
                     "title": "feat: feature that will be plain merged",
+                    "baseRefName": "main",
                     "headRefName": "feature-branch-plain-merge",
                     "labels": {
                       "nodes": []
@@ -61,6 +64,7 @@
                   {
                     "number": 6,
                     "title": "feat: feature that will be rebase merged",
+                    "baseRefName": "main",
                     "headRefName": "feature-branch-merge",
                     "labels": {
                       "nodes": []
@@ -78,6 +82,7 @@
                   {
                     "number": 6,
                     "title": "feat: feature that will be rebase merged",
+                    "baseRefName": "main",
                     "headRefName": "feature-branch-merge",
                     "labels": {
                       "nodes": []
@@ -95,6 +100,7 @@
                   {
                     "number": 6,
                     "title": "feat: feature that will be rebase merged",
+                    "baseRefName": "main",
                     "headRefName": "feature-branch-merge",
                     "labels": {
                       "nodes": []
@@ -112,6 +118,7 @@
                   {
                     "number": 6,
                     "title": "feat: feature that will be rebase merged",
+                    "baseRefName": "main",
                     "headRefName": "feature-branch-merge",
                     "labels": {
                       "nodes": []
@@ -129,6 +136,7 @@
                   {
                     "number": 3,
                     "title": "chore(main): release 0.1.1-SNAPSHOT",
+                    "baseRefName": "main",
                     "headRefName": "release-please/branches/main",
                     "labels": {
                       "nodes": [
@@ -150,6 +158,7 @@
                   {
                     "number": 2,
                     "title": "feat: feature-branch that will be squash merged",
+                    "baseRefName": "main",
                     "headRefName": "feature-branch",
                     "labels": {
                       "nodes": []

--- a/test/fixtures/commits-since-page-1.json
+++ b/test/fixtures/commits-since-page-1.json
@@ -1,0 +1,180 @@
+{
+  "repository": {
+    "ref": {
+      "target": {
+        "history": {
+          "nodes": [
+            {
+              "associatedPullRequests": {
+                "nodes": [
+                  {
+                    "number": 7,
+                    "title": "feat: feature that will be plain merged",
+                    "headRefName": "feature-branch-plain-merge",
+                    "labels": {
+                      "nodes": []
+                    },
+                    "body": ""
+                  }
+                ]
+              },
+              "sha": "e6daec403626c9987c7af0d97b34f324cd84320a",
+              "message": "Merge pull request #7 from chingor13/feature-branch-plain-merge\n\nfeat: feature that will be plain merged"
+            },
+            {
+              "associatedPullRequests": {
+                "nodes": [
+                  {
+                    "number": 7,
+                    "title": "feat: feature that will be plain merged",
+                    "headRefName": "feature-branch-plain-merge",
+                    "labels": {
+                      "nodes": []
+                    },
+                    "body": ""
+                  }
+                ]
+              },
+              "sha": "b29149f890e6f76ee31ed128585744d4c598924c",
+              "message": "feat: feature-branch-plain-merge commit 2"
+            },
+            {
+              "associatedPullRequests": {
+                "nodes": [
+                  {
+                    "number": 7,
+                    "title": "feat: feature that will be plain merged",
+                    "headRefName": "feature-branch-plain-merge",
+                    "labels": {
+                      "nodes": []
+                    },
+                    "body": ""
+                  }
+                ]
+              },
+              "sha": "27d7d7232e2e312d1380e906984f0823f5decf61",
+              "message": "feat: feature-branch-plain-merge commit 1"
+            },
+            {
+              "associatedPullRequests": {
+                "nodes": [
+                  {
+                    "number": 6,
+                    "title": "feat: feature that will be rebase merged",
+                    "headRefName": "feature-branch-merge",
+                    "labels": {
+                      "nodes": []
+                    },
+                    "body": ""
+                  }
+                ]
+              },
+              "sha": "2b4e0b3be2e231cd87cc44c411bd8f84b4587ab5",
+              "message": "fix: feature-branch-merge fix 1"
+            },
+            {
+              "associatedPullRequests": {
+                "nodes": [
+                  {
+                    "number": 6,
+                    "title": "feat: feature that will be rebase merged",
+                    "headRefName": "feature-branch-merge",
+                    "labels": {
+                      "nodes": []
+                    },
+                    "body": ""
+                  }
+                ]
+              },
+              "sha": "a257514a541d483425118d973674b1ce006a5489",
+              "message": "chore: feature-branch-merge lint"
+            },
+            {
+              "associatedPullRequests": {
+                "nodes": [
+                  {
+                    "number": 6,
+                    "title": "feat: feature that will be rebase merged",
+                    "headRefName": "feature-branch-merge",
+                    "labels": {
+                      "nodes": []
+                    },
+                    "body": ""
+                  }
+                ]
+              },
+              "sha": "b6a8ab1a50106cfb03f22c2cdaf7abfdcccce088",
+              "message": "feat: feature-branch-merge commit 2"
+            },
+            {
+              "associatedPullRequests": {
+                "nodes": [
+                  {
+                    "number": 6,
+                    "title": "feat: feature that will be rebase merged",
+                    "headRefName": "feature-branch-merge",
+                    "labels": {
+                      "nodes": []
+                    },
+                    "body": ""
+                  }
+                ]
+              },
+              "sha": "520b6f42551c86002197d033564a76a3f99b0019",
+              "message": "feat: feature-branch-merge commit 1"
+            },
+            {
+              "associatedPullRequests": {
+                "nodes": [
+                  {
+                    "number": 3,
+                    "title": "chore(main): release 0.1.1-SNAPSHOT",
+                    "headRefName": "release-please/branches/main",
+                    "labels": {
+                      "nodes": [
+                        {
+                          "name": "type: process"
+                        }
+                      ]
+                    },
+                    "body": ":robot: I have created a release \\*beep\\* \\*boop\\* \n---\n### Updating meta-information for bleeding-edge SNAPSHOT release.\n---\n\n\nThis PR was generated with [Release Please](https://github.com/googleapis/release-please). See [documentation](https://github.com/googleapis/release-please#release-please)."
+                  }
+                ]
+              },
+              "sha": "9dda1a331d311d0a7643015cc9e6802548c8d943",
+              "message": "chore(main): release 0.1.1-SNAPSHOT (#3)"
+            },
+            {
+              "associatedPullRequests": {
+                "nodes": [
+                  {
+                    "number": 2,
+                    "title": "feat: feature-branch that will be squash merged",
+                    "headRefName": "feature-branch",
+                    "labels": {
+                      "nodes": []
+                    },
+                    "body": ""
+                  }
+                ]
+              },
+              "sha": "e86984fb22ccc5eafb6c3d815851ade3463193da",
+              "message": "feat: feature-branch that will be squash merged (#2)\n\n* feat: feature-branch commit 1\r\n\r\n* feat: feature-branch commit 2\r\n\r\n* chore: fix lint\r\n\r\n* fix: feature-branch fix 1"
+            },
+            {
+              "associatedPullRequests": {
+                "nodes": []
+              },
+              "sha": "0cda26c2e7776748072ba5a24302474947b3ebbd",
+              "message": "build: add release-please bot"
+            }
+          ],
+          "pageInfo": {
+            "hasNextPage": true,
+            "endCursor": "e6daec403626c9987c7af0d97b34f324cd84320a 9"
+          }
+        }
+      }
+    }
+  }
+}

--- a/test/fixtures/commits-since-page-2.json
+++ b/test/fixtures/commits-since-page-2.json
@@ -1,0 +1,51 @@
+{
+  "repository": {
+    "ref": {
+      "target": {
+        "history": {
+          "nodes": [
+            {
+              "associatedPullRequests": {
+                "nodes": [
+                  {
+                    "number": 1,
+                    "title": "Release release-please-test v0.1.0",
+                    "headRefName": "release-release-please-test-v0.1.0",
+                    "labels": {
+                      "nodes": [
+                        {
+                          "name": "autorelease: tagged"
+                        }
+                      ]
+                    },
+                    "body": "This pull request was generated using releasetool.\n\n02-03-2021 11:56 PST\n\n### New Features\n- feat: initial commit\n\n### Internal / Testing Changes\n- build: add java structure"
+                  }
+                ]
+              },
+              "sha": "959ee48c95f254300eb040c46ebdc8248317efe4",
+              "message": "Release v0.1.0 (#1)"
+            },
+            {
+              "associatedPullRequests": {
+                "nodes": []
+              },
+              "sha": "c6d9dfb03aa2dbe1abc329592af60713fe28586d",
+              "message": "build: add java structure"
+            },
+            {
+              "associatedPullRequests": {
+                "nodes": []
+              },
+              "sha": "c8f1498c92c323bfa8f5ffe84e0ade1c37e4ea6e",
+              "message": "feat: initial commit"
+            }
+          ],
+          "pageInfo": {
+            "hasNextPage": false,
+            "endCursor": "e6daec403626c9987c7af0d97b34f324cd84320a 12"
+          }
+        }
+      }
+    }
+  }
+}

--- a/test/fixtures/commits-since-page-2.json
+++ b/test/fixtures/commits-since-page-2.json
@@ -10,6 +10,7 @@
                   {
                     "number": 1,
                     "title": "Release release-please-test v0.1.0",
+                    "baseRefName": "main",
                     "headRefName": "release-release-please-test-v0.1.0",
                     "labels": {
                       "nodes": [

--- a/test/fixtures/commits-since.json
+++ b/test/fixtures/commits-since.json
@@ -10,6 +10,7 @@
                   {
                     "number": 7,
                     "title": "feat: feature that will be plain merged",
+                    "baseRefName": "main",
                     "headRefName": "feature-branch-plain-merge",
                     "labels": {
                       "nodes": []
@@ -27,6 +28,7 @@
                   {
                     "number": 7,
                     "title": "feat: feature that will be plain merged",
+                    "baseRefName": "main",
                     "headRefName": "feature-branch-plain-merge",
                     "labels": {
                       "nodes": []
@@ -44,6 +46,7 @@
                   {
                     "number": 7,
                     "title": "feat: feature that will be plain merged",
+                    "baseRefName": "main",
                     "headRefName": "feature-branch-plain-merge",
                     "labels": {
                       "nodes": []
@@ -61,6 +64,7 @@
                   {
                     "number": 6,
                     "title": "feat: feature that will be rebase merged",
+                    "baseRefName": "main",
                     "headRefName": "feature-branch-merge",
                     "labels": {
                       "nodes": []
@@ -78,6 +82,7 @@
                   {
                     "number": 6,
                     "title": "feat: feature that will be rebase merged",
+                    "baseRefName": "main",
                     "headRefName": "feature-branch-merge",
                     "labels": {
                       "nodes": []
@@ -95,6 +100,7 @@
                   {
                     "number": 6,
                     "title": "feat: feature that will be rebase merged",
+                    "baseRefName": "main",
                     "headRefName": "feature-branch-merge",
                     "labels": {
                       "nodes": []
@@ -112,6 +118,7 @@
                   {
                     "number": 6,
                     "title": "feat: feature that will be rebase merged",
+                    "baseRefName": "main",
                     "headRefName": "feature-branch-merge",
                     "labels": {
                       "nodes": []
@@ -129,6 +136,7 @@
                   {
                     "number": 3,
                     "title": "chore(main): release 0.1.1-SNAPSHOT",
+                    "baseRefName": "main",
                     "headRefName": "release-please/branches/main",
                     "labels": {
                       "nodes": [
@@ -150,6 +158,7 @@
                   {
                     "number": 2,
                     "title": "feat: feature-branch that will be squash merged",
+                    "baseRefName": "main",
                     "headRefName": "feature-branch",
                     "labels": {
                       "nodes": []
@@ -174,6 +183,7 @@
                   {
                     "number": 1,
                     "title": "Release release-please-test v0.1.0",
+                    "baseRefName": "main",
                     "headRefName": "release-release-please-test-v0.1.0",
                     "labels": {
                       "nodes": [

--- a/test/fixtures/commits-since.json
+++ b/test/fixtures/commits-since.json
@@ -1,0 +1,215 @@
+{
+  "repository": {
+    "ref": {
+      "target": {
+        "history": {
+          "nodes": [
+            {
+              "associatedPullRequests": {
+                "nodes": [
+                  {
+                    "number": 7,
+                    "title": "feat: feature that will be plain merged",
+                    "headRefName": "feature-branch-plain-merge",
+                    "labels": {
+                      "nodes": []
+                    },
+                    "body": ""
+                  }
+                ]
+              },
+              "sha": "e6daec403626c9987c7af0d97b34f324cd84320a",
+              "message": "Merge pull request #7 from chingor13/feature-branch-plain-merge\n\nfeat: feature that will be plain merged"
+            },
+            {
+              "associatedPullRequests": {
+                "nodes": [
+                  {
+                    "number": 7,
+                    "title": "feat: feature that will be plain merged",
+                    "headRefName": "feature-branch-plain-merge",
+                    "labels": {
+                      "nodes": []
+                    },
+                    "body": ""
+                  }
+                ]
+              },
+              "sha": "b29149f890e6f76ee31ed128585744d4c598924c",
+              "message": "feat: feature-branch-plain-merge commit 2"
+            },
+            {
+              "associatedPullRequests": {
+                "nodes": [
+                  {
+                    "number": 7,
+                    "title": "feat: feature that will be plain merged",
+                    "headRefName": "feature-branch-plain-merge",
+                    "labels": {
+                      "nodes": []
+                    },
+                    "body": ""
+                  }
+                ]
+              },
+              "sha": "27d7d7232e2e312d1380e906984f0823f5decf61",
+              "message": "feat: feature-branch-plain-merge commit 1"
+            },
+            {
+              "associatedPullRequests": {
+                "nodes": [
+                  {
+                    "number": 6,
+                    "title": "feat: feature that will be rebase merged",
+                    "headRefName": "feature-branch-merge",
+                    "labels": {
+                      "nodes": []
+                    },
+                    "body": ""
+                  }
+                ]
+              },
+              "sha": "2b4e0b3be2e231cd87cc44c411bd8f84b4587ab5",
+              "message": "fix: feature-branch-merge fix 1"
+            },
+            {
+              "associatedPullRequests": {
+                "nodes": [
+                  {
+                    "number": 6,
+                    "title": "feat: feature that will be rebase merged",
+                    "headRefName": "feature-branch-merge",
+                    "labels": {
+                      "nodes": []
+                    },
+                    "body": ""
+                  }
+                ]
+              },
+              "sha": "a257514a541d483425118d973674b1ce006a5489",
+              "message": "chore: feature-branch-merge lint"
+            },
+            {
+              "associatedPullRequests": {
+                "nodes": [
+                  {
+                    "number": 6,
+                    "title": "feat: feature that will be rebase merged",
+                    "headRefName": "feature-branch-merge",
+                    "labels": {
+                      "nodes": []
+                    },
+                    "body": ""
+                  }
+                ]
+              },
+              "sha": "b6a8ab1a50106cfb03f22c2cdaf7abfdcccce088",
+              "message": "feat: feature-branch-merge commit 2"
+            },
+            {
+              "associatedPullRequests": {
+                "nodes": [
+                  {
+                    "number": 6,
+                    "title": "feat: feature that will be rebase merged",
+                    "headRefName": "feature-branch-merge",
+                    "labels": {
+                      "nodes": []
+                    },
+                    "body": ""
+                  }
+                ]
+              },
+              "sha": "520b6f42551c86002197d033564a76a3f99b0019",
+              "message": "feat: feature-branch-merge commit 1"
+            },
+            {
+              "associatedPullRequests": {
+                "nodes": [
+                  {
+                    "number": 3,
+                    "title": "chore(main): release 0.1.1-SNAPSHOT",
+                    "headRefName": "release-please/branches/main",
+                    "labels": {
+                      "nodes": [
+                        {
+                          "name": "type: process"
+                        }
+                      ]
+                    },
+                    "body": ":robot: I have created a release \\*beep\\* \\*boop\\* \n---\n### Updating meta-information for bleeding-edge SNAPSHOT release.\n---\n\n\nThis PR was generated with [Release Please](https://github.com/googleapis/release-please). See [documentation](https://github.com/googleapis/release-please#release-please)."
+                  }
+                ]
+              },
+              "sha": "9dda1a331d311d0a7643015cc9e6802548c8d943",
+              "message": "chore(main): release 0.1.1-SNAPSHOT (#3)"
+            },
+            {
+              "associatedPullRequests": {
+                "nodes": [
+                  {
+                    "number": 2,
+                    "title": "feat: feature-branch that will be squash merged",
+                    "headRefName": "feature-branch",
+                    "labels": {
+                      "nodes": []
+                    },
+                    "body": ""
+                  }
+                ]
+              },
+              "sha": "e86984fb22ccc5eafb6c3d815851ade3463193da",
+              "message": "feat: feature-branch that will be squash merged (#2)\n\n* feat: feature-branch commit 1\r\n\r\n* feat: feature-branch commit 2\r\n\r\n* chore: fix lint\r\n\r\n* fix: feature-branch fix 1"
+            },
+            {
+              "associatedPullRequests": {
+                "nodes": []
+              },
+              "sha": "0cda26c2e7776748072ba5a24302474947b3ebbd",
+              "message": "build: add release-please bot"
+            },
+            {
+              "associatedPullRequests": {
+                "nodes": [
+                  {
+                    "number": 1,
+                    "title": "Release release-please-test v0.1.0",
+                    "headRefName": "release-release-please-test-v0.1.0",
+                    "labels": {
+                      "nodes": [
+                        {
+                          "name": "autorelease: tagged"
+                        }
+                      ]
+                    },
+                    "body": "This pull request was generated using releasetool.\n\n02-03-2021 11:56 PST\n\n### New Features\n- feat: initial commit\n\n### Internal / Testing Changes\n- build: add java structure"
+                  }
+                ]
+              },
+              "sha": "959ee48c95f254300eb040c46ebdc8248317efe4",
+              "message": "Release v0.1.0 (#1)"
+            },
+            {
+              "associatedPullRequests": {
+                "nodes": []
+              },
+              "sha": "c6d9dfb03aa2dbe1abc329592af60713fe28586d",
+              "message": "build: add java structure"
+            },
+            {
+              "associatedPullRequests": {
+                "nodes": []
+              },
+              "sha": "c8f1498c92c323bfa8f5ffe84e0ade1c37e4ea6e",
+              "message": "feat: initial commit"
+            }
+          ],
+          "pageInfo": {
+            "hasNextPage": false,
+            "endCursor": "e6daec403626c9987c7af0d97b34f324cd84320a 12"
+          }
+        }
+      }
+    }
+  }
+}

--- a/test/fixtures/latest-tag-alternate-branch.json
+++ b/test/fixtures/latest-tag-alternate-branch.json
@@ -1,0 +1,118 @@
+{
+  "repository": {
+    "ref": {
+      "target": {
+        "history": {
+          "nodes": [
+            {
+              "associatedPullRequests": {
+                "nodes": [
+                  {
+                    "number": 4,
+                    "title": "chore: release v2.0.0-rc1",
+                    "baseRefName": "legacy-8",
+                    "headRefName": "release-v2.0.0-rc1",
+                    "labels": {
+                      "nodes": [
+                        {
+                          "name": "autorelease: tagged"
+                        }
+                      ]
+                    },
+                    "body": "This pull request was generated using releasetool.\n\n02-03-2021 11:56 PST\n\n### New Features\n- feat: initial commit\n\n### Internal / Testing Changes\n- build: add java structure"
+                  }
+                ]
+              },
+              "sha": "bc329592af60713fe28586dc6d9dfb03aa2dbe1a",
+              "message": "chore: release v2.0.0-rc1"
+            },
+            {
+              "associatedPullRequests": {
+                "nodes": [
+                  {
+                    "number": 2,
+                    "title": "chore: release v1.3.0",
+                    "baseRefName": "legacy-8",
+                    "headRefName": "release-v1.3.0",
+                    "labels": {
+                      "nodes": [
+                        {
+                          "name": "autorelease: tagged"
+                        }
+                      ]
+                    },
+                    "body": "This pull request was generated using releasetool.\n\n02-03-2021 11:56 PST\n\n### New Features\n- feat: initial commit\n\n### Internal / Testing Changes\n- build: add java structure"
+                  }
+                ]
+              },
+              "sha": "92af60713fe28586dc6d9dfb03aa2dbe1abc3295",
+              "message": "chore: release v1.3.0"
+            },
+            {
+              "associatedPullRequests": {
+                "nodes": [
+                  {
+                    "number": 1,
+                    "title": "chore: release v1.2.0",
+                    "baseRefName": "legacy-8",
+                    "headRefName": "release-v1.2.0",
+                    "labels": {
+                      "nodes": [
+                        {
+                          "name": "autorelease: tagged"
+                        }
+                      ]
+                    },
+                    "body": "This pull request was generated using releasetool.\n\n02-03-2021 11:56 PST\n\n### New Features\n- feat: initial commit\n\n### Internal / Testing Changes\n- build: add java structure"
+                  }
+                ]
+              },
+              "sha": "959ee48c95f254300eb040c46ebdc8248317efe4",
+              "message": "chore: release v1.2.0"
+            },
+            {
+              "associatedPullRequests": {
+                "nodes": [
+                  {
+                    "number": 3,
+                    "title": "chore: release v1.1.0",
+                    "baseRefName": "legacy-8",
+                    "headRefName": "release-v1.1.0",
+                    "labels": {
+                      "nodes": [
+                        {
+                          "name": "autorelease: tagged"
+                        }
+                      ]
+                    },
+                    "body": "This pull request was generated using releasetool.\n\n02-03-2021 11:56 PST\n\n### New Features\n- feat: initial commit\n\n### Internal / Testing Changes\n- build: add java structure"
+                  }
+                ]
+              },
+              "sha": "959ee48c95f254300eb040c46ebdc8248317efe4",
+              "message": "chore: release v1.1.0"
+            },
+            {
+              "associatedPullRequests": {
+                "nodes": []
+              },
+              "sha": "c6d9dfb03aa2dbe1abc329592af60713fe28586d",
+              "message": "build: add java structure"
+            },
+            {
+              "associatedPullRequests": {
+                "nodes": []
+              },
+              "sha": "c8f1498c92c323bfa8f5ffe84e0ade1c37e4ea6e",
+              "message": "feat: initial commit"
+            }
+          ],
+          "pageInfo": {
+            "hasNextPage": false,
+            "endCursor": "e6daec403626c9987c7af0d97b34f324cd84320a 12"
+          }
+        }
+      }
+    }
+  }
+}

--- a/test/fixtures/latest-tag-monorepo.json
+++ b/test/fixtures/latest-tag-monorepo.json
@@ -1,0 +1,96 @@
+{
+  "repository": {
+    "ref": {
+      "target": {
+        "history": {
+          "nodes": [
+            {
+              "associatedPullRequests": {
+                "nodes": [
+                  {
+                    "number": 2,
+                    "title": "chore: release complex-package_name-v1 1.1.0",
+                    "baseRefName": "main",
+                    "headRefName": "release-complex-package_name-v1-v1.1.0",
+                    "labels": {
+                      "nodes": [
+                        {
+                          "name": "autorelease: tagged"
+                        }
+                      ]
+                    },
+                    "body": "This pull request was generated using releasetool.\n\n02-03-2021 11:56 PST\n\n### New Features\n- feat: initial commit\n\n### Internal / Testing Changes\n- build: add java structure"
+                  }
+                ]
+              },
+              "sha": "92af60713fe28586dc6d9dfb03aa2dbe1abc3295",
+              "message": "chore: release complex-package_name-v1 1.1.0"
+            },
+            {
+              "associatedPullRequests": {
+                "nodes": [
+                  {
+                    "number": 1,
+                    "title": "chore: release complex-package_name-v2.1 v2.0.0-beta",
+                    "baseRefName": "main",
+                    "headRefName": "release-complex-package_name-v2.1-v2.0.0-beta",
+                    "labels": {
+                      "nodes": [
+                        {
+                          "name": "autorelease: tagged"
+                        }
+                      ]
+                    },
+                    "body": "This pull request was generated using releasetool.\n\n02-03-2021 11:56 PST\n\n### New Features\n- feat: initial commit\n\n### Internal / Testing Changes\n- build: add java structure"
+                  }
+                ]
+              },
+              "sha": "959ee48c95f254300eb040c46ebdc8248317efe4",
+              "message": "chore: release complex-package_name-v2.1 v2.0.0-beta"
+            },
+            {
+              "associatedPullRequests": {
+                "nodes": [
+                  {
+                    "number": 3,
+                    "title": "chore: release v1.3.0",
+                    "baseRefName": "main",
+                    "headRefName": "release-v1.3.0",
+                    "labels": {
+                      "nodes": [
+                        {
+                          "name": "autorelease: tagged"
+                        }
+                      ]
+                    },
+                    "body": "This pull request was generated using releasetool.\n\n02-03-2021 11:56 PST\n\n### New Features\n- feat: initial commit\n\n### Internal / Testing Changes\n- build: add java structure"
+                  }
+                ]
+              },
+              "sha": "959ee48c95f254300eb040c46ebdc8248317efe4",
+              "message": "chore: release v1.3.0"
+            },
+            {
+              "associatedPullRequests": {
+                "nodes": []
+              },
+              "sha": "c6d9dfb03aa2dbe1abc329592af60713fe28586d",
+              "message": "build: add java structure"
+            },
+            {
+              "associatedPullRequests": {
+                "nodes": []
+              },
+              "sha": "c8f1498c92c323bfa8f5ffe84e0ade1c37e4ea6e",
+              "message": "feat: initial commit"
+            }
+          ],
+          "pageInfo": {
+            "hasNextPage": false,
+            "endCursor": "e6daec403626c9987c7af0d97b34f324cd84320a 12"
+          }
+        }
+      }
+    }
+  }
+}

--- a/test/fixtures/latest-tag-no-commits.json
+++ b/test/fixtures/latest-tag-no-commits.json
@@ -1,0 +1,15 @@
+{
+  "repository": {
+    "ref": {
+      "target": {
+        "history": {
+          "nodes": [],
+          "pageInfo": {
+            "hasNextPage": false,
+            "endCursor": "e6daec403626c9987c7af0d97b34f324cd84320a 12"
+          }
+        }
+      }
+    }
+  }
+}

--- a/test/fixtures/latest-tag.json
+++ b/test/fixtures/latest-tag.json
@@ -1,0 +1,118 @@
+{
+  "repository": {
+    "ref": {
+      "target": {
+        "history": {
+          "nodes": [
+            {
+              "associatedPullRequests": {
+                "nodes": [
+                  {
+                    "number": 4,
+                    "title": "chore: release v2.0.0-rc1",
+                    "baseRefName": "main",
+                    "headRefName": "release-v2.0.0-rc1",
+                    "labels": {
+                      "nodes": [
+                        {
+                          "name": "autorelease: tagged"
+                        }
+                      ]
+                    },
+                    "body": "This pull request was generated using releasetool.\n\n02-03-2021 11:56 PST\n\n### New Features\n- feat: initial commit\n\n### Internal / Testing Changes\n- build: add java structure"
+                  }
+                ]
+              },
+              "sha": "bc329592af60713fe28586dc6d9dfb03aa2dbe1a",
+              "message": "chore: release v2.0.0-rc1"
+            },
+            {
+              "associatedPullRequests": {
+                "nodes": [
+                  {
+                    "number": 2,
+                    "title": "chore: release v1.3.0",
+                    "baseRefName": "main",
+                    "headRefName": "release-v1.3.0",
+                    "labels": {
+                      "nodes": [
+                        {
+                          "name": "autorelease: tagged"
+                        }
+                      ]
+                    },
+                    "body": "This pull request was generated using releasetool.\n\n02-03-2021 11:56 PST\n\n### New Features\n- feat: initial commit\n\n### Internal / Testing Changes\n- build: add java structure"
+                  }
+                ]
+              },
+              "sha": "92af60713fe28586dc6d9dfb03aa2dbe1abc3295",
+              "message": "chore: release v1.3.0"
+            },
+            {
+              "associatedPullRequests": {
+                "nodes": [
+                  {
+                    "number": 1,
+                    "title": "chore: release v1.2.0",
+                    "baseRefName": "main",
+                    "headRefName": "release-v1.2.0",
+                    "labels": {
+                      "nodes": [
+                        {
+                          "name": "autorelease: tagged"
+                        }
+                      ]
+                    },
+                    "body": "This pull request was generated using releasetool.\n\n02-03-2021 11:56 PST\n\n### New Features\n- feat: initial commit\n\n### Internal / Testing Changes\n- build: add java structure"
+                  }
+                ]
+              },
+              "sha": "959ee48c95f254300eb040c46ebdc8248317efe4",
+              "message": "chore: release v1.2.0"
+            },
+            {
+              "associatedPullRequests": {
+                "nodes": [
+                  {
+                    "number": 3,
+                    "title": "chore: release v1.1.0",
+                    "baseRefName": "main",
+                    "headRefName": "release-v1.1.0",
+                    "labels": {
+                      "nodes": [
+                        {
+                          "name": "autorelease: tagged"
+                        }
+                      ]
+                    },
+                    "body": "This pull request was generated using releasetool.\n\n02-03-2021 11:56 PST\n\n### New Features\n- feat: initial commit\n\n### Internal / Testing Changes\n- build: add java structure"
+                  }
+                ]
+              },
+              "sha": "959ee48c95f254300eb040c46ebdc8248317efe4",
+              "message": "chore: release v1.1.0"
+            },
+            {
+              "associatedPullRequests": {
+                "nodes": []
+              },
+              "sha": "c6d9dfb03aa2dbe1abc329592af60713fe28586d",
+              "message": "build: add java structure"
+            },
+            {
+              "associatedPullRequests": {
+                "nodes": []
+              },
+              "sha": "c8f1498c92c323bfa8f5ffe84e0ade1c37e4ea6e",
+              "message": "feat: initial commit"
+            }
+          ],
+          "pageInfo": {
+            "hasNextPage": false,
+            "endCursor": "e6daec403626c9987c7af0d97b34f324cd84320a 12"
+          }
+        }
+      }
+    }
+  }
+}

--- a/test/github.ts
+++ b/test/github.ts
@@ -230,189 +230,53 @@ describe('GitHub', () => {
   });
 
   describe('latestTag', () => {
-    const samplePrReturn = [
-      {
-        base: {
-          label: 'fake:prerelease',
-        },
-        head: {
-          label: 'fake:release-v3.0.0-rc1',
-          ref: 'release-v3.0.0-rc1',
-        },
-        merged_at: new Date().toISOString(),
-      },
-      {
-        base: {
-          label: 'fake:main',
-        },
-        head: {
-          label: 'fake:release-v2.0.0-rc1',
-          ref: 'release-v2.0.0-rc1',
-        },
-        merged_at: new Date().toISOString(),
-      },
-      {
-        base: {
-          label: 'fake:legacy-8',
-        },
-        head: {
-          label: 'fake:release-v1.1.5',
-          ref: 'release-v1.1.5',
-        },
-        merged_at: new Date().toISOString(),
-      },
-      {
-        base: {
-          label: 'fake:main',
-        },
-        head: {
-          label: 'fake:release-v1.3.0',
-          ref: 'release-v1.3.0',
-        },
-        merged_at: new Date().toISOString(),
-      },
-      {
-        base: {
-          label: 'fake:main',
-        },
-        head: {
-          label: 'fake:release-v1.2.0',
-          ref: 'release-v1.2.0',
-        },
-        merged_at: new Date().toISOString(),
-      },
-      {
-        base: {
-          label: 'fake:main',
-        },
-        head: {
-          label: 'fake:release-v1.1.0',
-          ref: 'release-v1.1.0',
-        },
-        merged_at: new Date().toISOString(),
-      },
-    ];
-
     it('handles monorepo composite branch names properly', async () => {
-      const sampleResults = [
-        {
-          base: {
-            label: 'fake:main',
-          },
-          head: {
-            label: 'fake:release-complex-package_name-v1-v1.1.0',
-            ref: 'release-complex-package_name-v1-v1.1.0',
-          },
-          merged_at: new Date().toISOString(),
-        },
-        {
-          base: {
-            label: 'fake:main',
-          },
-          head: {
-            label: 'fake:release-complex-package_name-v2.1-v2.0.0-beta',
-            ref: 'release-complex-package_name-v2.1-v2.0.0-beta',
-          },
-          merged_at: new Date().toISOString(),
-        },
-      ];
-      req
-        .get(
-          '/repos/fake/fake/pulls?state=closed&per_page=100&page=1&base=main&sort=created&direction=desc'
-        )
-        .reply(200, sampleResults);
+      const graphql = JSON.parse(
+        readFileSync(resolve(fixturesPath, 'latest-tag-monorepo.json'), 'utf8')
+      );
+      req.post('/graphql').reply(200, {
+        data: graphql,
+      });
       const latestTag = await github.latestTag('complex-package_name-v1-');
       expect(latestTag!.version).to.equal('1.1.0');
       req.done();
     });
 
     it('does not return monorepo composite tag, if no prefix provided', async () => {
-      const sampleResults = [
-        {
-          base: {
-            label: 'fake:main',
-          },
-          head: {
-            label: 'fake:release-complex-package_name-v1-v1.1.0',
-            ref: 'release-complex-package_name-v1-v1.1.0',
-          },
-          merged_at: new Date().toISOString(),
-        },
-        {
-          base: {
-            label: 'fake:main',
-          },
-          head: {
-            label: 'fake:release-complex-package_name-v2.1-v2.0.0-beta',
-            ref: 'release-complex-package_name-v2.1-v2.0.0-beta',
-          },
-          merged_at: new Date().toISOString(),
-        },
-        {
-          base: {
-            label: 'fake:main',
-          },
-          head: {
-            label: 'fake:release-v1.3.0',
-            ref: 'release-v1.3.0',
-          },
-          merged_at: new Date().toISOString(),
-        },
-      ];
-      req
-        .get(
-          '/repos/fake/fake/pulls?state=closed&per_page=100&page=1&base=main&sort=created&direction=desc'
-        )
-        .reply(200, sampleResults);
+      const graphql = JSON.parse(
+        readFileSync(resolve(fixturesPath, 'latest-tag-monorepo.json'), 'utf8')
+      );
+      req.post('/graphql').reply(200, {
+        data: graphql,
+      });
       const latestTag = await github.latestTag();
       expect(latestTag!.version).to.equal('1.3.0');
       req.done();
     });
 
     it('returns the latest tag on the main branch, based on PR date', async () => {
-      const ret = [
-        {
-          base: {
-            label: 'fake:main',
-          },
-          head: {
-            label: 'fake:release-v1.3.0',
-            ref: 'release-v1.3.0',
-          },
-          merged_at: new Date().toISOString(),
-        },
-        {
-          base: {
-            label: 'fake:main',
-          },
-          head: {
-            label: 'fake:release-v1.2.0',
-            ref: 'release-v1.2.0',
-          },
-          merged_at: new Date().toISOString(),
-        },
-        {
-          base: {
-            label: 'fake:main',
-          },
-          head: {
-            label: 'fake:release-v1.1.0',
-            ref: 'release-v1.1.0',
-          },
-          merged_at: new Date().toISOString(),
-        },
-      ];
-      req
-        .get(
-          '/repos/fake/fake/pulls?state=closed&per_page=100&page=1&base=main&sort=created&direction=desc'
-        )
-        .reply(200, ret);
+      const graphql = JSON.parse(
+        readFileSync(resolve(fixturesPath, 'latest-tag.json'), 'utf8')
+      );
+      req.post('/graphql').reply(200, {
+        data: graphql,
+      });
       const latestTag = await github.latestTag();
       expect(latestTag!.version).to.equal('1.3.0');
       req.done();
     });
 
     it('returns the latest tag on a sub branch, based on PR date', async () => {
+      const graphql = JSON.parse(
+        readFileSync(
+          resolve(fixturesPath, 'latest-tag-alternate-branch.json'),
+          'utf8'
+        )
+      );
+      req.post('/graphql').reply(200, {
+        data: graphql,
+      });
+
       // We need a special one here to set an alternate branch.
       github = new GitHub({
         owner: 'fake',
@@ -420,105 +284,70 @@ describe('GitHub', () => {
         defaultBranch: 'legacy-8',
       });
 
-      req
-        .get(
-          '/repos/fake/fake/pulls?state=closed&per_page=100&page=1&base=legacy-8&sort=created&direction=desc'
-        )
-        .reply(200, samplePrReturn);
       const latestTag = await github.latestTag();
-      expect(latestTag!.version).to.equal('1.1.5');
+      expect(latestTag!.version).to.equal('1.3.0');
       req.done();
     });
 
     it('does not return pre-releases as latest tag', async () => {
-      const ret = [
-        {
-          base: {
-            label: 'fake:main',
-          },
-          head: {
-            label: 'fake:release-v2.0.0-rc1',
-            ref: 'release-v2.0.0-rc1',
-          },
-          merged_at: new Date().toISOString(),
-        },
-        {
-          base: {
-            label: 'fake:main',
-          },
-          head: {
-            label: 'fake:release-v1.3.0',
-            ref: 'release-v1.3.0',
-          },
-          merged_at: new Date().toISOString(),
-        },
-      ];
-      req
-        .get(
-          '/repos/fake/fake/pulls?state=closed&per_page=100&page=1&base=main&sort=created&direction=desc'
-        )
-        .reply(200, ret);
+      const graphql = JSON.parse(
+        readFileSync(resolve(fixturesPath, 'latest-tag.json'), 'utf8')
+      );
+      req.post('/graphql').reply(200, {
+        data: graphql,
+      });
+
       const latestTag = await github.latestTag();
       expect(latestTag!.version).to.equal('1.3.0');
       req.done();
     });
 
     it('returns pre-releases on the main branch as latest, when preRelease is true', async () => {
-      const ret = [
-        {
-          base: {
-            label: 'fake:main',
-          },
-          head: {
-            label: 'fake:release-v2.0.0-rc1',
-            ref: 'release-v2.0.0-rc1',
-          },
-          merged_at: new Date().toISOString(),
-        },
-        {
-          base: {
-            label: 'fake:main',
-          },
-          head: {
-            label: 'fake:release-v1.3.0',
-            ref: 'release-v1.3.0',
-          },
-          merged_at: new Date().toISOString(),
-        },
-      ];
-      req
-        .get(
-          '/repos/fake/fake/pulls?state=closed&per_page=100&page=1&base=main&sort=created&direction=desc'
-        )
-        .reply(200, ret);
+      const graphql = JSON.parse(
+        readFileSync(resolve(fixturesPath, 'latest-tag.json'), 'utf8')
+      );
+      req.post('/graphql').reply(200, {
+        data: graphql,
+      });
       const latestTag = await github.latestTag(undefined, true);
       expect(latestTag!.version).to.equal('2.0.0-rc1');
       req.done();
     });
 
     it('returns pre-releases on a sub branch as latest, when preRelease is true', async () => {
+      const graphql = JSON.parse(
+        readFileSync(
+          resolve(fixturesPath, 'latest-tag-alternate-branch.json'),
+          'utf8'
+        )
+      );
+      req.post('/graphql').reply(200, {
+        data: graphql,
+      });
+
       // We need a special one here to set an alternate branch.
       github = new GitHub({
         owner: 'fake',
         repo: 'fake',
         defaultBranch: 'prerelease',
       });
-
-      req
-        .get(
-          '/repos/fake/fake/pulls?state=closed&per_page=100&page=1&base=prerelease&sort=created&direction=desc'
-        )
-        .reply(200, samplePrReturn);
       const latestTag = await github.latestTag(undefined, true);
-      expect(latestTag!.version).to.equal('3.0.0-rc1');
+      expect(latestTag!.version).to.equal('2.0.0-rc1');
       req.done();
     });
+
     it('falls back to using tags, for simple case', async () => {
-      req
-        .get(
-          '/repos/fake/fake/pulls?state=closed&per_page=100&page=1&base=main&sort=created&direction=desc'
+      const graphql = JSON.parse(
+        readFileSync(
+          resolve(fixturesPath, 'latest-tag-no-commits.json'),
+          'utf8'
         )
-        .reply(200, [])
+      );
+      req
+        .post('/graphql')
+        .reply(200, {
+          data: graphql,
+        })
         .get('/repos/fake/fake/tags?per_page=100')
         .reply(200, [
           {
@@ -535,11 +364,17 @@ describe('GitHub', () => {
       req.done();
     });
     it('falls back to using tags, when prefix is provided', async () => {
-      req
-        .get(
-          '/repos/fake/fake/pulls?state=closed&per_page=100&page=1&base=main&sort=created&direction=desc'
+      const graphql = JSON.parse(
+        readFileSync(
+          resolve(fixturesPath, 'latest-tag-no-commits.json'),
+          'utf8'
         )
-        .reply(200, [])
+      );
+      req
+        .post('/graphql')
+        .reply(200, {
+          data: graphql,
+        })
         .get('/repos/fake/fake/tags?per_page=100')
         .reply(200, [
           {
@@ -564,11 +399,17 @@ describe('GitHub', () => {
       req.done();
     });
     it('allows for "@" rather than "-" when fallback used', async () => {
-      req
-        .get(
-          '/repos/fake/fake/pulls?state=closed&per_page=100&page=1&base=main&sort=created&direction=desc'
+      const graphql = JSON.parse(
+        readFileSync(
+          resolve(fixturesPath, 'latest-tag-no-commits.json'),
+          'utf8'
         )
-        .reply(200, [])
+      );
+      req
+        .post('/graphql')
+        .reply(200, {
+          data: graphql,
+        })
         .get('/repos/fake/fake/tags?per_page=100')
         .reply(200, [
           {
@@ -597,11 +438,17 @@ describe('GitHub', () => {
       req.done();
     });
     it('allows for "/" rather than "-" when fallback used', async () => {
-      req
-        .get(
-          '/repos/fake/fake/pulls?state=closed&per_page=100&page=1&base=main&sort=created&direction=desc'
+      const graphql = JSON.parse(
+        readFileSync(
+          resolve(fixturesPath, 'latest-tag-no-commits.json'),
+          'utf8'
         )
-        .reply(200, [])
+      );
+      req
+        .post('/graphql')
+        .reply(200, {
+          data: graphql,
+        })
         .get('/repos/fake/fake/tags?per_page=100')
         .reply(200, [
           {
@@ -711,12 +558,10 @@ describe('GitHub', () => {
       req.post('/graphql').reply(200, {
         data: graphql,
       });
-      const commitsSinceSha = await github.commitsSince(
-        (commit, pullRequest) => {
-          // this commit is the 2nd most recent
-          return commit.sha === 'b29149f890e6f76ee31ed128585744d4c598924c';
-        }
-      );
+      const commitsSinceSha = await github.commitsSince(commit => {
+        // this commit is the 2nd most recent
+        return commit.sha === 'b29149f890e6f76ee31ed128585744d4c598924c';
+      });
       expect(commitsSinceSha.length).to.eql(1);
       snapshot(commitsSinceSha);
       req.done();
@@ -738,12 +583,10 @@ describe('GitHub', () => {
         .reply(200, {
           data: graphql2,
         });
-      const commitsSinceSha = await github.commitsSince(
-        (commit, pullRequest) => {
-          // this commit is on page 2
-          return commit.sha === 'c6d9dfb03aa2dbe1abc329592af60713fe28586d';
-        }
-      );
+      const commitsSinceSha = await github.commitsSince(commit => {
+        // this commit is on page 2
+        return commit.sha === 'c6d9dfb03aa2dbe1abc329592af60713fe28586d';
+      });
       expect(commitsSinceSha.length).to.eql(11);
       snapshot(commitsSinceSha);
       req.done();

--- a/test/github.ts
+++ b/test/github.ts
@@ -610,7 +610,7 @@ describe('GitHub', () => {
       req.done();
     });
   });
-  
+
   describe('createRelease', () => {
     it('should create a release with a package prefix', async () => {
       req

--- a/test/github.ts
+++ b/test/github.ts
@@ -729,11 +729,15 @@ describe('GitHub', () => {
       const graphql2 = JSON.parse(
         readFileSync(resolve(fixturesPath, 'commits-since-page-2.json'), 'utf8')
       );
-      req.post('/graphql').reply(200, {
-        data: graphql1,
-      }).post('/graphql').reply(200, {
-        data: graphql2,
-      });
+      req
+        .post('/graphql')
+        .reply(200, {
+          data: graphql1,
+        })
+        .post('/graphql')
+        .reply(200, {
+          data: graphql2,
+        });
       const commitsSinceSha = await github.commitsSince(
         (commit, pullRequest) => {
           // this commit is on page 2


### PR DESCRIPTION
Adds a GraphQL query that looks at commits to the current branch and iterates/pages through them to find a commit that matches certain conditions. We use this to find the last commit to a branch that looks like a release. 

`GitHub#latestTag` now uses this method of finding the last release PR. The previous method looks at the `base` branch of a pull request.

Fixes #740 