### PR TITLE
refactor(github): unused GitHubPR properties

### DIFF
--- a/src/github.ts
+++ b/src/github.ts
@@ -108,10 +108,8 @@ export interface GitHubFileContents {
 export interface GitHubPR {
   branch: string;
   fork: boolean;
-  version: string;
   title: string;
   body: string;
-  sha: string;
   updates: Update[];
   labels: string[];
 }

--- a/src/release-pr.ts
+++ b/src/release-pr.ts
@@ -324,7 +324,6 @@ export class ReleasePR {
   }
 
   protected async openPR(options: OpenPROptions): Promise<number | undefined> {
-    const sha = options.sha;
     const changelogEntry = options.changelogEntry;
     const updates = options.updates;
     const version = options.version;
@@ -334,8 +333,6 @@ export class ReleasePR {
     const branchName = await this.buildBranchName(version, includePackageName);
     const pr: number | undefined = await this.gh.openPR({
       branch: branchName.toString(),
-      version,
-      sha,
       updates,
       title,
       body,


### PR DESCRIPTION
`GitHub.openPR` is version agnostic. Callers are responsible for embedding
version information however they see fit into the components of a PR

It also does not need to know about any particular sha as its sole job
is to create or update a releasePR with the provided changes.
