### PR TITLE
feat: allow explicitly empty packageName when creating a release

### DIFF
--- a/__snapshots__/github.js
+++ b/__snapshots__/github.js
@@ -529,3 +529,19 @@ exports['GitHub findMergedPullRequests finds merged pull requests with labels 1'
     "body": "(cherry picked from commit a03d7dcdd8458d5c3542ec2914a031afd69815cf)\r\n"
   }
 ]
+
+exports['GitHub createRelease should create a release with a package prefix 1'] = {
+  "tag_name": "v1.2.3",
+  "target_commitish": "abc123",
+  "body": "Some release notes",
+  "name": "my package v1.2.3",
+  "draft": false
+}
+
+exports['GitHub createRelease should create a release without a package prefix 1'] = {
+  "tag_name": "v1.2.3",
+  "target_commitish": "abc123",
+  "body": "Some release notes",
+  "name": "v1.2.3",
+  "draft": false
+}

--- a/src/github-release.ts
+++ b/src/github-release.ts
@@ -80,12 +80,12 @@ export class GitHubRelease {
   async run(): Promise<ReleaseResponse | undefined> {
     // Attempt to lookup the package name from a well known location, such
     // as package.json, if none is provided:
-    if (!this.packageName && this.releaseType) {
+    if (this.packageName === undefined && this.releaseType) {
       this.packageName = await factory
         .releasePRClass(this.releaseType)
         .lookupPackageName(this.gh, this.path);
     }
-    if (!this.packageName) {
+    if (this.packageName === undefined) {
       throw Error(
         `could not determine package name for release repo = ${this.repoUrl}`
       );

--- a/src/github.ts
+++ b/src/github.ts
@@ -1026,6 +1026,7 @@ export class GitHub {
     draft: boolean
   ): Promise<ReleaseCreateResponse> {
     checkpoint(`creating release ${tagName}`, CheckpointType.Success);
+    const name = packageName ? `${packageName} ${tagName}` : tagName;
     return (
       await this.request('POST /repos/:owner/:repo/releases', {
         owner: this.owner,
@@ -1033,7 +1034,7 @@ export class GitHub {
         tag_name: tagName,
         target_commitish: sha,
         body: releaseNotes,
-        name: `${packageName} ${tagName}`,
+        name,
         draft: draft,
       })
     ).data;

--- a/test/github.ts
+++ b/test/github.ts
@@ -705,25 +705,24 @@ describe('GitHub', () => {
 
   describe('createRelease', () => {
     it('should create a release with a package prefix', async () => {
-      req.post(
-        '/repos/fake/fake/releases',
-        (body) => {
-          snapshot(body)
+      req
+        .post('/repos/fake/fake/releases', body => {
+          snapshot(body);
           return true;
-        }
-      )
-      .reply(200, {
-        tag_name: 'v1.2.3',
-        draft: false,
-        html_url: 'https://github.com/fake/fake/releases/v1.2.3',
-        upload_url: 'https://uploads.github.com/repos/fake/fake/releases/1/assets{?name,label}',
-      });
+        })
+        .reply(200, {
+          tag_name: 'v1.2.3',
+          draft: false,
+          html_url: 'https://github.com/fake/fake/releases/v1.2.3',
+          upload_url:
+            'https://uploads.github.com/repos/fake/fake/releases/1/assets{?name,label}',
+        });
       const release = await github.createRelease(
         'my package',
         'v1.2.3',
         'abc123',
         'Some release notes',
-        false,
+        false
       );
       req.done();
       expect(release).to.not.be.undefined;
@@ -732,25 +731,24 @@ describe('GitHub', () => {
     });
 
     it('should create a release without a package prefix', async () => {
-      req.post(
-        '/repos/fake/fake/releases',
-        (body) => {
-          snapshot(body)
+      req
+        .post('/repos/fake/fake/releases', body => {
+          snapshot(body);
           return true;
-        }
-      )
-      .reply(200, {
-        tag_name: 'v1.2.3',
-        draft: false,
-        html_url: 'https://github.com/fake/fake/releases/v1.2.3',
-        upload_url: 'https://uploads.github.com/repos/fake/fake/releases/1/assets{?name,label}',
-      });
+        })
+        .reply(200, {
+          tag_name: 'v1.2.3',
+          draft: false,
+          html_url: 'https://github.com/fake/fake/releases/v1.2.3',
+          upload_url:
+            'https://uploads.github.com/repos/fake/fake/releases/1/assets{?name,label}',
+        });
       const release = await github.createRelease(
         '',
         'v1.2.3',
         'abc123',
         'Some release notes',
-        false,
+        false
       );
       req.done();
       expect(release).to.not.be.undefined;

--- a/test/github.ts
+++ b/test/github.ts
@@ -702,4 +702,60 @@ describe('GitHub', () => {
       req.done();
     });
   });
+
+  describe('createRelease', () => {
+    it('should create a release with a package prefix', async () => {
+      req.post(
+        '/repos/fake/fake/releases',
+        (body) => {
+          snapshot(body)
+          return true;
+        }
+      )
+      .reply(200, {
+        tag_name: 'v1.2.3',
+        draft: false,
+        html_url: 'https://github.com/fake/fake/releases/v1.2.3',
+        upload_url: 'https://uploads.github.com/repos/fake/fake/releases/1/assets{?name,label}',
+      });
+      const release = await github.createRelease(
+        'my package',
+        'v1.2.3',
+        'abc123',
+        'Some release notes',
+        false,
+      );
+      req.done();
+      expect(release).to.not.be.undefined;
+      expect(release!.tag_name).to.eql('v1.2.3');
+      expect(release!.draft).to.be.false;
+    });
+
+    it('should create a release without a package prefix', async () => {
+      req.post(
+        '/repos/fake/fake/releases',
+        (body) => {
+          snapshot(body)
+          return true;
+        }
+      )
+      .reply(200, {
+        tag_name: 'v1.2.3',
+        draft: false,
+        html_url: 'https://github.com/fake/fake/releases/v1.2.3',
+        upload_url: 'https://uploads.github.com/repos/fake/fake/releases/1/assets{?name,label}',
+      });
+      const release = await github.createRelease(
+        '',
+        'v1.2.3',
+        'abc123',
+        'Some release notes',
+        false,
+      );
+      req.done();
+      expect(release).to.not.be.undefined;
+      expect(release!.tag_name).to.eql('v1.2.3');
+      expect(release!.draft).to.be.false;
+    });
+  });
 });


### PR DESCRIPTION
This will allow us to pass `""` as the `packageName` in order to tag releases where we do not want to include the package name. (The release title will just be the version)
