### PR TITLE
refactor: stricter releaseType typing

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -1,3 +1,9 @@
 {
-  "extends": "./node_modules/gts"
+  "extends": "./node_modules/gts",
+  "rules": {
+    "@typescript-eslint/no-unused-vars": [
+      "error",
+      {"argsIgnorePattern": "^_", "varsIgnorePattern": "^_$"}
+    ]
+  }
 }

--- a/src/bin/release-please.ts
+++ b/src/bin/release-please.ts
@@ -19,7 +19,7 @@ import {coerceOption} from '../util/coerce-option';
 import {GitHubReleaseOptions} from '../github-release';
 import {ReleasePROptions} from '../release-pr';
 import {factory} from '../factory';
-import {getReleaserNames} from '../releasers';
+import {getReleaserTypes, ReleaseType} from '../releasers';
 import * as yargs from 'yargs';
 
 interface ErrorObject {
@@ -31,7 +31,7 @@ interface ErrorObject {
 
 interface YargsOptions {
   describe: string;
-  choices?: string[];
+  choices?: readonly ReleaseType[];
   demand?: boolean;
   type?: string;
   default?: string | boolean;
@@ -113,7 +113,7 @@ export const parser = yargs
   })
   .option('release-type', {
     describe: 'what type of repo is a release being created for?',
-    choices: getReleaserNames(),
+    choices: getReleaserTypes(),
     default: 'node',
   })
   .option('bump-minor-pre-major', {

--- a/src/factory.ts
+++ b/src/factory.ts
@@ -22,7 +22,7 @@ import {
   GitHubRelease,
   ReleaseResponse,
 } from './github-release';
-import {getReleasers} from './releasers';
+import {ReleaseType, getReleasers} from './releasers';
 
 function runCommand(
   command: string,
@@ -55,7 +55,7 @@ function releasePR(options: ReleasePROptions): ReleasePR {
   return new (factory.releasePRClass(options.releaseType))(releaseOptions);
 }
 
-export function releasePRClass(releaseType: string): typeof ReleasePR {
+export function releasePRClass(releaseType: ReleaseType): typeof ReleasePR {
   const releasers = getReleasers();
   const releaser = releasers[releaseType];
   if (!releaser) {

--- a/src/github-release.ts
+++ b/src/github-release.ts
@@ -19,6 +19,7 @@ import {factory} from './factory';
 import {GitHub, OctokitAPIs} from './github';
 import {parse} from 'semver';
 import {ReleasePR} from './release-pr';
+import {ReleaseType} from './releasers';
 
 // eslint-disable-next-line @typescript-eslint/no-var-requires
 const parseGithubRepoUrl = require('parse-github-repo-url');
@@ -38,7 +39,7 @@ export interface ReleaseResponse {
 }
 
 export interface GitHubReleaseOptions extends SharedOptions {
-  releaseType?: string;
+  releaseType?: ReleaseType;
   changelogPath?: string;
   draft?: boolean;
   defaultBranch?: string;
@@ -54,7 +55,7 @@ export class GitHubRelease {
   packageName?: string;
   monorepoTags?: boolean;
   token?: string;
-  releaseType?: string;
+  releaseType?: ReleaseType;
   draft: boolean;
   defaultBranch?: string;
 
@@ -108,7 +109,7 @@ export class GitHubRelease {
         })
       : new ReleasePR({
           ...releaseOptions,
-          ...{releaseType: 'unknown'},
+          ...{releaseType: 'base'},
         });
 
     const candidate = await releasePR.buildRelease(

--- a/src/index.ts
+++ b/src/index.ts
@@ -30,7 +30,7 @@ export interface SharedOptions {
 }
 
 export {factory} from './factory';
-export {getReleaserNames, getReleasers} from './releasers';
+export {getReleaserTypes, getReleasers} from './releasers';
 export {GitHubRelease, GitHubReleaseOptions} from './github-release';
 export {JavaYoshi} from './releasers/java-yoshi';
 export {Ruby} from './releasers/ruby';

--- a/src/release-pr.ts
+++ b/src/release-pr.ts
@@ -196,10 +196,8 @@ export class ReleasePR {
   // the release name when creating a GitHub release, for instance by returning
   // name in package.json, or setup.py.
   static async lookupPackageName(
-    // eslint-disable-next-line @typescript-eslint/no-unused-vars
-    gh: GitHub,
-    // eslint-disable-next-line @typescript-eslint/no-unused-vars
-    path?: string
+    _gh: GitHub,
+    _path?: string
   ): Promise<string | undefined> {
     return Promise.resolve(undefined);
   }
@@ -291,7 +289,6 @@ export class ReleasePR {
 
   // Override this method to detect the release version from code (if it cannot be
   // inferred from the release PR head branch)
-  // eslint-disable-next-line @typescript-eslint/no-unused-vars
   protected detectReleaseVersionFromTitle(title: string): string | undefined {
     const pattern = /^chore: release ?(?<component>.*) (?<version>\d+\.\d+\.\d+)$/;
     const match = title.match(pattern);
@@ -316,7 +313,7 @@ export class ReleasePR {
 
   // Override this method to modify the pull request body
   protected async buildPullRequestBody(
-    version: string,
+    _version: string,
     changelogEntry: string
   ): Promise<string> {
     return `:robot: I have created a release \\*beep\\* \\*boop\\* \n---\n${changelogEntry}\n\nThis PR was generated with [Release Please](https://github.com/googleapis/${RELEASE_PLEASE}). See [documentation](https://github.com/googleapis/${RELEASE_PLEASE}#${RELEASE_PLEASE}).`;

--- a/src/release-pr.ts
+++ b/src/release-pr.ts
@@ -31,6 +31,7 @@ import {Commit} from './graphql-to-commits';
 import {Update} from './updaters/update';
 import {BranchName} from './util/branch-name';
 import {extractReleaseNotes} from './util/release-notes';
+import {ReleaseType} from './releasers';
 
 // eslint-disable-next-line @typescript-eslint/no-var-requires
 const parseGithubRepoUrl = require('parse-github-repo-url');
@@ -51,7 +52,7 @@ export interface ReleasePROptions extends SharedOptions {
   octokitAPIs?: OctokitAPIs;
   // Path to version.rb file
   versionFile?: string;
-  releaseType: string;
+  releaseType: ReleaseType;
   changelogSections?: [];
   // Optionally provide GitHub instance
   github?: GitHub;
@@ -87,8 +88,6 @@ export interface OpenPROptions {
 }
 
 export class ReleasePR {
-  static releaserName = 'base';
-
   apiUrl: string;
   defaultBranch?: string;
   labels: string[];

--- a/src/releasers/go-yoshi.ts
+++ b/src/releasers/go-yoshi.ts
@@ -52,8 +52,7 @@ export class GoYoshi extends ReleasePR {
       this.monorepoTags ? `${this.packageName}-` : undefined,
       false
     );
-    // eslint-disable-next-line @typescript-eslint/no-unused-vars
-    const [_owner, repo] = parseGithubRepoUrl(this.repoUrl);
+    const [_, repo] = parseGithubRepoUrl(this.repoUrl);
     let regenPR: Commit | undefined;
     let sha: null | string = null;
     const commits = (

--- a/src/releasers/go-yoshi.ts
+++ b/src/releasers/go-yoshi.ts
@@ -47,7 +47,6 @@ const SUB_MODULES = [
 const REGEN_PR_REGEX = /.*auto-regenerate.*/;
 
 export class GoYoshi extends ReleasePR {
-  static releaserName = 'go-yoshi';
   protected async _run(): Promise<number | undefined> {
     const latestTag = await this.gh.latestTag(
       this.monorepoTags ? `${this.packageName}-` : undefined,

--- a/src/releasers/index.ts
+++ b/src/releasers/index.ts
@@ -27,30 +27,50 @@ import {TerraformModule} from './terraform-module';
 import {Rust} from './rust';
 import {OCaml} from './ocaml';
 
-// TODO: add any new releasers you create to this list:
-export function getReleasers(): {[key: string]: typeof ReleasePR} {
-  const releasers = {
-    go: GoYoshi, // TODO(codyoss): refactor this into a more generic go strategy.
-    'go-yoshi': GoYoshi,
-    'java-bom': JavaBom,
-    'java-yoshi': JavaYoshi,
-    node: Node,
-    'php-yoshi': PHPYoshi,
-    python: Python,
-    'ruby-yoshi': RubyYoshi,
-    ruby: Ruby,
-    simple: Simple,
-    'terraform-module': TerraformModule,
-    rust: Rust,
-    ocaml: OCaml,
-  };
+// add any new releasers you create to this type as well as the `releasers`
+// object below.
+export type ReleaseType =
+  | 'base' // not exposed to end users
+  | 'go'
+  | 'go-yoshi'
+  | 'java-bom'
+  | 'java-yoshi'
+  | 'node'
+  | 'php-yoshi'
+  | 'python'
+  | 'ruby-yoshi'
+  | 'ruby'
+  | 'simple'
+  | 'terraform-module'
+  | 'rust'
+  | 'ocaml';
+
+type Releasers = Partial<Record<ReleaseType, typeof ReleasePR>>;
+
+const releasers: Releasers = {
+  go: GoYoshi, // TODO(codyoss): refactor this into a more generic go strategy.
+  'go-yoshi': GoYoshi,
+  'java-bom': JavaBom,
+  'java-yoshi': JavaYoshi,
+  node: Node,
+  'php-yoshi': PHPYoshi,
+  python: Python,
+  'ruby-yoshi': RubyYoshi,
+  ruby: Ruby,
+  simple: Simple,
+  'terraform-module': TerraformModule,
+  rust: Rust,
+  ocaml: OCaml,
+};
+
+export function getReleasers(): Releasers {
   return releasers;
 }
 
-export function getReleaserNames(): string[] {
-  const releasers = getReleasers();
-  return Object.keys(releasers).map(key => {
-    const releaser = releasers[key];
-    return releaser.releaserName;
-  });
+export function getReleaserTypes(): readonly ReleaseType[] {
+  const names: ReleaseType[] = [];
+  for (const releaseType of Object.keys(releasers)) {
+    names.push(releaseType as ReleaseType);
+  }
+  return names;
 }

--- a/src/releasers/index.ts
+++ b/src/releasers/index.ts
@@ -36,14 +36,14 @@ export type ReleaseType =
   | 'java-bom'
   | 'java-yoshi'
   | 'node'
+  | 'ocaml'
   | 'php-yoshi'
   | 'python'
-  | 'ruby-yoshi'
   | 'ruby'
-  | 'simple'
-  | 'terraform-module'
+  | 'ruby-yoshi'
   | 'rust'
-  | 'ocaml';
+  | 'simple'
+  | 'terraform-module';
 
 type Releasers = Partial<Record<ReleaseType, typeof ReleasePR>>;
 
@@ -53,18 +53,23 @@ const releasers: Releasers = {
   'java-bom': JavaBom,
   'java-yoshi': JavaYoshi,
   node: Node,
+  ocaml: OCaml,
   'php-yoshi': PHPYoshi,
   python: Python,
-  'ruby-yoshi': RubyYoshi,
   ruby: Ruby,
+  'ruby-yoshi': RubyYoshi,
+  rust: Rust,
   simple: Simple,
   'terraform-module': TerraformModule,
-  rust: Rust,
-  ocaml: OCaml,
 };
 
 export function getReleasers(): Releasers {
   return releasers;
+}
+
+// deprecated, use getReleaserTypes
+export function getReleaserNames(): string[] {
+  return getReleaserTypes() as string[];
 }
 
 export function getReleaserTypes(): readonly ReleaseType[] {

--- a/src/releasers/java-bom.ts
+++ b/src/releasers/java-bom.ts
@@ -47,7 +47,6 @@ const DEPENDENCY_UPDATE_REGEX = /^deps: update dependency (.*) to (v.*)(\s\(#\d+
 const DEPENDENCY_PATCH_VERSION_REGEX = /^v\d+\.\d+\.[1-9]\d*(-.*)?/;
 
 export class JavaBom extends ReleasePR {
-  static releaserName = 'java-bom';
   protected async _run(): Promise<number | undefined> {
     const versionsManifestContent = await this.gh.getFileContents(
       'versions.txt'

--- a/src/releasers/java-yoshi.ts
+++ b/src/releasers/java-yoshi.ts
@@ -49,7 +49,6 @@ const CHANGELOG_SECTIONS = [
 ];
 
 export class JavaYoshi extends ReleasePR {
-  static releaserName = 'java-yoshi';
   protected async _run(): Promise<number | undefined> {
     const versionsManifestContent = await this.gh.getFileContents(
       'versions.txt'

--- a/src/releasers/java-yoshi.ts
+++ b/src/releasers/java-yoshi.ts
@@ -294,7 +294,7 @@ export class JavaYoshi extends ReleasePR {
   // If you modify this, you must ensure that the releaser can parse the tag version
   // from the pull request.
   protected async buildBranchName(
-    version: string,
+    _version: string,
     includePackageName: boolean
   ): Promise<BranchName> {
     const defaultBranch = await this.getDefaultBranch();
@@ -320,7 +320,6 @@ export class JavaYoshi extends ReleasePR {
 
   // Override this method to detect the release version from code (if it cannot be
   // inferred from the release PR head branch)
-  // eslint-disable-next-line @typescript-eslint/no-unused-vars
   protected detectReleaseVersionFromTitle(title: string): string | undefined {
     const pattern = /^chore\((?<branch>[^(]+)\): release ?(?<component>.*) (?<version>\d+\.\d+\.\d+)$/;
     const match = title.match(pattern);

--- a/src/releasers/node.ts
+++ b/src/releasers/node.ts
@@ -27,7 +27,6 @@ import {PackageJson} from '../updaters/package-json';
 import {SamplesPackageJson} from '../updaters/samples-package-json';
 
 export class Node extends ReleasePR {
-  static releaserName = 'node';
   protected async _run(): Promise<number | undefined> {
     // Make an effort to populate packageName from the contents of
     // the package.json, rather than forcing this to be set:

--- a/src/releasers/ocaml.ts
+++ b/src/releasers/ocaml.ts
@@ -42,7 +42,6 @@ const CHANGELOG_SECTIONS = [
 ];
 
 export class OCaml extends ReleasePR {
-  static releaserName = 'ocaml';
   protected async _run(): Promise<number | undefined> {
     const latestTag: GitHubTag | undefined = await this.gh.latestTag(
       this.monorepoTags ? `${this.packageName}-` : undefined

--- a/src/releasers/php-yoshi.ts
+++ b/src/releasers/php-yoshi.ts
@@ -50,7 +50,6 @@ interface PHPYoshiBulkUpdate {
 }
 
 export class PHPYoshi extends ReleasePR {
-  static releaserName = 'php-yoshi';
   protected async _run(): Promise<number | undefined> {
     const latestTag: GitHubTag | undefined = await this.gh.latestTag();
     const commits: Commit[] = await this.commits({

--- a/src/releasers/python.ts
+++ b/src/releasers/python.ts
@@ -43,7 +43,6 @@ const CHANGELOG_SECTIONS = [
 ];
 
 export class Python extends ReleasePR {
-  static releaserName = 'python';
   protected async _run(): Promise<number | undefined> {
     const latestTag: GitHubTag | undefined = await this.gh.latestTag(
       this.monorepoTags ? `${this.packageName}-` : undefined

--- a/src/releasers/ruby-yoshi.ts
+++ b/src/releasers/ruby-yoshi.ts
@@ -41,7 +41,6 @@ const CHANGELOG_SECTIONS = [
 ];
 
 export class RubyYoshi extends ReleasePR {
-  static releaserName = 'ruby-yoshi';
   protected async _run(): Promise<number | undefined> {
     const lastReleaseSha: string | undefined = this.lastPackageVersion
       ? await this.gh.getTagSha(

--- a/src/releasers/ruby.ts
+++ b/src/releasers/ruby.ts
@@ -33,7 +33,6 @@ export interface RubyReleasePROptions extends ReleasePROptions {
 }
 
 export class Ruby extends ReleasePR {
-  static releaserName = 'ruby';
   versionFile: string;
   constructor(options: RubyReleasePROptions) {
     super(options as ReleasePROptions);

--- a/src/releasers/rust.ts
+++ b/src/releasers/rust.ts
@@ -28,7 +28,6 @@ import {CargoLock} from '../updaters/rust/cargo-lock';
 import {CargoManifest, parseCargoManifest} from '../updaters/rust/common';
 
 export class Rust extends ReleasePR {
-  static releaserName = 'rust';
   protected async _run(): Promise<number | undefined> {
     const prefix = this.monorepoTags ? `${this.packageName}-` : undefined;
     const addPrefix = (tagOrBranch: string | undefined): string | undefined => {

--- a/src/releasers/simple.ts
+++ b/src/releasers/simple.ts
@@ -26,7 +26,6 @@ import {Changelog} from '../updaters/changelog';
 import {VersionTxt} from '../updaters/version-txt';
 
 export class Simple extends ReleasePR {
-  static releaserName = 'simple';
   protected async _run(): Promise<number | undefined> {
     const latestTag: GitHubTag | undefined = await this.gh.latestTag(
       this.monorepoTags ? `${this.packageName}-` : undefined

--- a/src/releasers/terraform-module.ts
+++ b/src/releasers/terraform-module.ts
@@ -27,7 +27,6 @@ import {ReadMe} from '../updaters/terraform/readme';
 import {ModuleVersion} from '../updaters/terraform/module-version';
 
 export class TerraformModule extends ReleasePR {
-  static releaserName = 'terraform-module';
   protected async _run(): Promise<number | undefined> {
     const latestTag: GitHubTag | undefined = await this.gh.latestTag(
       this.monorepoTags ? `${this.packageName}-` : undefined

--- a/src/util/branch-name.ts
+++ b/src/util/branch-name.ts
@@ -54,10 +54,9 @@ export class BranchName {
       `${RELEASE_PLEASE}/branches/${targetBranch}/components/${component}`
     );
   }
-  // eslint-disable-next-line @typescript-eslint/no-unused-vars
-  constructor(branchName: string) {}
-  // eslint-disable-next-line @typescript-eslint/no-unused-vars
-  static matches(branchName: string): boolean {
+  constructor(_branchName: string) {}
+
+  static matches(_branchName: string): boolean {
     return false;
   }
   getTargetBranch(): string | undefined {

--- a/synth.py
+++ b/synth.py
@@ -11,7 +11,7 @@ s.copy(templates, excludes=[
   'README.md',
   'CONTRIBUTING.md',
   '.eslintignore',
-  '.eslintrc.yml',
+  '.eslintrc.json',
   '.prettierignore',
   '.prettierrc',
   '.nycrc',

--- a/test/cli.ts
+++ b/test/cli.ts
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 import * as assert from 'assert';
+import {expect} from 'chai';
 import {factory} from '../src/factory';
 import {GitHubRelease} from '../src/github-release';
 import {ReleasePR} from '../src/release-pr';
@@ -20,6 +21,7 @@ import {describe, it, afterEach} from 'mocha';
 import * as sinon from 'sinon';
 
 import {parser} from '../src/bin/release-please';
+import {ParseCallback} from 'yargs';
 
 const sandbox = sinon.createSandbox();
 
@@ -49,6 +51,41 @@ describe('CLI', () => {
       assert.strictEqual(classToRun.packageName, 'cli-package');
       // Defaults to Node.js release type:
       assert.strictEqual(classToRun.releaseType, 'node');
+    });
+    it('validates releaseType choices', () => {
+      sandbox.stub(factory, 'run').resolves(undefined);
+
+      const cmd =
+        'release-pr ' +
+        '--release-type=foobar ' +
+        '--repo-url=googleapis/release-please-cli ' +
+        '--package-name=cli-package';
+      const choices = [
+        'go',
+        'go-yoshi',
+        'java-bom',
+        'java-yoshi',
+        'node',
+        'ocaml',
+        'php-yoshi',
+        'python',
+        'ruby',
+        'ruby-yoshi',
+        'rust',
+        'simple',
+        'terraform-module',
+      ];
+      const parseCallback: ParseCallback = (err, _argv, _output) => {
+        expect(err).to.be.an('Error');
+        expect(err)
+          .to.have.property('message')
+          .to.equal(
+            'Invalid values:\n  Argument: release-type, Given: "foobar", ' +
+              'Choices: ' +
+              choices.map(c => `"${c}"`).join(', ')
+          );
+      };
+      parser.parse(cmd, parseCallback);
     });
   });
   describe('github-release', () => {

--- a/test/cli.ts
+++ b/test/cli.ts
@@ -52,7 +52,7 @@ describe('CLI', () => {
       // Defaults to Node.js release type:
       assert.strictEqual(classToRun.releaseType, 'node');
     });
-    it('validates releaseType choices', () => {
+    it('validates releaseType choices', done => {
       sandbox.stub(factory, 'run').resolves(undefined);
 
       const cmd =
@@ -84,6 +84,7 @@ describe('CLI', () => {
               'Choices: ' +
               choices.map(c => `"${c}"`).join(', ')
           );
+        done();
       };
       parser.parse(cmd, parseCallback);
     });

--- a/test/factory.ts
+++ b/test/factory.ts
@@ -93,4 +93,16 @@ describe('factory', () => {
       expect(githubRelease.releaseType).to.be.undefined;
     });
   });
+  describe('run', () => {
+    it('runs a runnable', async () => {
+      const runnable = factory.releasePR({
+        repoUrl: 'googleapis/simple-test-repo',
+        packageName: 'simple-test-repo',
+        apiUrl: 'https://api.github.com',
+        releaseType: 'simple',
+      });
+      sandbox.stub(runnable, 'run').resolves(47);
+      expect(await factory.run(runnable)).to.equal(47);
+    });
+  });
 });

--- a/test/factory.ts
+++ b/test/factory.ts
@@ -36,14 +36,14 @@ describe('factory', () => {
       expect(releasePR.constructor.name).to.eql('Simple');
       expect(releasePR.packageName).to.eql('simple-test-repo');
     });
-    it('throws an error on unknown release type', () => {
+    it('throws an error on invalid release type', () => {
       let caught = false;
       try {
         factory.releasePR({
           repoUrl: 'googleapis/simple-test-repo',
           packageName: 'simple-test-repo',
           apiUrl: 'https://api.github.com',
-          releaseType: 'unknown-release-type-name',
+          releaseType: 'base',
         });
         assert.fail();
       } catch (e) {
@@ -56,13 +56,13 @@ describe('factory', () => {
   describe('releasePRClass', () => {
     it('returns a releaser class', () => {
       const releaseClass = factory.releasePRClass('ruby');
-      expect(releaseClass.releaserName).to.eql('ruby');
+      expect(releaseClass.name).to.equal('Ruby');
     });
 
-    it('throws and error on unknown release type', () => {
+    it('throws and error on invalid release type', () => {
       let caught = false;
       try {
-        factory.releasePRClass('unknown-release-type-name');
+        factory.releasePRClass('base');
         assert.fail();
       } catch (e) {
         caught = true;

--- a/test/release-pr.ts
+++ b/test/release-pr.ts
@@ -233,7 +233,7 @@ describe('Release-PR', () => {
           packageName: input,
           repoUrl: 'owner/repo',
           apiUrl: 'unused',
-          releaseType: 'unused',
+          releaseType: 'base',
         });
         expect(releasePR.packagePrefix).to.eql(input);
       });

--- a/test/releasers/index.ts
+++ b/test/releasers/index.ts
@@ -1,0 +1,24 @@
+// Copyright 2021 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import {describe, it} from 'mocha';
+import {expect} from 'chai';
+import {getReleasers, getReleaserTypes} from '../../src/releasers';
+
+describe('getReleaserTypes', () => {
+  it('gets types for all releasers', async () => {
+    const releasers = getReleasers();
+    expect(Object.keys(releasers)).to.eql(getReleaserTypes());
+  });
+});

--- a/test/releasers/index.ts
+++ b/test/releasers/index.ts
@@ -14,11 +14,22 @@
 
 import {describe, it} from 'mocha';
 import {expect} from 'chai';
-import {getReleasers, getReleaserTypes} from '../../src/releasers';
+import {
+  getReleasers,
+  getReleaserTypes,
+  getReleaserNames,
+} from '../../src/releasers';
 
 describe('getReleaserTypes', () => {
   it('gets types for all releasers', async () => {
     const releasers = getReleasers();
     expect(Object.keys(releasers)).to.eql(getReleaserTypes());
+  });
+});
+
+describe('getReleaserNames', () => {
+  it('gets types for all releasers', async () => {
+    const releasers = getReleasers();
+    expect(Object.keys(releasers)).to.eql(getReleaserNames());
   });
 });

--- a/test/releasers/yoshi-go.ts
+++ b/test/releasers/yoshi-go.ts
@@ -36,7 +36,7 @@ describe('YoshiGo', () => {
     it('creates a release PR for google-cloud-go', async () => {
       const releasePR = new GoYoshi({
         repoUrl: 'googleapis/google-cloud-go',
-        releaseType: 'yoshi-go',
+        releaseType: 'go-yoshi',
         // not actually used by this type of repo.
         packageName: 'yoshi-go',
         apiUrl: 'https://api.github.com',
@@ -111,7 +111,7 @@ describe('YoshiGo', () => {
     it('creates a release PR for google-api-go-client', async () => {
       const releasePR = new GoYoshi({
         repoUrl: 'googleapis/google-api-go-client',
-        releaseType: 'yoshi-go',
+        releaseType: 'go-yoshi',
         // not actually used by this type of repo.
         packageName: 'yoshi-go',
         apiUrl: 'https://api.github.com',
@@ -197,7 +197,7 @@ describe('YoshiGo', () => {
   it('supports releasing submodule from google-cloud-go', async () => {
     const releasePR = new GoYoshi({
       repoUrl: 'googleapis/google-cloud-go',
-      releaseType: 'yoshi-go',
+      releaseType: 'go-yoshi',
       packageName: 'pubsublite',
       monorepoTags: true,
       path: 'pubsublite',


### PR DESCRIPTION
releasers/index.js is the source of truth for available releasers. This
change strengthens that by introducing the ReleaseType as the typed
definition of what releasers are available.

Keeping the source of truth (ReleaseType) separate from actual ReleasePR
subclasses allows multiple types to point to the same subclass (e.g. the
case of "go" and "go-yoshi"). Prior to this change it would not have
been possible (via yargs cli options) to specify `--release-type go` (or
at least it's not listed in the help output)

Since the only case for ReleasePR.releaserName is now obviated it's been
removed. If there a need in the future for a "display friendly"
representation of the releaser instance then we can add it back.