### PR TITLE
refactor: commit-split enhancements

### DIFF
--- a/src/commit-split.ts
+++ b/src/commit-split.ts
@@ -15,31 +15,66 @@
 import {Commit} from './graphql-to-commits';
 import {relative} from 'path';
 
-interface CommitSplitOptions {
+export interface CommitSplitOptions {
+  // Defaults to './'
   root?: string;
+  // Include empty git commits: each empty commit is included
+  // in the list of commits for each path.
+  includeEmpty?: boolean;
+  // rather than split by top level folder, split by these package
+  // paths (e.g. ["packages/pkg1", "python/pkg1"]). Commits that
+  // only touch files under paths not specified here are ignored.
+  packagePaths?: string[];
 }
 
 export class CommitSplit {
   root: string;
+  includeEmpty: boolean;
+  packagePaths?: string[];
   constructor(opts?: CommitSplitOptions) {
     opts = opts || {};
     this.root = opts.root || './';
+    this.includeEmpty = !!opts.includeEmpty;
+    if (opts.packagePaths) {
+      const paths: string[] = [];
+      for (let newPath of opts.packagePaths) {
+        newPath = newPath.replace(/[/\\]$/, '');
+        for (const exPath of paths) {
+          if (newPath.indexOf(exPath) >= 0 || exPath.indexOf(newPath) >= 0) {
+            throw new Error(
+              `Path prefixes must be unique: ${newPath}, ${exPath}`
+            );
+          }
+        }
+        paths.push(newPath);
+      }
+      this.packagePaths = paths;
+    }
   }
+
   split(commits: Commit[]): {[key: string]: Commit[]} {
     const splitCommits: {[key: string]: Commit[]} = {};
     commits.forEach((commit: Commit) => {
       const dedupe: Set<string> = new Set();
       for (let i = 0; i < commit.files.length; i++) {
         const file: string = commit.files[i];
-        const splitPath = relative(this.root, file).split(/[/\\]/);
+        const path = relative(this.root, file);
+        const splitPath = path.split(/[/\\]/);
         // indicates that we have a top-level file and not a folder
         // in this edge-case we should not attempt to update the path.
         if (splitPath.length === 1) continue;
-        const pkgName = splitPath[0];
-        if (dedupe.has(pkgName)) continue;
+        const pkgName = this.packagePaths
+          ? this.packagePaths.find(p => path.indexOf(p) >= 0)
+          : splitPath[0];
+        if (!pkgName || dedupe.has(pkgName)) continue;
         else dedupe.add(pkgName);
         if (!splitCommits[pkgName]) splitCommits[pkgName] = [];
         splitCommits[pkgName].push(commit);
+      }
+      if (commit.files.length === 0 && this.includeEmpty) {
+        for (const pkgName in splitCommits) {
+          splitCommits[pkgName].push(commit);
+        }
       }
     });
     return splitCommits;

--- a/src/github.ts
+++ b/src/github.ts
@@ -252,6 +252,7 @@ export class GitHub {
     }
   }
 
+  // Commit.files only for commits from PRs.
   async commitsSinceSha(
     sha: string | undefined,
     perPage = 100,

--- a/test/commit-split.ts
+++ b/test/commit-split.ts
@@ -13,13 +13,15 @@
 // limitations under the License.
 
 import {readFileSync} from 'fs';
-import {resolve} from 'path';
+import * as path from 'path';
 import * as snapshot from 'snap-shot-it';
 import {describe, it} from 'mocha';
+import {expect} from 'chai';
 
-import {CommitSplit} from '../src/commit-split';
+import {CommitSplit, CommitSplitOptions} from '../src/commit-split';
 import {GitHub} from '../src/github';
 import {Commit, graphqlToCommits} from '../src/graphql-to-commits';
+import {buildMockCommit} from './helpers';
 
 const fixturesPath = './test/fixtures';
 
@@ -29,7 +31,7 @@ describe('CommitSplit', () => {
   it('partitions commits based on path from root directory by default', async () => {
     const graphql = JSON.parse(
       readFileSync(
-        resolve(fixturesPath, 'commits-yoshi-php-monorepo.json'),
+        path.resolve(fixturesPath, 'commits-yoshi-php-monorepo.json'),
         'utf8'
       )
     );
@@ -37,4 +39,126 @@ describe('CommitSplit', () => {
     const cs = new CommitSplit();
     snapshot(cs.split(commits));
   });
+
+  type ExpectedCommitSplit = Record<string, Commit[]>;
+  type PackagePaths = string[];
+  const setupPackagePathCommits = (
+    includeEmpty: boolean,
+    usePackagePaths: boolean
+  ): [ExpectedCommitSplit, PackagePaths, Commit[]] => {
+    const pkgsPath = 'packages';
+    const fooPath = path.join(pkgsPath, 'foo');
+    const barPath = path.join(pkgsPath, 'bar');
+    const bazPath = 'python';
+    const somePath = 'some';
+    const fooCommit = buildMockCommit('fix(foo): fix foo', [
+      path.join(fooPath, 'foo.ts'),
+    ]);
+    const barCommit = buildMockCommit('fix(bar): fix bar', [
+      path.join(barPath, 'bar.ts'),
+    ]);
+    const bazCommit = buildMockCommit('fix(baz): fix baz', [
+      path.join(bazPath, 'baz', 'baz.py'),
+    ]);
+    const foobarCommit = buildMockCommit('fix(foobar): fix foobar', [
+      path.join(fooPath, 'foo.ts'),
+      path.join(barPath, 'bar.ts'),
+    ]);
+    const foobarbazCommit = buildMockCommit('fix(foobarbaz): fix foobarbaz', [
+      path.join(fooPath, 'foo.ts'),
+      path.join(barPath, 'bar.ts'),
+      path.join(bazPath, 'baz', 'baz.py'),
+    ]);
+    const someCommit = buildMockCommit('fix(some): fix something', [
+      path.join(somePath, 'other', 'file.ts'),
+    ]);
+    const emptyCommit = buildMockCommit(
+      'chore: empty\n\nrelease-packages/foo-as: 1.2.3',
+      []
+    );
+    const commits = [
+      fooCommit,
+      barCommit,
+      bazCommit,
+      foobarCommit,
+      foobarbazCommit,
+      someCommit,
+      emptyCommit,
+    ];
+
+    let packagePaths: string[] = [];
+    let perPathCommits: ExpectedCommitSplit = {};
+
+    if (usePackagePaths) {
+      // trailing slash to test path normalization.
+      packagePaths = [fooPath, barPath, bazPath + '/'];
+      // Expected output of commit-split with packagePaths
+      perPathCommits = {
+        [fooPath]: [fooCommit, foobarCommit, foobarbazCommit],
+        [barPath]: [barCommit, foobarCommit, foobarbazCommit],
+        [bazPath]: [bazCommit, foobarbazCommit],
+      };
+    } else {
+      // Expected output of commit-split with default behavior
+      perPathCommits = {
+        [pkgsPath]: [fooCommit, barCommit, foobarCommit, foobarbazCommit],
+        [bazPath]: [bazCommit, foobarbazCommit],
+        [somePath]: [someCommit],
+      };
+    }
+    if (includeEmpty) {
+      // Expected that each splits' Commit[] will have the empty commit appended
+      for (const commitPath in perPathCommits) {
+        perPathCommits[commitPath].push(emptyCommit);
+      }
+    }
+    return [perPathCommits, packagePaths, commits];
+  };
+
+  const emptyVsPaths = [
+    [true, true],
+    [true, false],
+    [false, true],
+    [false, false],
+  ];
+  for (const [includeEmpty, usePackagePaths] of emptyVsPaths) {
+    it(`partitions commits by ${
+      usePackagePaths ? 'specified' : 'top level'
+    } paths: includeEmpty(${includeEmpty})`, () => {
+      const [
+        expectedSplitCommitSplit,
+        packagePaths,
+        commits,
+      ] = setupPackagePathCommits(includeEmpty, usePackagePaths);
+      const commitSplitOpts: CommitSplitOptions = {};
+      if (usePackagePaths) {
+        commitSplitOpts.packagePaths = packagePaths;
+      }
+      if (includeEmpty) {
+        commitSplitOpts.includeEmpty = includeEmpty;
+      }
+      const cs = new CommitSplit(commitSplitOpts);
+      const actualSplitCommits = cs.split(commits);
+
+      expect(actualSplitCommits).to.eql(expectedSplitCommitSplit);
+    });
+  }
+
+  const invaldPaths = [
+    // intentionally inconsistent trailing slashes to test path normalization.
+    ['foo/bar', 'foo/'],
+    ['foo', 'foo/bar/'],
+    ['one/two/', 'foo/bar/', 'one/two/three'],
+  ];
+  for (const invalid of invaldPaths) {
+    it(`validates configured paths: ${invalid}`, () => {
+      let caught = false;
+      try {
+        new CommitSplit({packagePaths: invalid});
+      } catch (e) {
+        caught = true;
+      }
+      expect(caught).to.be.true;
+    });
+  }
 });

--- a/test/commit-split.ts
+++ b/test/commit-split.ts
@@ -184,7 +184,7 @@ describe('CommitSplit', () => {
 
   // Test invalid CommitSplitOptions.packagePaths combinations.
   // Intentionally inconsistent trailing slashes to test path normalization.
-  const invaldPaths = [
+  const invalidPaths = [
     // "foo/bar" overlaps "foo"
     ['foo/bar', 'foo/'],
     // ditto, testing order
@@ -192,7 +192,7 @@ describe('CommitSplit', () => {
     // "one/two/three" overlaps "one/two"
     ['one/two/', 'foo/bar/', 'one/two/three'],
   ];
-  for (const invalid of invaldPaths) {
+  for (const invalid of invalidPaths) {
     it(`validates configured paths: ${invalid}`, () => {
       let caught = false;
       try {

--- a/test/helpers.ts
+++ b/test/helpers.ts
@@ -14,6 +14,8 @@
 
 import {readFileSync} from 'fs';
 import {resolve} from 'path';
+import {Commit} from '../src/graphql-to-commits';
+import * as crypto from 'crypto';
 
 /*
  * Given an object of chnages expected to be made by code-suggester API,
@@ -43,4 +45,12 @@ export function readPOJO(name: string): object {
     'utf8'
   );
   return JSON.parse(content);
+}
+
+export function buildMockCommit(message: string, files: string[] = []): Commit {
+  return {
+    sha: crypto.createHash('md5').update(message).digest('hex'),
+    message,
+    files: files,
+  };
 }

--- a/test/releasers/java-bom.ts
+++ b/test/releasers/java-bom.ts
@@ -20,7 +20,8 @@ import * as snapshot from 'snap-shot-it';
 import * as suggester from 'code-suggester';
 import * as sinon from 'sinon';
 import {GitHubFileContents} from '../../src/github';
-import {buildGitHubFileContent, buildMockCommit} from './utils';
+import {buildGitHubFileContent} from './utils';
+import {buildMockCommit} from '../helpers';
 
 const sandbox = sinon.createSandbox();
 

--- a/test/releasers/java-yoshi.ts
+++ b/test/releasers/java-yoshi.ts
@@ -22,7 +22,8 @@ import * as suggester from 'code-suggester';
 import * as sinon from 'sinon';
 import {GitHubFileContents} from '../../src/github';
 import {expect} from 'chai';
-import {buildGitHubFileContent, buildMockCommit} from './utils';
+import {buildGitHubFileContent} from './utils';
+import {buildMockCommit} from '../helpers';
 
 const sandbox = sinon.createSandbox();
 

--- a/test/releasers/node.ts
+++ b/test/releasers/node.ts
@@ -20,7 +20,8 @@ import {Node} from '../../src/releasers/node';
 import * as snapshot from 'snap-shot-it';
 import * as suggester from 'code-suggester';
 import * as sinon from 'sinon';
-import {buildGitHubFileContent, buildMockCommit} from './utils';
+import {buildGitHubFileContent} from './utils';
+import {buildMockCommit} from '../helpers';
 
 const sandbox = sinon.createSandbox();
 

--- a/test/releasers/utils.ts
+++ b/test/releasers/utils.ts
@@ -13,7 +13,6 @@
 // limitations under the License.
 
 import {GitHubFileContents} from '../../src/github';
-import {Commit} from '../../src/graphql-to-commits';
 import {readFileSync} from 'fs';
 import {resolve} from 'path';
 import * as crypto from 'crypto';
@@ -33,13 +32,5 @@ export function buildGitHubFileRaw(content: string): GitHubFileContents {
     parsedContent: content,
     // fake a consistent sha
     sha: crypto.createHash('md5').update(content).digest('hex'),
-  };
-}
-
-export function buildMockCommit(message: string): Commit {
-  return {
-    sha: crypto.createHash('md5').update(message).digest('hex'),
-    message,
-    files: [],
   };
 }

--- a/test/releasers/yoshi-go.ts
+++ b/test/releasers/yoshi-go.ts
@@ -21,7 +21,7 @@ import * as snapshot from 'snap-shot-it';
 import * as suggester from 'code-suggester';
 import * as sinon from 'sinon';
 import {expect} from 'chai';
-import {buildMockCommit} from './utils';
+import {buildMockCommit} from '../helpers';
 
 const sandbox = sinon.createSandbox();
 


### PR DESCRIPTION
The aggregate releaser will get all commits on the default branch and
use this function to partition them per configured package path to send
to individual releasers.

- packagePaths: restrict splits to specific paths
- includeEmpty: include `git commit --allowEmtpy` commits. Each path gets
  a copy.

default behavior is the original: split by 1st child dir, drop empty
commits.