### PR TITLE
refactor: releaser interface for aggregate

### DIFF
--- a/__snapshots__/python.js
+++ b/__snapshots__/python.js
@@ -1,0 +1,65 @@
+exports['Python run creates a release PR 1'] = `
+[
+  [
+    "CHANGELOG.md",
+    {
+      "content": "# Changelog\\n\\n### [0.123.5](https://www.github.com/googleapis/py-test-repo/compare/v0.123.4...v0.123.5) (1983-10-10)\\n\\n\\n### Bug Fixes\\n\\n* **deps:** update dependency com.google.cloud:google-cloud-spanner to v1.50.0 ([08ca011](https://www.github.com/googleapis/py-test-repo/commit/08ca01180a91c0a1ba8992b491db9212))\\n* **deps:** update dependency com.google.cloud:google-cloud-storage to v1.120.0 ([845db13](https://www.github.com/googleapis/py-test-repo/commit/845db1381b3d5d20151cad2588f85feb))\\n",
+      "mode": "100644"
+    }
+  ],
+  [
+    "setup.cfg",
+    {
+      "content": "# Copyright 2020 Google LLC\\n#\\n# Licensed under the Apache License, Version 2.0 (the \\"License\\");\\n# you may not use this file except in compliance with the License.\\n# You may obtain a copy of the License at\\n#\\n#     https://www.apache.org/licenses/LICENSE-2.0\\n#\\n# Unless required by applicable law or agreed to in writing, software\\n# distributed under the License is distributed on an \\"AS IS\\" BASIS,\\n# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.\\n# See the License for the specific language governing permissions and\\n# limitations under the License.\\n\\n[metadata]\\nname = google-crc32c\\nversion = 0.123.5\\ndescription = A python wrapper of the C library 'Google CRC32C'\\nurl = https://github.com/googleapis/python-crc32c\\nlong_description = file: README.md\\nlong_description_content_type = text/markdown\\nauthor = Google LLC\\nauthor_email = googleapis-packages@google.com\\n\\nlicense = Apache 2.0\\nplatforms = Posix, MacOS X, Windows\\nclassifiers =\\n    Development Status :: 4 - Beta\\n    Intended Audience :: Developers\\n    License :: OSI Approved :: Apache Software License\\n    Operating System :: OS Independent\\n    Programming Language :: Python :: 3\\n    Programming Language :: Python :: 3.5\\n    Programming Language :: Python :: 3.6\\n    Programming Language :: Python :: 3.7\\n    Programming Language :: Python :: 3.8\\n    \\n[options]\\nzip_safe = True\\npython_requires = >=3.5\\n\\n[options.extras_require]\\ntesting = pytest\\n\\n",
+      "mode": "100644"
+    }
+  ],
+  [
+    "setup.py",
+    {
+      "content": "# Copyright 2018 Google LLC\\n#\\n# Licensed under the Apache License, Version 2.0 (the \\"License\\");\\n# you may not use this file except in compliance with the License.\\n# You may obtain a copy of the License at\\n#\\n#     https://www.apache.org/licenses/LICENSE-2.0\\n#\\n# Unless required by applicable law or agreed to in writing, software\\n# distributed under the License is distributed on an \\"AS IS\\" BASIS,\\n# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.\\n# See the License for the specific language governing permissions and\\n# limitations under the License.\\n\\nimport io\\nimport os\\n\\nimport setuptools\\n\\nname = \\"google-cloud-automl\\"\\ndescription = \\"Cloud AutoML API client library\\"\\nversion = \\"0.123.5\\"\\nrelease_status = \\"Development Status :: 3 - Alpha\\"\\ndependencies = [\\n    \\"google-api-core[grpc] >= 1.14.0, < 2.0.0dev\\",\\n    'enum34; python_version < \\"3.4\\"',\\n]\\nextras = {\\n    \\"pandas\\": [\\"pandas>=0.24.0\\"],\\n    \\"storage\\": [\\"google-cloud-storage >= 1.18.0, < 2.0.0dev\\"],\\n}\\n\\npackage_root = os.path.abspath(os.path.dirname(__file__))\\n\\nreadme_filename = os.path.join(package_root, \\"README.rst\\")\\nwith io.open(readme_filename, encoding=\\"utf-8\\") as readme_file:\\n    readme = readme_file.read()\\n\\npackages = [\\n    package for package in setuptools.find_packages() if package.startswith(\\"google\\")\\n]\\n\\nnamespaces = [\\"google\\"]\\nif \\"google.cloud\\" in packages:\\n    namespaces.append(\\"google.cloud\\")\\n\\nsetuptools.setup(\\n    name=name,\\n    version=version,\\n    description=description,\\n    long_description=readme,\\n    author=\\"Google LLC\\",\\n    author_email=\\"googleapis-packages@oogle.com\\",\\n    license=\\"Apache 2.0\\",\\n    url=\\"https://github.com/GoogleCloudPlatform/google-cloud-python\\",\\n    classifiers=[\\n        release_status,\\n        \\"Intended Audience :: Developers\\",\\n        \\"License :: OSI Approved :: Apache Software License\\",\\n        \\"Programming Language :: Python\\",\\n        \\"Programming Language :: Python :: 2\\",\\n        \\"Programming Language :: Python :: 2.7\\",\\n        \\"Programming Language :: Python :: 3\\",\\n        \\"Programming Language :: Python :: 3.5\\",\\n        \\"Programming Language :: Python :: 3.6\\",\\n        \\"Programming Language :: Python :: 3.7\\",\\n        \\"Operating System :: OS Independent\\",\\n        \\"Topic :: Internet\\",\\n    ],\\n    platforms=\\"Posix; MacOS X; Windows\\",\\n    packages=packages,\\n    namespace_packages=namespaces,\\n    install_requires=dependencies,\\n    extras_require=extras,\\n    python_requires=\\">=2.7,!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*\\",\\n    include_package_data=True,\\n    zip_safe=False,\\n)",
+      "mode": "100644"
+    }
+  ],
+  [
+    "src/version.py",
+    {
+      "content": "# Copyright 2020 Google LLC\\n#\\n# Licensed under the Apache License, Version 2.0 (the \\"License\\");\\n# you may not use this file except in compliance with the License.\\n# You may obtain a copy of the License at\\n#\\n#     https://www.apache.org/licenses/LICENSE-2.0\\n#\\n# Unless required by applicable law or agreed to in writing, software\\n# distributed under the License is distributed on an \\"AS IS\\" BASIS,\\n# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.\\n# See the License for the specific language governing permissions and\\n# limitations under the License.\\n\\n__version__ = \\"0.123.5\\"\\n",
+      "mode": "100644"
+    }
+  ]
+]
+`
+
+exports['Python run creates a release PR relative to a path 1'] = `
+[
+  [
+    "projects/python/CHANGELOG.md",
+    {
+      "content": "# Changelog\\n\\n### [0.123.5](https://www.github.com/googleapis/py-test-repo/compare/v0.123.4...v0.123.5) (1983-10-10)\\n\\n\\n### Bug Fixes\\n\\n* **deps:** update dependency com.google.cloud:google-cloud-spanner to v1.50.0 ([08ca011](https://www.github.com/googleapis/py-test-repo/commit/08ca01180a91c0a1ba8992b491db9212))\\n* **deps:** update dependency com.google.cloud:google-cloud-storage to v1.120.0 ([845db13](https://www.github.com/googleapis/py-test-repo/commit/845db1381b3d5d20151cad2588f85feb))\\n",
+      "mode": "100644"
+    }
+  ],
+  [
+    "projects/python/setup.cfg",
+    {
+      "content": "# Copyright 2020 Google LLC\\n#\\n# Licensed under the Apache License, Version 2.0 (the \\"License\\");\\n# you may not use this file except in compliance with the License.\\n# You may obtain a copy of the License at\\n#\\n#     https://www.apache.org/licenses/LICENSE-2.0\\n#\\n# Unless required by applicable law or agreed to in writing, software\\n# distributed under the License is distributed on an \\"AS IS\\" BASIS,\\n# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.\\n# See the License for the specific language governing permissions and\\n# limitations under the License.\\n\\n[metadata]\\nname = google-crc32c\\nversion = 0.123.5\\ndescription = A python wrapper of the C library 'Google CRC32C'\\nurl = https://github.com/googleapis/python-crc32c\\nlong_description = file: README.md\\nlong_description_content_type = text/markdown\\nauthor = Google LLC\\nauthor_email = googleapis-packages@google.com\\n\\nlicense = Apache 2.0\\nplatforms = Posix, MacOS X, Windows\\nclassifiers =\\n    Development Status :: 4 - Beta\\n    Intended Audience :: Developers\\n    License :: OSI Approved :: Apache Software License\\n    Operating System :: OS Independent\\n    Programming Language :: Python :: 3\\n    Programming Language :: Python :: 3.5\\n    Programming Language :: Python :: 3.6\\n    Programming Language :: Python :: 3.7\\n    Programming Language :: Python :: 3.8\\n    \\n[options]\\nzip_safe = True\\npython_requires = >=3.5\\n\\n[options.extras_require]\\ntesting = pytest\\n\\n",
+      "mode": "100644"
+    }
+  ],
+  [
+    "projects/python/setup.py",
+    {
+      "content": "# Copyright 2018 Google LLC\\n#\\n# Licensed under the Apache License, Version 2.0 (the \\"License\\");\\n# you may not use this file except in compliance with the License.\\n# You may obtain a copy of the License at\\n#\\n#     https://www.apache.org/licenses/LICENSE-2.0\\n#\\n# Unless required by applicable law or agreed to in writing, software\\n# distributed under the License is distributed on an \\"AS IS\\" BASIS,\\n# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.\\n# See the License for the specific language governing permissions and\\n# limitations under the License.\\n\\nimport io\\nimport os\\n\\nimport setuptools\\n\\nname = \\"google-cloud-automl\\"\\ndescription = \\"Cloud AutoML API client library\\"\\nversion = \\"0.123.5\\"\\nrelease_status = \\"Development Status :: 3 - Alpha\\"\\ndependencies = [\\n    \\"google-api-core[grpc] >= 1.14.0, < 2.0.0dev\\",\\n    'enum34; python_version < \\"3.4\\"',\\n]\\nextras = {\\n    \\"pandas\\": [\\"pandas>=0.24.0\\"],\\n    \\"storage\\": [\\"google-cloud-storage >= 1.18.0, < 2.0.0dev\\"],\\n}\\n\\npackage_root = os.path.abspath(os.path.dirname(__file__))\\n\\nreadme_filename = os.path.join(package_root, \\"README.rst\\")\\nwith io.open(readme_filename, encoding=\\"utf-8\\") as readme_file:\\n    readme = readme_file.read()\\n\\npackages = [\\n    package for package in setuptools.find_packages() if package.startswith(\\"google\\")\\n]\\n\\nnamespaces = [\\"google\\"]\\nif \\"google.cloud\\" in packages:\\n    namespaces.append(\\"google.cloud\\")\\n\\nsetuptools.setup(\\n    name=name,\\n    version=version,\\n    description=description,\\n    long_description=readme,\\n    author=\\"Google LLC\\",\\n    author_email=\\"googleapis-packages@oogle.com\\",\\n    license=\\"Apache 2.0\\",\\n    url=\\"https://github.com/GoogleCloudPlatform/google-cloud-python\\",\\n    classifiers=[\\n        release_status,\\n        \\"Intended Audience :: Developers\\",\\n        \\"License :: OSI Approved :: Apache Software License\\",\\n        \\"Programming Language :: Python\\",\\n        \\"Programming Language :: Python :: 2\\",\\n        \\"Programming Language :: Python :: 2.7\\",\\n        \\"Programming Language :: Python :: 3\\",\\n        \\"Programming Language :: Python :: 3.5\\",\\n        \\"Programming Language :: Python :: 3.6\\",\\n        \\"Programming Language :: Python :: 3.7\\",\\n        \\"Operating System :: OS Independent\\",\\n        \\"Topic :: Internet\\",\\n    ],\\n    platforms=\\"Posix; MacOS X; Windows\\",\\n    packages=packages,\\n    namespace_packages=namespaces,\\n    install_requires=dependencies,\\n    extras_require=extras,\\n    python_requires=\\">=2.7,!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*\\",\\n    include_package_data=True,\\n    zip_safe=False,\\n)",
+      "mode": "100644"
+    }
+  ],
+  [
+    "projects/python/src/version.py",
+    {
+      "content": "# Copyright 2020 Google LLC\\n#\\n# Licensed under the Apache License, Version 2.0 (the \\"License\\");\\n# you may not use this file except in compliance with the License.\\n# You may obtain a copy of the License at\\n#\\n#     https://www.apache.org/licenses/LICENSE-2.0\\n#\\n# Unless required by applicable law or agreed to in writing, software\\n# distributed under the License is distributed on an \\"AS IS\\" BASIS,\\n# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.\\n# See the License for the specific language governing permissions and\\n# limitations under the License.\\n\\n__version__ = \\"0.123.5\\"\\n",
+      "mode": "100644"
+    }
+  ]
+]
+`

--- a/__snapshots__/python.js
+++ b/__snapshots__/python.js
@@ -63,3 +63,27 @@ exports['Python run creates a release PR relative to a path 1'] = `
   ]
 ]
 `
+
+exports['Python getOpenPROptions returns release PR changes with defaultInitialVersion 1'] = `
+## 0.1.0 (1983-10-10)
+
+
+### Bug Fixes
+
+* **deps:** update dependency com.google.cloud:google-cloud-spanner to v1.50.0 ([08ca011](https://www.github.com/googleapis/py-test-repo/commit/08ca01180a91c0a1ba8992b491db9212))
+* **deps:** update dependency com.google.cloud:google-cloud-storage to v1.120.0 ([845db13](https://www.github.com/googleapis/py-test-repo/commit/845db1381b3d5d20151cad2588f85feb))
+---
+
+`
+
+exports['Python getOpenPROptions returns release PR changes with semver patch bump 1'] = `
+### [0.123.5](https://www.github.com/googleapis/py-test-repo/compare/v0.123.4...v0.123.5) (1983-10-10)
+
+
+### Bug Fixes
+
+* **deps:** update dependency com.google.cloud:google-cloud-spanner to v1.50.0 ([08ca011](https://www.github.com/googleapis/py-test-repo/commit/08ca01180a91c0a1ba8992b491db9212))
+* **deps:** update dependency com.google.cloud:google-cloud-storage to v1.120.0 ([845db13](https://www.github.com/googleapis/py-test-repo/commit/845db1381b3d5d20151cad2588f85feb))
+---
+
+`

--- a/src/release-pr.ts
+++ b/src/release-pr.ts
@@ -134,6 +134,13 @@ export class ReleasePR {
     this.packagePrefix = this.coercePackagePrefix(this.packageName);
   }
 
+  async getOpenPROptions(
+    _commits: Commit[],
+    _latestTag?: GitHubTag
+  ): Promise<OpenPROptions | undefined> {
+    throw Error('must be implemented by subclass');
+  }
+
   async run(): Promise<number | undefined> {
     if (this.snapshot && !this.supportsSnapshots()) {
       checkpoint(

--- a/test/releasers/node.ts
+++ b/test/releasers/node.ts
@@ -15,19 +15,38 @@
 import * as assert from 'assert';
 import {describe, it, afterEach} from 'mocha';
 import {expect} from 'chai';
-import {GitHub, GitHubFileContents} from '../../src/github';
+import {GitHub} from '../../src/github';
 import {Node} from '../../src/releasers/node';
 import * as snapshot from 'snap-shot-it';
 import * as suggester from 'code-suggester';
 import * as sinon from 'sinon';
-import {buildGitHubFileContent} from './utils';
+import {stubFilesFromFixtures} from './utils';
 import {buildMockCommit} from '../helpers';
+import {Changelog} from '../../src/updaters/changelog';
+import {PackageJson} from '../../src/updaters/package-json';
+import {SamplesPackageJson} from '../../src/updaters/samples-package-json';
 
 const sandbox = sinon.createSandbox();
 
-function buildFileContent(fixture: string): GitHubFileContents {
-  return buildGitHubFileContent('./test/releasers/fixtures/node', fixture);
+function stubFilesToUpdate(gh: GitHub, files: string[]) {
+  stubFilesFromFixtures('./test/releasers/fixtures/node', sandbox, gh, files);
 }
+
+const LATEST_TAG = {
+  name: 'v0.123.4',
+  sha: 'da6e52d956c1e35d19e75e0f2fdba439739ba364',
+  version: '0.123.4',
+};
+
+const COMMITS = [
+  buildMockCommit(
+    'fix(deps): update dependency com.google.cloud:google-cloud-storage to v1.120.0'
+  ),
+  buildMockCommit(
+    'fix(deps): update dependency com.google.cloud:google-cloud-spanner to v1.50.0'
+  ),
+  buildMockCommit('chore: update common templates'),
+];
 
 function mockRequest(releasePR: Node) {
   sandbox.stub(releasePR.gh, 'getDefaultBranch').resolves('master');
@@ -39,25 +58,9 @@ function mockRequest(releasePR: Node) {
     .stub(releasePR.gh, 'findMergedReleasePR')
     .returns(Promise.resolve(undefined));
 
-  sandbox.stub(releasePR.gh, 'latestTag').returns(
-    Promise.resolve({
-      name: 'v0.123.4',
-      sha: 'da6e52d956c1e35d19e75e0f2fdba439739ba364',
-      version: '0.123.4',
-    })
-  );
+  sandbox.stub(releasePR.gh, 'latestTag').resolves(LATEST_TAG);
 
-  sandbox
-    .stub(releasePR.gh, 'commitsSinceSha')
-    .resolves([
-      buildMockCommit(
-        'fix(deps): update dependency com.google.cloud:google-cloud-storage to v1.120.0'
-      ),
-      buildMockCommit(
-        'fix(deps): update dependency com.google.cloud:google-cloud-spanner to v1.50.0'
-      ),
-      buildMockCommit('chore: update common templates'),
-    ]);
+  sandbox.stub(releasePR.gh, 'commitsSinceSha').resolves(COMMITS);
 
   sandbox.stub(releasePR.gh, 'addLabels');
 }
@@ -65,6 +68,175 @@ function mockRequest(releasePR: Node) {
 describe('Node', () => {
   afterEach(() => {
     sandbox.restore();
+  });
+  describe('getOpenPROptions', () => {
+    it('returns release PR changes with defaultInitialVersion', async () => {
+      const expectedVersion = '1.0.0';
+      const pkgName = 'node-test-repo';
+      const releasePR = new Node({
+        repoUrl: 'googleapis/node-test-repo',
+        releaseType: 'node',
+        apiUrl: 'https://api.github.com',
+      });
+      mockRequest(releasePR);
+      // this stub is required only because Node lookupPackageName calls
+      // getFileContentsOnBranch('package.json'). Otherwise this test
+      // doesn't rely on getting the contents of each Update file.
+      stubFilesToUpdate(releasePR.gh, ['package.json']);
+
+      // no latestTag to pass to getOpenPROptions (never found a release)
+      // releaser should set defaultInitialVersion
+      const openPROptions = await releasePR.getOpenPROptions(COMMITS);
+
+      expect(openPROptions).to.not.be.undefined;
+      expect(openPROptions).to.have.property('sha').equal(COMMITS[0].sha);
+      expect(openPROptions).to.have.property('version').equal(expectedVersion);
+      expect(openPROptions).to.have.property('includePackageName').to.be.false;
+      expect(openPROptions).to.have.property('changelogEntry');
+
+      const normalizedChangelog = openPROptions!.changelogEntry.replace(
+        /[0-9]{4}-[0-9]{2}-[0-9]{2}/,
+        '1983-10-10'
+      );
+      const expectedChangelog = `
+## ${expectedVersion} (1983-10-10)
+
+
+### Bug Fixes
+
+* **deps:** update dependency com.google.cloud:google-cloud-spanner to v1.50.0 ([08ca011](https://www.github.com/googleapis/node-test-repo/commit/${COMMITS[1].sha}))
+* **deps:** update dependency com.google.cloud:google-cloud-storage to v1.120.0 ([845db13](https://www.github.com/googleapis/node-test-repo/commit/${COMMITS[0].sha}))
+---
+`.substring(1); // leading \n is aesthetic
+      expect(normalizedChangelog).to.equal(expectedChangelog);
+
+      const perUpdateChangelog = openPROptions!.changelogEntry.substring(
+        0,
+        openPROptions!.changelogEntry.length - 5 // no trailing "\n---\n"
+      );
+      expect(openPROptions)
+        .to.have.property('updates')
+        .to.eql([
+          new PackageJson({
+            path: 'package-lock.json',
+            changelogEntry: perUpdateChangelog,
+            version: expectedVersion,
+            packageName: pkgName,
+          }),
+          new SamplesPackageJson({
+            path: 'samples/package.json',
+            changelogEntry: perUpdateChangelog,
+            version: expectedVersion,
+            packageName: pkgName,
+          }),
+          new Changelog({
+            path: 'CHANGELOG.md',
+            changelogEntry: perUpdateChangelog,
+            version: expectedVersion,
+            packageName: pkgName,
+          }),
+          new PackageJson({
+            path: 'package.json',
+            changelogEntry: perUpdateChangelog,
+            version: expectedVersion,
+            packageName: pkgName,
+          }),
+        ]);
+    });
+    it('returns release PR changes with semver patch bump', async () => {
+      const expectedVersion = '0.123.5';
+      const pkgName = 'node-test-repo';
+      const releasePR = new Node({
+        repoUrl: 'googleapis/node-test-repo',
+        releaseType: 'node',
+        apiUrl: 'https://api.github.com',
+      });
+      mockRequest(releasePR);
+      // this stub is required only because Node lookupPackageName calls
+      // getFileContentsOnBranch('package.json'). Otherwise this test
+      // doesn't rely on getting the contents of each Update file.
+      stubFilesToUpdate(releasePR.gh, ['package.json']);
+
+      // found last release (LATEST_TAG) so releaser should semver bump.
+      const openPROptions = await releasePR.getOpenPROptions(
+        COMMITS,
+        LATEST_TAG
+      );
+
+      expect(openPROptions).to.not.be.undefined;
+      expect(openPROptions).to.have.property('sha').equal(COMMITS[0].sha);
+      expect(openPROptions).to.have.property('version').equal(expectedVersion);
+      expect(openPROptions).to.have.property('includePackageName').to.be.false;
+      expect(openPROptions).to.have.property('changelogEntry');
+
+      const normalizedChangelog = openPROptions!.changelogEntry.replace(
+        /[0-9]{4}-[0-9]{2}-[0-9]{2}/,
+        '1983-10-10'
+      );
+      const expectedChangelog = `
+### [${expectedVersion}](https://www.github.com/googleapis/node-test-repo/compare/v0.123.4...v${expectedVersion}) (1983-10-10)
+
+
+### Bug Fixes
+
+* **deps:** update dependency com.google.cloud:google-cloud-spanner to v1.50.0 ([08ca011](https://www.github.com/googleapis/node-test-repo/commit/${COMMITS[1].sha}))
+* **deps:** update dependency com.google.cloud:google-cloud-storage to v1.120.0 ([845db13](https://www.github.com/googleapis/node-test-repo/commit/${COMMITS[0].sha}))
+---
+`.substring(1); // leading \n is aesthetic
+      expect(normalizedChangelog).to.equal(expectedChangelog);
+
+      const perUpdateChangelog = openPROptions!.changelogEntry.substring(
+        0,
+        openPROptions!.changelogEntry.length - 5 // no trailing "\n---\n"
+      );
+      expect(openPROptions)
+        .to.have.property('updates')
+        .to.eql([
+          new PackageJson({
+            path: 'package-lock.json',
+            changelogEntry: perUpdateChangelog,
+            version: expectedVersion,
+            packageName: pkgName,
+          }),
+          new SamplesPackageJson({
+            path: 'samples/package.json',
+            changelogEntry: perUpdateChangelog,
+            version: expectedVersion,
+            packageName: pkgName,
+          }),
+          new Changelog({
+            path: 'CHANGELOG.md',
+            changelogEntry: perUpdateChangelog,
+            version: expectedVersion,
+            packageName: pkgName,
+          }),
+          new PackageJson({
+            path: 'package.json',
+            changelogEntry: perUpdateChangelog,
+            version: expectedVersion,
+            packageName: pkgName,
+          }),
+        ]);
+    });
+    it('returns undefined for no CC changes', async () => {
+      const releasePR = new Node({
+        repoUrl: 'googleapis/node-test-repo',
+        releaseType: 'python',
+        apiUrl: 'https://api.github.com',
+      });
+      mockRequest(releasePR);
+      // this stub is required only because Node lookupPackageName calls
+      // getFileContentsOnBranch('package.json'). Otherwise this test
+      // doesn't rely on getting the contents of each Update file.
+      stubFilesToUpdate(releasePR.gh, ['package.json']);
+
+      const openPROptions = await releasePR.getOpenPROptions(
+        [buildMockCommit('chore: update common templates')],
+        LATEST_TAG
+      );
+
+      expect(openPROptions).to.be.undefined;
+    });
   });
   describe('run', () => {
     it('creates a release PR without package-lock.json', async () => {
@@ -88,17 +260,7 @@ describe('Node', () => {
         }
       );
       mockRequest(releasePR);
-      const getFileContentsStub = sandbox.stub(
-        releasePR.gh,
-        'getFileContentsOnBranch'
-      );
-      getFileContentsStub
-        .withArgs('package.json', 'master')
-        .resolves(buildFileContent('package.json'));
-      getFileContentsStub.rejects(
-        Object.assign(Error('not found'), {status: 404})
-      );
-
+      stubFilesToUpdate(releasePR.gh, ['package.json']);
       const pr = await releasePR.run();
       assert.strictEqual(pr, 22);
       snapshot(
@@ -131,20 +293,7 @@ describe('Node', () => {
       );
 
       mockRequest(releasePR);
-      const getFileContentsStub = sandbox.stub(
-        releasePR.gh,
-        'getFileContentsOnBranch'
-      );
-      getFileContentsStub
-        .withArgs('package.json', 'master')
-        .resolves(buildFileContent('package.json'));
-      getFileContentsStub
-        .withArgs('package-lock.json', 'master')
-        .resolves(buildFileContent('package-lock.json'));
-      getFileContentsStub.rejects(
-        Object.assign(Error('not found'), {status: 404})
-      );
-
+      stubFilesToUpdate(releasePR.gh, ['package.json', 'package-lock.json']);
       await releasePR.run();
       snapshot(
         JSON.stringify(expectedChanges, null, 2).replace(
@@ -174,17 +323,10 @@ describe('Node', () => {
         }
       );
       mockRequest(releasePR);
-
-      const getFileContentsStub = sandbox.stub(
-        releasePR.gh,
-        'getFileContentsOnBranch'
-      );
-      getFileContentsStub
-        .withArgs('packages/foo/package.json', 'master')
-        .resolves(buildFileContent('package.json'));
-      getFileContentsStub.rejects(
-        Object.assign(Error('not found'), {status: 404})
-      );
+      stubFilesToUpdate(releasePR.gh, [
+        'packages/foo/package.json',
+        'package-lock.json',
+      ]);
       await releasePR.run();
       snapshot(
         JSON.stringify(expectedChanges, null, 2).replace(
@@ -231,17 +373,7 @@ describe('Node', () => {
       });
       mockRequest(releasePR);
 
-      const getFileContentsStub = sandbox.stub(
-        releasePR.gh,
-        'getFileContentsOnBranch'
-      );
-      getFileContentsStub
-        .withArgs('package.json', 'master')
-        .resolves(buildFileContent('package.json'));
-      getFileContentsStub.rejects(
-        Object.assign(Error('not found'), {status: 404})
-      );
-
+      stubFilesToUpdate(releasePR.gh, ['package.json']);
       const pr = await releasePR.run();
       assert.strictEqual(pr, 22);
       snapshot(
@@ -259,16 +391,7 @@ describe('Node', () => {
       const github = new GitHub({owner: 'googleapis', repo: 'node-test-repo'});
 
       sandbox.stub(github, 'getDefaultBranch').resolves('master');
-      const getFileContentsStub = sandbox.stub(
-        github,
-        'getFileContentsOnBranch'
-      );
-      getFileContentsStub
-        .withArgs('package.json', 'master')
-        .resolves(buildFileContent('package.json'));
-      getFileContentsStub.rejects(
-        Object.assign(Error('not found'), {status: 404})
-      );
+      stubFilesToUpdate(github, ['package.json']);
 
       const expectedPackageName = await Node.lookupPackageName(github);
       expect(expectedPackageName).to.equal('node-test-repo');
@@ -278,16 +401,7 @@ describe('Node', () => {
       const github = new GitHub({owner: 'googleapis', repo: 'node-test-repo'});
 
       sandbox.stub(github, 'getDefaultBranch').resolves('master');
-      const getFileContentsStub = sandbox.stub(
-        github,
-        'getFileContentsOnBranch'
-      );
-      getFileContentsStub
-        .withArgs('some-path/package.json', 'master')
-        .resolves(buildFileContent('package.json'));
-      getFileContentsStub.rejects(
-        Object.assign(Error('not found'), {status: 404})
-      );
+      stubFilesToUpdate(github, ['some-path/package.json']);
 
       const expectedPackageName = await Node.lookupPackageName(
         github,

--- a/test/releasers/python.ts
+++ b/test/releasers/python.ts
@@ -88,21 +88,12 @@ describe('Python', () => {
       expect(openPROptions).to.have.property('includePackageName').to.be.false;
       expect(openPROptions).to.have.property('changelogEntry');
 
-      const normalizedChangelog = openPROptions!.changelogEntry.replace(
-        /[0-9]{4}-[0-9]{2}-[0-9]{2}/,
-        '1983-10-10'
+      snapshot(
+        openPROptions!.changelogEntry.replace(
+          /[0-9]{4}-[0-9]{2}-[0-9]{2}/,
+          '1983-10-10'
+        )
       );
-      const expectedChangelog = `
-## ${expectedVersion} (1983-10-10)
-
-
-### Bug Fixes
-
-* **deps:** update dependency com.google.cloud:google-cloud-spanner to v1.50.0 ([08ca011](https://www.github.com/googleapis/py-test-repo/commit/${COMMITS[1].sha}))
-* **deps:** update dependency com.google.cloud:google-cloud-storage to v1.120.0 ([845db13](https://www.github.com/googleapis/py-test-repo/commit/${COMMITS[0].sha}))
----
-`.substring(1); // leading \n is aesthetic
-      expect(normalizedChangelog).to.equal(expectedChangelog);
 
       const perUpdateChangelog = openPROptions!.changelogEntry.substring(
         0,
@@ -159,21 +150,12 @@ describe('Python', () => {
       expect(openPROptions).to.have.property('includePackageName').to.be.false;
       expect(openPROptions).to.have.property('changelogEntry');
 
-      const normalizedChangelog = openPROptions!.changelogEntry.replace(
-        /[0-9]{4}-[0-9]{2}-[0-9]{2}/,
-        '1983-10-10'
+      snapshot(
+        openPROptions!.changelogEntry.replace(
+          /[0-9]{4}-[0-9]{2}-[0-9]{2}/,
+          '1983-10-10'
+        )
       );
-      const expectedChangelog = `
-### [${expectedVersion}](https://www.github.com/googleapis/py-test-repo/compare/v0.123.4...v${expectedVersion}) (1983-10-10)
-
-
-### Bug Fixes
-
-* **deps:** update dependency com.google.cloud:google-cloud-spanner to v1.50.0 ([08ca011](https://www.github.com/googleapis/py-test-repo/commit/${COMMITS[1].sha}))
-* **deps:** update dependency com.google.cloud:google-cloud-storage to v1.120.0 ([845db13](https://www.github.com/googleapis/py-test-repo/commit/${COMMITS[0].sha}))
----
-`.substring(1); // leading \n is aesthetic
-      expect(normalizedChangelog).to.equal(expectedChangelog);
 
       const perUpdateChangelog = openPROptions!.changelogEntry.substring(
         0,

--- a/test/releasers/python.ts
+++ b/test/releasers/python.ts
@@ -1,0 +1,302 @@
+// Copyright 2021 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import * as assert from 'assert';
+import {describe, it, afterEach} from 'mocha';
+import {expect} from 'chai';
+import {GitHub} from '../../src/github';
+import {Python} from '../../src/releasers/python';
+import * as snapshot from 'snap-shot-it';
+import * as suggester from 'code-suggester';
+import * as sinon from 'sinon';
+import {stubFilesFromFixtures} from './utils';
+import {buildMockCommit} from '../helpers';
+import {Changelog} from '../../src/updaters/changelog';
+import {SetupCfg} from '../../src/updaters/python/setup-cfg';
+import {SetupPy} from '../../src/updaters/python/setup-py';
+import {VersionPy} from '../../src/updaters/python/version-py';
+
+const sandbox = sinon.createSandbox();
+
+function stubFilesToUpdate(gh: GitHub, files: string[]) {
+  stubFilesFromFixtures('./test/updaters/fixtures/', sandbox, gh, files);
+}
+
+const LATEST_TAG = {
+  name: 'v0.123.4',
+  sha: 'da6e52d956c1e35d19e75e0f2fdba439739ba364',
+  version: '0.123.4',
+};
+
+const COMMITS = [
+  buildMockCommit(
+    'fix(deps): update dependency com.google.cloud:google-cloud-storage to v1.120.0'
+  ),
+  buildMockCommit(
+    'fix(deps): update dependency com.google.cloud:google-cloud-spanner to v1.50.0'
+  ),
+  buildMockCommit('chore: update common templates'),
+];
+
+function stubGithub(releasePR: Python, versionFiles: string[] = []) {
+  sandbox.stub(releasePR.gh, 'getDefaultBranch').resolves('master');
+  // No open release PRs, so create a new release PR
+  sandbox.stub(releasePR.gh, 'findOpenReleasePRs').returns(Promise.resolve([]));
+  sandbox
+    .stub(releasePR.gh, 'findMergedReleasePR')
+    .returns(Promise.resolve(undefined));
+  sandbox.stub(releasePR.gh, 'latestTag').resolves(LATEST_TAG);
+  sandbox.stub(releasePR.gh, 'commitsSinceSha').resolves(COMMITS);
+  sandbox.stub(releasePR.gh, 'addLabels');
+  sandbox.stub(releasePR.gh, 'findFilesByFilename').resolves(versionFiles);
+}
+
+describe('Python', () => {
+  afterEach(() => {
+    sandbox.restore();
+  });
+  const pkgName = 'google-cloud-automl';
+  describe('getOpenPROptions', () => {
+    it('returns release PR changes with defaultInitialVersion', async () => {
+      const expectedVersion = '0.1.0';
+      const releasePR = new Python({
+        repoUrl: 'googleapis/py-test-repo',
+        releaseType: 'python',
+        packageName: pkgName,
+        apiUrl: 'https://api.github.com',
+      });
+      stubGithub(releasePR, ['src/version.py']);
+
+      // no latestTag to pass to getOpenPROptions (never found a release)
+      // releaser should set defaultInitialVersion
+      const openPROptions = await releasePR.getOpenPROptions(COMMITS);
+
+      expect(openPROptions).to.not.be.undefined;
+      expect(openPROptions).to.have.property('sha').equal(COMMITS[0].sha);
+      expect(openPROptions).to.have.property('version').equal(expectedVersion);
+      expect(openPROptions).to.have.property('includePackageName').to.be.false;
+      expect(openPROptions).to.have.property('changelogEntry');
+
+      const normalizedChangelog = openPROptions!.changelogEntry.replace(
+        /[0-9]{4}-[0-9]{2}-[0-9]{2}/,
+        '1983-10-10'
+      );
+      const expectedChangelog = `
+## ${expectedVersion} (1983-10-10)
+
+
+### Bug Fixes
+
+* **deps:** update dependency com.google.cloud:google-cloud-spanner to v1.50.0 ([08ca011](https://www.github.com/googleapis/py-test-repo/commit/${COMMITS[1].sha}))
+* **deps:** update dependency com.google.cloud:google-cloud-storage to v1.120.0 ([845db13](https://www.github.com/googleapis/py-test-repo/commit/${COMMITS[0].sha}))
+---
+`.substring(1); // leading \n is aesthetic
+      expect(normalizedChangelog).to.equal(expectedChangelog);
+
+      const perUpdateChangelog = openPROptions!.changelogEntry.substring(
+        0,
+        openPROptions!.changelogEntry.length - 5 // no trailing "\n---\n"
+      );
+      expect(openPROptions)
+        .to.have.property('updates')
+        .to.eql([
+          new Changelog({
+            path: 'CHANGELOG.md',
+            changelogEntry: perUpdateChangelog,
+            version: expectedVersion,
+            packageName: pkgName,
+          }),
+          new SetupCfg({
+            path: 'setup.cfg',
+            changelogEntry: perUpdateChangelog,
+            version: expectedVersion,
+            packageName: pkgName,
+          }),
+          new SetupPy({
+            path: 'setup.py',
+            changelogEntry: perUpdateChangelog,
+            version: expectedVersion,
+            packageName: pkgName,
+          }),
+          new VersionPy({
+            path: 'src/version.py',
+            changelogEntry: perUpdateChangelog,
+            version: expectedVersion,
+            packageName: pkgName,
+          }),
+        ]);
+    });
+    it('returns release PR changes with semver patch bump', async () => {
+      const expectedVersion = '0.123.5';
+      const releasePR = new Python({
+        repoUrl: 'googleapis/py-test-repo',
+        releaseType: 'python',
+        packageName: pkgName,
+        apiUrl: 'https://api.github.com',
+      });
+      stubGithub(releasePR, ['src/version.py']);
+
+      // found last release (LATEST_TAG) so releaser should semver bump.
+      const openPROptions = await releasePR.getOpenPROptions(
+        COMMITS,
+        LATEST_TAG
+      );
+
+      expect(openPROptions).to.not.be.undefined;
+      expect(openPROptions).to.have.property('sha').equal(COMMITS[0].sha);
+      expect(openPROptions).to.have.property('version').equal(expectedVersion);
+      expect(openPROptions).to.have.property('includePackageName').to.be.false;
+      expect(openPROptions).to.have.property('changelogEntry');
+
+      const normalizedChangelog = openPROptions!.changelogEntry.replace(
+        /[0-9]{4}-[0-9]{2}-[0-9]{2}/,
+        '1983-10-10'
+      );
+      const expectedChangelog = `
+### [${expectedVersion}](https://www.github.com/googleapis/py-test-repo/compare/v0.123.4...v${expectedVersion}) (1983-10-10)
+
+
+### Bug Fixes
+
+* **deps:** update dependency com.google.cloud:google-cloud-spanner to v1.50.0 ([08ca011](https://www.github.com/googleapis/py-test-repo/commit/${COMMITS[1].sha}))
+* **deps:** update dependency com.google.cloud:google-cloud-storage to v1.120.0 ([845db13](https://www.github.com/googleapis/py-test-repo/commit/${COMMITS[0].sha}))
+---
+`.substring(1); // leading \n is aesthetic
+      expect(normalizedChangelog).to.equal(expectedChangelog);
+
+      const perUpdateChangelog = openPROptions!.changelogEntry.substring(
+        0,
+        openPROptions!.changelogEntry.length - 5 // no trailing "\n---\n"
+      );
+      expect(openPROptions)
+        .to.have.property('updates')
+        .to.eql([
+          new Changelog({
+            path: 'CHANGELOG.md',
+            changelogEntry: perUpdateChangelog,
+            version: expectedVersion,
+            packageName: pkgName,
+          }),
+          new SetupCfg({
+            path: 'setup.cfg',
+            changelogEntry: perUpdateChangelog,
+            version: expectedVersion,
+            packageName: pkgName,
+          }),
+          new SetupPy({
+            path: 'setup.py',
+            changelogEntry: perUpdateChangelog,
+            version: expectedVersion,
+            packageName: pkgName,
+          }),
+          new VersionPy({
+            path: 'src/version.py',
+            changelogEntry: perUpdateChangelog,
+            version: expectedVersion,
+            packageName: pkgName,
+          }),
+        ]);
+    });
+    it('returns undefined for no CC changes', async () => {
+      const releasePR = new Python({
+        repoUrl: 'googleapis/py-test-repo',
+        releaseType: 'python',
+        packageName: pkgName,
+        apiUrl: 'https://api.github.com',
+      });
+      stubGithub(releasePR);
+      const openPROptions = await releasePR.getOpenPROptions(
+        [buildMockCommit('chore: update common templates')],
+        LATEST_TAG
+      );
+      expect(openPROptions).to.be.undefined;
+    });
+  });
+
+  describe('run', () => {
+    // normally you'd only have your version in one location
+    // e.g. setup.py or setup.cfg or src/version.py, not all 3!
+    // just testing the releaser does try to update all 3.
+    it('creates a release PR', async () => {
+      const releasePR = new Python({
+        repoUrl: 'googleapis/py-test-repo',
+        releaseType: 'python',
+        packageName: pkgName,
+        apiUrl: 'https://api.github.com',
+      });
+
+      // We stub the entire suggester API, asserting only that the
+      // the appropriate changes are proposed:
+      let expectedChanges = null;
+      sandbox.replace(
+        suggester,
+        'createPullRequest',
+        (_octokit, changes): Promise<number> => {
+          expectedChanges = [...(changes as Map<string, object>)]; // Convert map to key/value pairs.
+          return Promise.resolve(22);
+        }
+      );
+      stubGithub(releasePR, ['src/version.py']);
+      stubFilesToUpdate(releasePR.gh, [
+        'setup.py',
+        'src/version.py',
+        'setup.cfg',
+      ]);
+      const pr = await releasePR.run();
+      assert.strictEqual(pr, 22);
+      snapshot(
+        JSON.stringify(expectedChanges, null, 2).replace(
+          /[0-9]{4}-[0-9]{2}-[0-9]{2}/,
+          '1983-10-10' // don't save a real date, this will break tests.
+        )
+      );
+    });
+
+    it('creates a release PR relative to a path', async () => {
+      const releasePR = new Python({
+        repoUrl: 'googleapis/py-test-repo',
+        releaseType: 'python',
+        packageName: pkgName,
+        apiUrl: 'https://api.github.com',
+        path: 'projects/python',
+      });
+
+      // We stub the entire suggester API, asserting only that the
+      // the appropriate changes are proposed:
+      let expectedChanges = null;
+      sandbox.replace(
+        suggester,
+        'createPullRequest',
+        (_octokit, changes): Promise<number> => {
+          expectedChanges = [...(changes as Map<string, object>)]; // Convert map to key/value pairs.
+          return Promise.resolve(22);
+        }
+      );
+      stubGithub(releasePR, ['src/version.py']);
+      stubFilesToUpdate(releasePR.gh, [
+        'projects/python/setup.py',
+        'projects/python/src/version.py',
+        'projects/python/setup.cfg',
+      ]);
+      const pr = await releasePR.run();
+      assert.strictEqual(pr, 22);
+      snapshot(
+        JSON.stringify(expectedChanges, null, 2).replace(
+          /[0-9]{4}-[0-9]{2}-[0-9]{2}/,
+          '1983-10-10' // don't save a real date, this will break tests.
+        )
+      );
+    });
+  });
+});

--- a/test/releasers/utils.ts
+++ b/test/releasers/utils.ts
@@ -43,7 +43,8 @@ export function buildGitHubFileRaw(content: string): GitHubFileContents {
  *  direct children (no sub folders).
  * @param sandbox - created in test file.
  * @param gh - GitHub instance's `getFileContentsOnBranch` to stub
- * @param files - list of file paths from repo root to stub
+ * @param files - list of mock/repo/full/path/filename.ext. The stub file is
+ *   then read from fixturePath/filename.ext.
  * @param defaultBranch - branch arg to `getFileContentsOnBranch`
  */
 export function stubFilesFromFixtures(


### PR DESCRIPTION
The aggregate releaser will call into each releaser passing in
relevant commits and the lastest GitHubTag. In return it will receive
the OpenPROptions that releaser would have used to open a PR.

Starting with only Node and Python.

Finally some test coverage for the Python releaser.