### PR TITLE
refactor!: normalize configuration across classes

### DIFF
--- a/src/constants.ts
+++ b/src/constants.ts
@@ -13,4 +13,4 @@
 // limitations under the License.
 
 export const RELEASE_PLEASE = 'release-please';
-export const DEFAULT_LABELS = 'autorelease: pending';
+export const DEFAULT_LABELS = ['autorelease: pending'];

--- a/src/conventional-commits.ts
+++ b/src/conventional-commits.ts
@@ -32,13 +32,12 @@ const conventionalCommitsFilter = require('conventional-commits-filter');
 // eslint-disable-next-line @typescript-eslint/no-var-requires
 const conventionalChangelogWriter = require('conventional-changelog-writer');
 // eslint-disable-next-line @typescript-eslint/no-var-requires
-const parseGithubRepoUrl = require('parse-github-repo-url');
-// eslint-disable-next-line @typescript-eslint/no-var-requires
 const presetFactory = require('conventional-changelog-conventionalcommits');
 
 interface ConventionalCommitsOptions {
   commits: Commit[];
-  githubRepoUrl: string;
+  owner: string;
+  repository: string;
   host?: string;
   bumpMinorPreMajor?: boolean;
   // allow for customized commit template.
@@ -49,7 +48,7 @@ interface ConventionalCommitsOptions {
   commitFilter?: (c: ConventionalChangelogCommit) => boolean;
 }
 
-interface ChangelogSection {
+export interface ChangelogSection {
   type: string;
   section: string;
   hidden?: boolean;
@@ -156,14 +155,11 @@ export class ConventionalCommits {
   private commitFilter?: (c: ConventionalChangelogCommit) => boolean;
 
   constructor(options: ConventionalCommitsOptions) {
-    const parsedGithubRepoUrl = parseGithubRepoUrl(options.githubRepoUrl);
-    if (!parsedGithubRepoUrl) throw Error('could not parse githubRepoUrl');
-    const [owner, repository] = parsedGithubRepoUrl;
     this.commits = options.commits;
     this.bumpMinorPreMajor = options.bumpMinorPreMajor || false;
     this.host = options.host || 'https://www.github.com';
-    this.owner = owner;
-    this.repository = repository;
+    this.owner = options.owner;
+    this.repository = options.repository;
     // we allow some languages (currently Ruby) to provide their own
     // template style:
     this.commitPartial = options.commitPartial;

--- a/src/github.ts
+++ b/src/github.ts
@@ -82,20 +82,12 @@ import {
 import {Update} from './updaters/update';
 import {BranchName} from './util/branch-name';
 import {RELEASE_PLEASE} from './constants';
+import {GitHubConstructorOptions} from '.';
 
 export interface OctokitAPIs {
   graphql: Function;
   request: RequestFunctionType;
   octokit: OctokitType;
-}
-
-interface GitHubOptions {
-  defaultBranch?: string;
-  token?: string;
-  owner: string;
-  repo: string;
-  apiUrl?: string;
-  octokitAPIs?: OctokitAPIs;
 }
 
 export interface GitHubTag {
@@ -173,7 +165,7 @@ export class GitHub {
   repo: string;
   apiUrl: string;
 
-  constructor(options: GitHubOptions) {
+  constructor(options: GitHubConstructorOptions) {
     this.defaultBranch = options.defaultBranch;
     this.token = options.token;
     this.owner = options.owner;
@@ -191,7 +183,6 @@ export class GitHub {
           'user-agent': `${RELEASE_PLEASE}/${
             require('../../package.json').version
           }`,
-          // some proxies do not require the token prefix.
           Authorization: `token ${this.token}`,
         },
       };

--- a/src/index.ts
+++ b/src/index.ts
@@ -12,25 +12,98 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import {OctokitAPIs} from './github';
+import {OctokitAPIs, GitHub} from './github';
+import {ReleaseType} from './releasers';
+import {ReleasePR} from './release-pr';
+import {ChangelogSection} from './conventional-commits';
 
-export {ReleaseCandidate, ReleasePR, ReleasePROptions} from './release-pr';
+export {ReleaseCandidate, ReleasePR} from './release-pr';
 
-// Configuration options shared by Release PRs and
-// GitHub releases:
-export interface SharedOptions {
-  label?: string;
-  repoUrl: string;
+// Used by GitHub: Factory and Constructor
+interface GitHubOptions {
+  defaultBranch?: string;
+  token?: string;
+  apiUrl?: string;
+  octokitAPIs?: OctokitAPIs;
+}
+
+// Used by GitHubRelease: Factory and Constructor
+interface GitHubReleaseOptions {
+  changelogPath?: string;
+  draft?: boolean;
+}
+
+// Used by ReleasePR: Factory and Constructor
+interface ReleasePROptions {
   path?: string;
   packageName?: string;
+  bumpMinorPreMajor?: boolean;
+  releaseAs?: string;
+  snapshot?: boolean;
   monorepoTags?: boolean;
-  token?: string;
-  apiUrl: string;
-  octokitAPIs?: OctokitAPIs;
+  fork?: boolean;
+  changelogSections?: ChangelogSection[];
+  // only for Ruby: TODO replace with generic bootstrap option
+  lastPackageVersion?: string;
+  // for Ruby: TODO refactor to find version.rb like Python finds version.py
+  // and then remove this property
+  versionFile?: string;
+}
+
+// GitHub Constructor options
+export interface GitHubConstructorOptions extends GitHubOptions {
+  owner: string;
+  repo: string;
+}
+
+// Used by GitHubRelease and ReleasePR Constructor
+interface ReleaserConstructorOptions {
+  github: GitHub;
+}
+
+// ReleasePR Constructor options
+export interface ReleasePRConstructorOptions
+  extends ReleasePROptions,
+    ReleaserConstructorOptions {
+  labels?: string[];
+}
+
+// GitHubRelease Constructor options
+export interface GitHubReleaseConstructorOptions
+  extends GitHubReleaseOptions,
+    ReleaserConstructorOptions {
+  releasePR: ReleasePR;
+}
+
+// Used by everyone, Factory only. Convenience to offer shorthand way of
+// specifying the repo and owner. Implementation parses the repoUrl and passes
+// the resulting {owner,repo} to the GitHub constructor
+interface FactoryOptions {
+  repoUrl: string;
+}
+
+// GitHub factory/builder options
+export interface GitHubFactoryOptions extends GitHubOptions, FactoryOptions {}
+
+// ReleasePR factory/builder options
+// `releaseType` is required for the ReleaserPR factory. Using a type alias
+// here because the `interface ... extends` syntax produces the following error:
+// "An interface can only extend an identifier/qualified-name with optional
+// type arguments."
+export type ReleasePRFactoryOptions = ReleasePROptions &
+  GitHubFactoryOptions & {releaseType: ReleaseType; label?: string};
+
+// GitHubRelease factory/builder options
+export interface GitHubReleaseFactoryOptions
+  extends GitHubReleaseOptions,
+    ReleasePROptions,
+    Omit<ReleasePRFactoryOptions, 'releaseType'>,
+    GitHubFactoryOptions {
+  releaseType?: ReleaseType;
 }
 
 export {factory} from './factory';
 export {getReleaserTypes, getReleasers} from './releasers';
-export {GitHubRelease, GitHubReleaseOptions} from './github-release';
+export {GitHubRelease} from './github-release';
 export {JavaYoshi} from './releasers/java-yoshi';
 export {Ruby} from './releasers/ruby';

--- a/src/releasers/index.ts
+++ b/src/releasers/index.ts
@@ -31,7 +31,6 @@ import {Helm} from './helm';
 // add any new releasers you create to this type as well as the `releasers`
 // object below.
 export type ReleaseType =
-  | 'base' // not exposed to end users
   | 'go'
   | 'go-yoshi'
   | 'java-bom'

--- a/src/releasers/java-bom.ts
+++ b/src/releasers/java-bom.ts
@@ -93,7 +93,8 @@ export class JavaBom extends ReleasePR {
     const prSHA = commits[0].sha;
     const cc = new ConventionalCommits({
       commits,
-      githubRepoUrl: this.repoUrl,
+      owner: this.gh.owner,
+      repository: this.gh.repo,
       bumpMinorPreMajor: this.bumpMinorPreMajor,
       changelogSections: CHANGELOG_SECTIONS,
     });
@@ -145,6 +146,7 @@ export class JavaBom extends ReleasePR {
 
     const updates: Update[] = [];
 
+    const packageName = await this.getPackageName();
     if (!this.snapshot) {
       updates.push(
         new Changelog({
@@ -152,7 +154,7 @@ export class JavaBom extends ReleasePR {
           changelogEntry,
           versions: candidateVersions,
           version: candidate.version,
-          packageName: this.packageName,
+          packageName: packageName.name,
         })
       );
 
@@ -162,7 +164,7 @@ export class JavaBom extends ReleasePR {
           changelogEntry,
           versions: candidateVersions,
           version: candidate.version,
-          packageName: this.packageName,
+          packageName: packageName.name,
         })
       );
     }
@@ -173,7 +175,7 @@ export class JavaBom extends ReleasePR {
         changelogEntry,
         versions: candidateVersions,
         version: candidate.version,
-        packageName: this.packageName,
+        packageName: packageName.name,
         contents: versionsManifestContent,
       })
     );
@@ -186,7 +188,7 @@ export class JavaBom extends ReleasePR {
           changelogEntry,
           versions: candidateVersions,
           version: candidate.version,
-          packageName: this.packageName,
+          packageName: packageName.name,
         })
       );
     });

--- a/src/releasers/java-yoshi.ts
+++ b/src/releasers/java-yoshi.ts
@@ -115,7 +115,8 @@ export class JavaYoshi extends ReleasePR {
 
     const cc = new ConventionalCommits({
       commits,
-      githubRepoUrl: this.repoUrl,
+      owner: this.gh.owner,
+      repository: this.gh.repo,
       bumpMinorPreMajor: this.bumpMinorPreMajor,
       changelogSections: CHANGELOG_SECTIONS,
     });
@@ -159,6 +160,7 @@ export class JavaYoshi extends ReleasePR {
 
     const updates: Update[] = [];
 
+    const packageName = await this.getPackageName();
     if (!this.snapshot) {
       updates.push(
         new Changelog({
@@ -166,7 +168,7 @@ export class JavaYoshi extends ReleasePR {
           changelogEntry,
           versions: candidateVersions,
           version: candidate.version,
-          packageName: this.packageName,
+          packageName: packageName.name,
         })
       );
 
@@ -176,7 +178,7 @@ export class JavaYoshi extends ReleasePR {
           changelogEntry,
           versions: candidateVersions,
           version: candidate.version,
-          packageName: this.packageName,
+          packageName: packageName.name,
         })
       );
 
@@ -188,7 +190,7 @@ export class JavaYoshi extends ReleasePR {
           changelogEntry,
           versions: candidateVersions,
           version: candidate.version,
-          packageName: this.packageName,
+          packageName: packageName.name,
           contents: versionsManifestContent,
         })
       );
@@ -200,7 +202,7 @@ export class JavaYoshi extends ReleasePR {
         changelogEntry,
         versions: candidateVersions,
         version: candidate.version,
-        packageName: this.packageName,
+        packageName: packageName.name,
         contents: versionsManifestContent,
       })
     );
@@ -219,7 +221,7 @@ export class JavaYoshi extends ReleasePR {
           changelogEntry,
           versions: candidateVersions,
           version: candidate.version,
-          packageName: this.packageName,
+          packageName: packageName.name,
         })
       );
     });
@@ -232,7 +234,7 @@ export class JavaYoshi extends ReleasePR {
           changelogEntry,
           versions: candidateVersions,
           version: candidate.version,
-          packageName: this.packageName,
+          packageName: packageName.name,
         })
       );
     });
@@ -245,7 +247,7 @@ export class JavaYoshi extends ReleasePR {
           changelogEntry,
           versions: candidateVersions,
           version: candidate.version,
-          packageName: this.packageName,
+          packageName: packageName.name,
         })
       );
     });
@@ -297,10 +299,11 @@ export class JavaYoshi extends ReleasePR {
     _version: string,
     includePackageName: boolean
   ): Promise<BranchName> {
-    const defaultBranch = await this.getDefaultBranch();
-    if (includePackageName && this.packageName) {
+    const defaultBranch = await this.gh.getDefaultBranch();
+    const packageName = await this.getPackageName();
+    if (includePackageName && packageName.getComponent()) {
       return BranchName.ofComponentTargetBranch(
-        this.packageName,
+        packageName.getComponent(),
         defaultBranch
       );
     }
@@ -312,9 +315,10 @@ export class JavaYoshi extends ReleasePR {
     version: string,
     includePackageName: boolean
   ): Promise<string> {
-    const defaultBranch = await this.getDefaultBranch();
+    const defaultBranch = await this.gh.getDefaultBranch();
+    const packageName = await this.getPackageName();
     return includePackageName
-      ? `chore(${defaultBranch}): release ${this.packageName} ${version}`
+      ? `chore(${defaultBranch}): release ${packageName.name} ${version}`
       : `chore(${defaultBranch}): release ${version}`;
   }
 

--- a/src/releasers/ocaml.ts
+++ b/src/releasers/ocaml.ts
@@ -43,8 +43,9 @@ const CHANGELOG_SECTIONS = [
 
 export class OCaml extends ReleasePR {
   protected async _run(): Promise<number | undefined> {
+    const packageName = await this.getPackageName();
     const latestTag: GitHubTag | undefined = await this.latestTag(
-      this.monorepoTags ? `${this.packageName}-` : undefined
+      this.monorepoTags ? `${packageName.getComponent()}-` : undefined
     );
     const commits: Commit[] = await this.commits({
       sha: latestTag ? latestTag.sha : undefined,
@@ -53,7 +54,8 @@ export class OCaml extends ReleasePR {
 
     const cc = new ConventionalCommits({
       commits,
-      githubRepoUrl: this.repoUrl,
+      owner: this.gh.owner,
+      repository: this.gh.repo,
       bumpMinorPreMajor: this.bumpMinorPreMajor,
       // TODO: Is this configurable?
       changelogSections: CHANGELOG_SECTIONS,
@@ -96,7 +98,7 @@ export class OCaml extends ReleasePR {
               path: this.addPath(path),
               changelogEntry,
               version: candidate.version,
-              packageName: this.packageName,
+              packageName: packageName.name,
               contents,
             })
           );
@@ -111,7 +113,7 @@ export class OCaml extends ReleasePR {
           path: this.addPath(path),
           changelogEntry,
           version: candidate.version,
-          packageName: this.packageName,
+          packageName: packageName.name,
         })
       );
     });
@@ -121,7 +123,7 @@ export class OCaml extends ReleasePR {
         path: this.addPath('CHANGELOG.md'),
         changelogEntry,
         version: candidate.version,
-        packageName: this.packageName,
+        packageName: packageName.name,
       })
     );
 

--- a/src/releasers/php-yoshi.ts
+++ b/src/releasers/php-yoshi.ts
@@ -60,7 +60,8 @@ export class PHPYoshi extends ReleasePR {
     // top-level tag version we maintain on the mono-repo itself.
     const ccb = new ConventionalCommits({
       commits,
-      githubRepoUrl: this.repoUrl,
+      owner: this.gh.owner,
+      repository: this.gh.repo,
       bumpMinorPreMajor: true,
       changelogSections: CHANGELOG_SECTIONS,
     });
@@ -82,6 +83,7 @@ export class PHPYoshi extends ReleasePR {
     );
     changelogEntry = bulkUpdate.changelogEntry;
 
+    const packageName = await this.getPackageName();
     // update the aggregate package information in the root
     // composer.json and manifest.json.
     updates.push(
@@ -90,7 +92,7 @@ export class PHPYoshi extends ReleasePR {
         changelogEntry,
         version: candidate.version,
         versions: bulkUpdate.versionUpdates,
-        packageName: this.packageName,
+        packageName: packageName.name,
       })
     );
 
@@ -100,7 +102,7 @@ export class PHPYoshi extends ReleasePR {
         changelogEntry,
         version: candidate.version,
         versions: bulkUpdate.versionUpdates,
-        packageName: this.packageName,
+        packageName: packageName.name,
       })
     );
 
@@ -109,7 +111,7 @@ export class PHPYoshi extends ReleasePR {
         path: 'CHANGELOG.md',
         changelogEntry,
         version: candidate.version,
-        packageName: this.packageName,
+        packageName: packageName.name,
       })
     );
 
@@ -119,7 +121,7 @@ export class PHPYoshi extends ReleasePR {
           path,
           changelogEntry,
           version: candidate.version,
-          packageName: this.packageName,
+          packageName: packageName.name,
         })
       );
     });
@@ -151,7 +153,8 @@ export class PHPYoshi extends ReleasePR {
       const pkgKey: string = pkgKeys[i];
       const cc = new ConventionalCommits({
         commits: commitLookup[pkgKey],
-        githubRepoUrl: this.repoUrl,
+        owner: this.gh.owner,
+        repository: this.gh.repo,
         bumpMinorPreMajor: this.bumpMinorPreMajor,
         changelogSections: CHANGELOG_SECTIONS,
       });
@@ -192,12 +195,13 @@ export class PHPYoshi extends ReleasePR {
             await cc.generateChangelogEntry({version: candidate})
           );
 
+          const packageName = await this.getPackageName();
           updates.push(
             new Version({
               path: `${pkgKey}/VERSION`,
               changelogEntry,
               version: candidate,
-              packageName: this.packageName,
+              packageName: packageName.name,
               contents,
             })
           );
@@ -214,7 +218,7 @@ export class PHPYoshi extends ReleasePR {
                 path: `${pkgKey}/${meta.extra.component.entry}`,
                 changelogEntry,
                 version: candidate,
-                packageName: this.packageName,
+                packageName: packageName.name,
               })
             );
           }

--- a/src/releasers/rust.ts
+++ b/src/releasers/rust.ts
@@ -45,7 +45,8 @@ export class Rust extends ReleasePR {
 
     const cc = new ConventionalCommits({
       commits,
-      githubRepoUrl: this.repoUrl,
+      owner: this.gh.owner,
+      repository: this.gh.repo,
       bumpMinorPreMajor: this.bumpMinorPreMajor,
       changelogSections: this.changelogSections,
     });

--- a/src/releasers/simple.ts
+++ b/src/releasers/simple.ts
@@ -27,8 +27,9 @@ import {VersionTxt} from '../updaters/version-txt';
 
 export class Simple extends ReleasePR {
   protected async _run(): Promise<number | undefined> {
+    const packageName = await this.getPackageName();
     const latestTag: GitHubTag | undefined = await this.latestTag(
-      this.monorepoTags ? `${this.packageName}-` : undefined
+      this.monorepoTags ? `${packageName.getComponent()}-` : undefined
     );
     const commits: Commit[] = await this.commits({
       sha: latestTag ? latestTag.sha : undefined,
@@ -37,7 +38,8 @@ export class Simple extends ReleasePR {
 
     const cc = new ConventionalCommits({
       commits,
-      githubRepoUrl: this.repoUrl,
+      owner: this.gh.owner,
+      repository: this.gh.repo,
       bumpMinorPreMajor: this.bumpMinorPreMajor,
       changelogSections: this.changelogSections,
     });
@@ -72,7 +74,7 @@ export class Simple extends ReleasePR {
         path: 'CHANGELOG.md',
         changelogEntry,
         version: candidate.version,
-        packageName: this.packageName,
+        packageName: packageName.name,
       })
     );
 
@@ -81,7 +83,7 @@ export class Simple extends ReleasePR {
         path: 'version.txt',
         changelogEntry,
         version: candidate.version,
-        packageName: this.packageName,
+        packageName: packageName.name,
       })
     );
 

--- a/src/releasers/terraform-module.ts
+++ b/src/releasers/terraform-module.ts
@@ -28,8 +28,9 @@ import {ModuleVersion} from '../updaters/terraform/module-version';
 
 export class TerraformModule extends ReleasePR {
   protected async _run(): Promise<number | undefined> {
+    const packageName = await this.getPackageName();
     const latestTag: GitHubTag | undefined = await this.latestTag(
-      this.monorepoTags ? `${this.packageName}-` : undefined
+      this.monorepoTags ? `${packageName.getComponent()}-` : undefined
     );
     const commits: Commit[] = await this.commits({
       sha: latestTag ? latestTag.sha : undefined,
@@ -38,7 +39,8 @@ export class TerraformModule extends ReleasePR {
 
     const cc = new ConventionalCommits({
       commits,
-      githubRepoUrl: this.repoUrl,
+      owner: this.gh.owner,
+      repository: this.gh.repo,
       bumpMinorPreMajor: this.bumpMinorPreMajor,
       changelogSections: this.changelogSections,
     });
@@ -73,7 +75,7 @@ export class TerraformModule extends ReleasePR {
         path: this.addPath('CHANGELOG.md'),
         changelogEntry,
         version: candidate.version,
-        packageName: this.packageName,
+        packageName: packageName.name,
       })
     );
 
@@ -86,7 +88,7 @@ export class TerraformModule extends ReleasePR {
           path: this.addPath(path),
           changelogEntry,
           version: candidate.version,
-          packageName: this.packageName,
+          packageName: packageName.name,
         })
       );
     });
@@ -100,7 +102,7 @@ export class TerraformModule extends ReleasePR {
           path: this.addPath(path),
           changelogEntry,
           version: candidate.version,
-          packageName: this.packageName,
+          packageName: packageName.name,
         })
       );
     });

--- a/test/conventional-commits.ts
+++ b/test/conventional-commits.ts
@@ -36,7 +36,8 @@ describe('ConventionalCommits', () => {
           },
           {message: 'feat: awesome feature', sha: 'abc678', files: []},
         ],
-        githubRepoUrl: 'https://github.com/bcoe/release-please.git',
+        owner: 'bcoe',
+        repository: 'release-please',
         bumpMinorPreMajor: true,
       });
       const bump = await cc.suggestBump('0.3.0');
@@ -57,7 +58,8 @@ describe('ConventionalCommits', () => {
           },
           {message: 'feat: awesome feature', sha: 'abc678', files: []},
         ],
-        githubRepoUrl: 'https://github.com/bcoe/release-please.git',
+        owner: 'bcoe',
+        repository: 'release-please',
         bumpMinorPreMajor: true,
       });
       const cl = await cc.generateChangelogEntry({
@@ -77,7 +79,8 @@ describe('ConventionalCommits', () => {
           },
           {message: 'feat: awesome feature', sha: 'abc678', files: []},
         ],
-        githubRepoUrl: 'https://github.com/bcoe/release-please.git',
+        owner: 'bcoe',
+        repository: 'release-please',
         bumpMinorPreMajor: true,
       });
       const cl = await cc.generateChangelogEntry({
@@ -97,7 +100,8 @@ describe('ConventionalCommits', () => {
           },
           {message: 'feat: awesome feature', sha: 'abc678', files: []},
         ],
-        githubRepoUrl: 'https://github.com/bcoe/release-please.git',
+        owner: 'bcoe',
+        repository: 'release-please',
         bumpMinorPreMajor: true,
       });
       const cl = await cc.generateChangelogEntry({
@@ -118,7 +122,8 @@ describe('ConventionalCommits', () => {
           },
           {message: 'feat: awesome feature', sha: 'abc678', files: []},
         ],
-        githubRepoUrl: 'https://github.com/bcoe/release-please.git',
+        owner: 'bcoe',
+        repository: 'release-please',
         bumpMinorPreMajor: true,
       });
       const cl = await cc.generateChangelogEntry({
@@ -138,7 +143,8 @@ describe('ConventionalCommits', () => {
           },
           {message: 'feat: awesome feature', sha: 'abc678', files: []},
         ],
-        githubRepoUrl: 'https://github.com/bcoe/release-please.git',
+        owner: 'bcoe',
+        repository: 'release-please',
         bumpMinorPreMajor: true,
       });
       const cl = await cc.generateChangelogEntry({
@@ -168,7 +174,8 @@ fix(securitycenter): fixes security center.
           },
           {message: 'feat: awesome feature', sha: 'abc678', files: []},
         ],
-        githubRepoUrl: 'https://github.com/bcoe/release-please.git',
+        owner: 'bcoe',
+        repository: 'release-please',
         bumpMinorPreMajor: true,
       });
       const cl = await cc.generateChangelogEntry({
@@ -202,7 +209,8 @@ fix(securitycenter): fixes security center.
             files: [],
           },
         ],
-        githubRepoUrl: 'https://github.com/bcoe/release-please.git',
+        owner: 'bcoe',
+        repository: 'release-please',
         bumpMinorPreMajor: true,
       });
       const cl = await cc.generateChangelogEntry({

--- a/test/factory.ts
+++ b/test/factory.ts
@@ -17,6 +17,8 @@ import * as assert from 'assert';
 import {factory} from '../src/factory';
 import * as sinon from 'sinon';
 import {expect} from 'chai';
+import {RequestHeaders} from '@octokit/types';
+import {Ruby} from '../src';
 
 const sandbox = sinon.createSandbox();
 
@@ -25,16 +27,65 @@ describe('factory', () => {
     sandbox.restore();
   });
 
-  describe('releasePR', () => {
-    it('returns instance of dynamically loaded releaser', () => {
-      const releasePR = factory.releasePR({
-        repoUrl: 'googleapis/simple-test-repo',
-        packageName: 'simple-test-repo',
-        apiUrl: 'https://api.github.com',
-        releaseType: 'simple',
+  describe('gitHubInstance', () => {
+    const owner = 'google';
+    const repo = 'cloud';
+    const repoUrls = [
+      `${owner}/${repo}`,
+      `https://github.com/${owner}/${repo}.git`,
+      `git@github.com:${owner}/${repo}`,
+    ];
+    for (const repoUrl of repoUrls) {
+      it(`parses github repo url: ${repoUrl}`, () => {
+        const gh = factory.gitHubInstance({repoUrl});
+        expect(gh.owner).to.equal(owner);
+        expect(gh.repo).to.equal(repo);
       });
-      expect(releasePR.constructor.name).to.eql('Simple');
-      expect(releasePR.packageName).to.eql('simple-test-repo');
+    }
+
+    const repoUrl = repoUrls[0];
+    it('prefers configured defaultBranch', async () => {
+      const gh = factory.gitHubInstance({repoUrl, defaultBranch: '1.x'});
+      const branch = await gh.getDefaultBranch();
+      expect(branch).to.equal('1.x');
+    });
+    it('falls back to github defaultBranch', async () => {
+      const gh = factory.gitHubInstance({repoUrl});
+      const stub = sandbox.stub(gh.octokit.repos, 'get');
+      stub
+        .withArgs({
+          repo,
+          owner,
+          headers: (sinon.match.any as unknown) as RequestHeaders,
+        })
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        .resolves({data: {default_branch: 'main'}} as any);
+      stub.throwsArg(0);
+      const branch = await gh.getDefaultBranch();
+      expect(branch).to.equal('main');
+    });
+  });
+  describe('releasePR', () => {
+    it('returns instance of dynamically loaded releaser', async () => {
+      const releasePR = factory.releasePR({
+        repoUrl: 'googleapis/ruby-test-repo',
+        packageName: 'ruby-test-repo',
+        releaseType: 'ruby',
+      });
+      expect(releasePR.constructor.name).to.equal('Ruby');
+      expect(releasePR.labels).to.eql(['autorelease: pending']);
+      expect(releasePR.bumpMinorPreMajor).to.be.false;
+      expect(releasePR.fork).to.be.false;
+      expect(releasePR.path).to.be.undefined;
+      expect(releasePR.monorepoTags).to.be.false;
+      expect(releasePR.releaseAs).to.be.undefined;
+      expect(releasePR.snapshot).to.be.undefined;
+      expect(releasePR.lastPackageVersion).to.be.undefined;
+      expect(releasePR.changelogSections).to.be.undefined;
+      expect((releasePR as Ruby).versionFile).to.equal('');
+      const packageName = await releasePR.getPackageName();
+      expect(packageName.name).to.equal('ruby-test-repo');
+      expect(packageName.getComponent()).to.equal('ruby-test-repo');
     });
     it('throws an error on invalid release type', () => {
       let caught = false;
@@ -43,7 +94,7 @@ describe('factory', () => {
           repoUrl: 'googleapis/simple-test-repo',
           packageName: 'simple-test-repo',
           apiUrl: 'https://api.github.com',
-          releaseType: 'base',
+          releaseType: 'unknown' as 'go', //hack the typing
         });
         assert.fail();
       } catch (e) {
@@ -62,7 +113,7 @@ describe('factory', () => {
     it('throws and error on invalid release type', () => {
       let caught = false;
       try {
-        factory.releasePRClass('base');
+        factory.releasePRClass('unknown' as 'go'); // hack the typing
         assert.fail();
       } catch (e) {
         caught = true;
@@ -80,7 +131,7 @@ describe('factory', () => {
         releaseType: 'simple',
       });
       expect(githubRelease.constructor.name).to.eql('GitHubRelease');
-      expect(githubRelease.releaseType).to.eql('simple');
+      expect(githubRelease.releasePR.constructor.name).to.eql('Simple');
     });
 
     it('allows releaseType to be empty', () => {
@@ -90,7 +141,48 @@ describe('factory', () => {
         apiUrl: 'https://api.github.com',
       });
       expect(githubRelease.constructor.name).to.eql('GitHubRelease');
-      expect(githubRelease.releaseType).to.be.undefined;
+      expect(githubRelease.releasePR.constructor.name).to.eql('ReleasePR');
+    });
+
+    it('returns a GitHubRelease with all the things', () => {
+      const ghr = factory.githubRelease({
+        repoUrl: 'googleapis/simple-test-repo',
+        defaultBranch: '1.x',
+        token: 'some-token',
+        apiUrl: 'https://some.api.com',
+        releaseType: 'ruby',
+        label: 'foo,bar',
+        path: 'some/path',
+        packageName: 'simple-test-repo',
+        bumpMinorPreMajor: true,
+        releaseAs: '1.2.3',
+        snapshot: true,
+        monorepoTags: true,
+        fork: true,
+        changelogSections: [{type: 'feat', section: 'Features'}],
+        lastPackageVersion: '0.0.1',
+        versionFile: 'some/ruby/version.rb',
+      });
+      expect(ghr.constructor.name).to.equal('GitHubRelease');
+      expect(ghr.gh.owner).to.equal('googleapis');
+      expect(ghr.gh.repo).to.equal('simple-test-repo');
+      expect(ghr.gh.token).to.equal('some-token');
+      expect(ghr.gh.apiUrl).to.equal('https://some.api.com');
+      expect(ghr.releasePR.constructor.name).to.equal('Ruby');
+      expect(ghr.releasePR.labels).to.eql(['foo', 'bar']);
+      expect(ghr.releasePR.path).to.equal('some/path');
+      expect(ghr.releasePR.path).to.equal('some/path');
+      expect(ghr.releasePR.releaseAs).to.equal('1.2.3');
+      expect(ghr.releasePR.bumpMinorPreMajor).to.be.true;
+      expect(ghr.releasePR.monorepoTags).to.be.true;
+      expect(ghr.releasePR.fork).to.be.true;
+      expect(ghr.releasePR.changelogSections).to.eql([
+        {type: 'feat', section: 'Features'},
+      ]);
+      expect(ghr.releasePR.lastPackageVersion).to.equal('0.0.1');
+      expect((ghr.releasePR as Ruby).versionFile).to.equal(
+        'some/ruby/version.rb'
+      );
     });
   });
   describe('run', () => {

--- a/test/releasers/java-bom.ts
+++ b/test/releasers/java-bom.ts
@@ -19,7 +19,7 @@ import {JavaBom} from '../../src/releasers/java-bom';
 import * as snapshot from 'snap-shot-it';
 import * as suggester from 'code-suggester';
 import * as sinon from 'sinon';
-import {GitHubFileContents} from '../../src/github';
+import {GitHubFileContents, GitHub} from '../../src/github';
 import {buildGitHubFileContent} from './utils';
 import {buildMockCommit} from '../helpers';
 
@@ -36,11 +36,8 @@ describe('JavaBom', () => {
   describe('run', () => {
     it('creates a release PR', async () => {
       const releasePR = new JavaBom({
-        repoUrl: 'googleapis/java-cloud-bom',
-        releaseType: 'java-bom',
-        // not actually used by this type of repo.
+        github: new GitHub({owner: 'googleapis', repo: 'java-cloud-bom'}),
         packageName: 'java-cloud-bom',
-        apiUrl: 'https://api.github.com',
       });
 
       sandbox
@@ -131,11 +128,8 @@ describe('JavaBom', () => {
 
     it('creates a snapshot PR', async () => {
       const releasePR = new JavaBom({
-        repoUrl: 'googleapis/java-cloud-bom',
-        releaseType: 'java-bom',
-        // not actually used by this type of repo.
+        github: new GitHub({owner: 'googleapis', repo: 'java-cloud-bom'}),
         packageName: 'java-cloud-bom',
-        apiUrl: 'https://api.github.com',
         snapshot: true,
       });
 
@@ -227,11 +221,8 @@ describe('JavaBom', () => {
 
     it('ignores a snapshot release if no snapshot needed', async () => {
       const releasePR = new JavaBom({
-        repoUrl: 'googleapis/java-cloud-bom',
-        releaseType: 'java-bom',
-        // not actually used by this type of repo.
+        github: new GitHub({owner: 'googleapis', repo: 'java-cloud-bom'}),
         packageName: 'java-cloud-bom',
-        apiUrl: 'https://api.github.com',
         snapshot: true,
       });
 
@@ -264,11 +255,8 @@ describe('JavaBom', () => {
 
     it('creates a snapshot PR if an explicit release is requested, but a snapshot is needed', async () => {
       const releasePR = new JavaBom({
-        repoUrl: 'googleapis/java-cloud-bom',
-        releaseType: 'java-bom',
-        // not actually used by this type of repo.
+        github: new GitHub({owner: 'googleapis', repo: 'java-cloud-bom'}),
         packageName: 'java-cloud-bom',
-        apiUrl: 'https://api.github.com',
         snapshot: false,
       });
       sandbox
@@ -359,11 +347,8 @@ describe('JavaBom', () => {
 
     it('merges conventional commit messages', async () => {
       const releasePR = new JavaBom({
-        repoUrl: 'googleapis/java-cloud-bom',
-        releaseType: 'java-bom',
-        // not actually used by this type of repo.
+        github: new GitHub({owner: 'googleapis', repo: 'java-cloud-bom'}),
         packageName: 'java-cloud-bom',
-        apiUrl: 'https://api.github.com',
       });
 
       sandbox

--- a/test/releasers/ocaml.ts
+++ b/test/releasers/ocaml.ts
@@ -22,6 +22,7 @@ import * as sinon from 'sinon';
 import {readPOJO, stringifyExpectedChanges} from '../helpers';
 import {readFileSync} from 'fs';
 import {resolve} from 'path';
+import {GitHub} from '../../src/github';
 
 nock.disableNetConnect();
 const sandbox = sinon.createSandbox();
@@ -48,10 +49,8 @@ describe('OCaml', () => {
 
       it(`creates a release PR for non-monorepo (${suiteName})`, async () => {
         const releasePR = new OCaml({
-          repoUrl: 'phated/ocaml-sample-repo',
-          releaseType: 'ocaml',
+          github: new GitHub({owner: 'phated', repo: 'ocaml-sample-repo'}),
           packageName: 'sample',
-          apiUrl: 'https://api.github.com',
         });
 
         // Indicates that there are no PRs currently waiting to be released:
@@ -158,10 +157,8 @@ describe('OCaml', () => {
 
     it('skips JSON files that don\'t contain a "version" field', async () => {
       const releasePR = new OCaml({
-        repoUrl: 'phated/ocaml-sample-repo',
-        releaseType: 'ocaml',
+        github: new GitHub({owner: 'phated', repo: 'ocaml-sample-repo'}),
         packageName: 'sample',
-        apiUrl: 'https://api.github.com',
       });
 
       // Indicates that there are no PRs currently waiting to be released:
@@ -252,10 +249,8 @@ describe('OCaml', () => {
 
     it('does not support snapshot releases', async () => {
       const releasePR = new OCaml({
-        repoUrl: 'phated/ocaml-sample-repo',
-        releaseType: 'ocaml',
+        github: new GitHub({owner: 'phated', repo: 'ocaml-sample-repo'}),
         packageName: 'sample',
-        apiUrl: 'https://api.github.com',
         snapshot: true,
       });
       const pr = await releasePR.run();

--- a/test/releasers/php-yoshi.ts
+++ b/test/releasers/php-yoshi.ts
@@ -24,6 +24,7 @@ import {expect} from 'chai';
 import {buildGitHubFileRaw} from './utils';
 import {readFileSync} from 'fs';
 import {resolve} from 'path';
+import {GitHub} from '../../src/github';
 
 const sandbox = sinon.createSandbox();
 
@@ -36,12 +37,8 @@ describe('PHPYoshi', () => {
 
   it('generates CHANGELOG and aborts if duplicate', async () => {
     const releasePR = new PHPYoshi({
-      repoUrl: 'googleapis/release-please',
-      label: 'autorelease: pending',
-      releaseType: 'php-yoshi',
-      // not actually used by this type of repo.
+      github: new GitHub({owner: 'googleapis', repo: 'release-please'}),
       packageName: 'yoshi-php',
-      apiUrl: 'https://api.github.com',
     });
 
     sandbox

--- a/test/releasers/python.ts
+++ b/test/releasers/python.ts
@@ -71,10 +71,8 @@ describe('Python', () => {
     it('returns release PR changes with defaultInitialVersion', async () => {
       const expectedVersion = '0.1.0';
       const releasePR = new Python({
-        repoUrl: 'googleapis/py-test-repo',
-        releaseType: 'python',
+        github: new GitHub({owner: 'googleapis', repo: 'py-test-repo'}),
         packageName: pkgName,
-        apiUrl: 'https://api.github.com',
       });
       stubGithub(releasePR, ['src/version.py']);
 
@@ -131,10 +129,8 @@ describe('Python', () => {
     it('returns release PR changes with semver patch bump', async () => {
       const expectedVersion = '0.123.5';
       const releasePR = new Python({
-        repoUrl: 'googleapis/py-test-repo',
-        releaseType: 'python',
+        github: new GitHub({owner: 'googleapis', repo: 'py-test-repo'}),
         packageName: pkgName,
-        apiUrl: 'https://api.github.com',
       });
       stubGithub(releasePR, ['src/version.py']);
 
@@ -192,10 +188,8 @@ describe('Python', () => {
     });
     it('returns undefined for no CC changes', async () => {
       const releasePR = new Python({
-        repoUrl: 'googleapis/py-test-repo',
-        releaseType: 'python',
+        github: new GitHub({owner: 'googleapis', repo: 'py-test-repo'}),
         packageName: pkgName,
-        apiUrl: 'https://api.github.com',
       });
       stubGithub(releasePR);
       const openPROptions = await releasePR.getOpenPROptions(
@@ -212,10 +206,8 @@ describe('Python', () => {
     // just testing the releaser does try to update all 3.
     it('creates a release PR', async () => {
       const releasePR = new Python({
-        repoUrl: 'googleapis/py-test-repo',
-        releaseType: 'python',
+        github: new GitHub({owner: 'googleapis', repo: 'py-test-repo'}),
         packageName: pkgName,
-        apiUrl: 'https://api.github.com',
       });
 
       // We stub the entire suggester API, asserting only that the
@@ -247,10 +239,8 @@ describe('Python', () => {
 
     it('creates a release PR relative to a path', async () => {
       const releasePR = new Python({
-        repoUrl: 'googleapis/py-test-repo',
-        releaseType: 'python',
+        github: new GitHub({owner: 'googleapis', repo: 'py-test-repo'}),
         packageName: pkgName,
-        apiUrl: 'https://api.github.com',
         path: 'projects/python',
       });
 

--- a/test/releasers/rust.ts
+++ b/test/releasers/rust.ts
@@ -22,6 +22,7 @@ import * as sinon from 'sinon';
 import {readPOJO, stringifyExpectedChanges} from '../helpers';
 import {readFileSync} from 'fs';
 import {resolve} from 'path';
+import {GitHub} from '../../src/github';
 
 nock.disableNetConnect();
 const sandbox = sinon.createSandbox();
@@ -37,10 +38,8 @@ describe('Rust', () => {
 
       it(`creates a release PR for non-monorepo ${suffix}`, async () => {
         const releasePR = new Rust({
-          repoUrl: 'fasterthanlime/rust-test-repo',
-          releaseType: 'rust',
+          github: new GitHub({owner: 'fasterthanlime', repo: 'rust-test-repo'}),
           packageName: 'crate1',
-          apiUrl: 'https://api.github.com',
         });
 
         // Indicates that there are no PRs currently waiting to be released:
@@ -136,10 +135,8 @@ describe('Rust', () => {
 
       it(`creates a release PR for monorepo ${suffix}`, async () => {
         const releasePR = new Rust({
-          repoUrl: 'fasterthanlime/rust-test-repo',
-          releaseType: 'rust',
+          github: new GitHub({owner: 'fasterthanlime', repo: 'rust-test-repo'}),
           packageName: 'crate1',
-          apiUrl: 'https://api.github.com',
           path: 'crates/crate1',
           monorepoTags: true,
         });
@@ -272,10 +269,8 @@ describe('Rust', () => {
 
     it('does not support snapshot releases', async () => {
       const releasePR = new Rust({
-        repoUrl: 'fasterthanlime/rust-test-repo',
-        releaseType: 'rust',
+        github: new GitHub({owner: 'fasterthanlime', repo: 'rust-test-repo'}),
         packageName: 'crate1',
-        apiUrl: 'https://api.github.com',
         snapshot: true,
       });
       const pr = await releasePR.run();

--- a/test/releasers/simple.ts
+++ b/test/releasers/simple.ts
@@ -21,6 +21,7 @@ import * as nock from 'nock';
 import * as snapshot from 'snap-shot-it';
 import * as suggester from 'code-suggester';
 import * as sinon from 'sinon';
+import {GitHub} from '../../src/github';
 
 nock.disableNetConnect();
 const sandbox = sinon.createSandbox();
@@ -33,11 +34,8 @@ describe('Simple', () => {
   describe('run', () => {
     it('creates a release PR', async () => {
       const releasePR = new Simple({
-        repoUrl: 'googleapis/simple-test-repo',
-        releaseType: 'simple',
-        // not actually used by this type of repo.
+        github: new GitHub({owner: 'googleapis', repo: 'simple-test-repo'}),
         packageName: 'simple-test-repo',
-        apiUrl: 'https://api.github.com',
       });
 
       // Indicates that there are no PRs currently waiting to be released:

--- a/test/releasers/terraform-module.ts
+++ b/test/releasers/terraform-module.ts
@@ -21,16 +21,13 @@ import * as nock from 'nock';
 import * as snapshot from 'snap-shot-it';
 import * as suggester from 'code-suggester';
 import * as sinon from 'sinon';
+import {GitHub} from '../../src/github';
 
 nock.disableNetConnect();
 const sandbox = sinon.createSandbox();
 const fixturesPath = './test/releasers/fixtures/terraform';
 const releasePR = new TerraformModule({
-  repoUrl: 'googleapis/terraform-test-repo',
-  releaseType: 'terraform-module',
-  // not actually used by this type of repo.
-  packageName: 'terraform-test-repo',
-  apiUrl: 'https://api.github.com',
+  github: new GitHub({owner: 'googleapis', repo: 'terraform-test-repo'}),
 });
 
 describe('terraform-module', () => {

--- a/test/releasers/yoshi-go.ts
+++ b/test/releasers/yoshi-go.ts
@@ -22,6 +22,7 @@ import * as suggester from 'code-suggester';
 import * as sinon from 'sinon';
 import {expect} from 'chai';
 import {buildMockCommit} from '../helpers';
+import {GitHub} from '../../src/github';
 
 const sandbox = sinon.createSandbox();
 
@@ -35,11 +36,8 @@ describe('YoshiGo', () => {
     });
     it('creates a release PR for google-cloud-go', async () => {
       const releasePR = new GoYoshi({
-        repoUrl: 'googleapis/google-cloud-go',
-        releaseType: 'go-yoshi',
-        // not actually used by this type of repo.
+        github: new GitHub({owner: 'googleapis', repo: 'google-cloud-go'}),
         packageName: 'yoshi-go',
-        apiUrl: 'https://api.github.com',
       });
 
       // We stub the entire suggester API, asserting only that the
@@ -110,11 +108,8 @@ describe('YoshiGo', () => {
     });
     it('creates a release PR for google-api-go-client', async () => {
       const releasePR = new GoYoshi({
-        repoUrl: 'googleapis/google-api-go-client',
-        releaseType: 'go-yoshi',
-        // not actually used by this type of repo.
+        github: new GitHub({owner: 'googleapis', repo: 'google-api-go-client'}),
         packageName: 'yoshi-go',
-        apiUrl: 'https://api.github.com',
       });
 
       // We stub the entire suggester API, asserting only that the
@@ -196,12 +191,10 @@ describe('YoshiGo', () => {
   });
   it('supports releasing submodule from google-cloud-go', async () => {
     const releasePR = new GoYoshi({
-      repoUrl: 'googleapis/google-cloud-go',
-      releaseType: 'go-yoshi',
+      github: new GitHub({owner: 'googleapis', repo: 'google-cloud-go'}),
       packageName: 'pubsublite',
       monorepoTags: true,
       path: 'pubsublite',
-      apiUrl: 'https://api.github.com',
     });
 
     // We stub the entire suggester API, asserting only that the


### PR DESCRIPTION
This is a first take at normalizing the configuration options used to
construct GitHub, ReleasePR, and GitHubRelease instances as well as
higher level configuration used by the factory entrypoints to build
them. The principal motivation is to bring the code more inline with
IoC/DI patterns (https://stackoverflow.com/a/3140/13802304)

refactor!: interfaces for constructor options moved to src/index.ts
and signficantly reorganized
refactor!: GitHub constructor: GitHubConstructorOptions
refactor!: GitHubRelease constructor: GitHubReleaseConstructorOptions
refactor!: ReleasePR constructor: ReleasePRConstructorOptions
refactor!: ReleasePR package name handling refactored -
lookupPackageName removed in favor of getPackageName
refactor!: ConventionalCommits constructor takes owner and repo instead
of just repoUrl
refactor!: remove GitHubRelease.labels in favor of ReleasePR.labels