### PR TITLE
fix: find first associate pull request

### DIFF
--- a/src/github.ts
+++ b/src/github.ts
@@ -560,7 +560,7 @@ export class GitHub {
               ... on Commit {
                 history(first: $num, after: $cursor) {
                   nodes {
-                    associatedPullRequests(last: 1) {
+                    associatedPullRequests(first: 1) {
                       nodes {
                         number
                         title


### PR DESCRIPTION
For some reason, a commit can have multiple associated pull requests. We actually want the first result, not the last and this appears to correctly be the associated pull request that we want.

Fixes #756 