### PR TITLE
feat: add latest-tag command which will print out the detected latest tag

### DIFF
--- a/src/bin/release-please.ts
+++ b/src/bin/release-please.ts
@@ -99,6 +99,29 @@ export const parser = yargs
       factory.runCommand('github-release', argv).catch(handleError);
     }
   )
+  .command(
+    'latest-tag',
+    'find the sha of the latest release',
+    (yargs: YargsOptionsBuilder) => {
+      yargs
+        .option('version-file', {
+          describe: 'path to version file to update, e.g., version.rb',
+        })
+        .option('default-branch', {
+          describe: 'default branch to open release PR against',
+          type: 'string',
+        });
+    },
+    (argv: ReleasePROptions) => {
+      const releasePR = factory.releasePR(argv);
+      releasePR
+        .latestTag()
+        .catch(handleError)
+        .then(latestTag => {
+          console.log(latestTag);
+        });
+    }
+  )
   .middleware(_argv => {
     const argv = _argv as GitHubReleaseOptions;
     // allow secrets to be loaded from file path


### PR DESCRIPTION
Not sure if this is something we want to do broadly (add debug helpers). I wrote this for testing the latestTag functionality against real repositories.