### PR TITLE
refactor!: rename factory.run -> call

### DIFF
--- a/.mocharc.js
+++ b/.mocharc.js
@@ -12,11 +12,11 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 const config = {
-  "enable-source-maps": true,
-  "throw-deprecation": true,
-  "timeout": 10000,
-  "recursive": true
-}
+  'enable-source-maps': true,
+  'throw-deprecation': true,
+  timeout: 10000,
+  recursive: true,
+};
 if (process.env.MOCHA_THROW_DEPRECATION === 'false') {
   delete config['throw-deprecation'];
 }
@@ -26,4 +26,9 @@ if (process.env.MOCHA_REPORTER) {
 if (process.env.MOCHA_REPORTER_OUTPUT) {
   config['reporter-option'] = `output=${process.env.MOCHA_REPORTER_OUTPUT}`;
 }
-module.exports = config
+process.on('unhandledRejection', err => {
+  console.error(err);
+  process.exit(1);
+});
+
+module.exports = config;

--- a/src/bin/release-please.ts
+++ b/src/bin/release-please.ts
@@ -75,7 +75,12 @@ export const parser = yargs
         .runCommand('latest-tag', argv)
         .catch(handleError)
         .then(latestTag => {
-          if (latestTag) console.log(latestTag);
+          if (latestTag) {
+            console.log(latestTag);
+          } else {
+            console.log('No latest tag found.');
+            process.exitCode = 1;
+          }
         });
     }
   )
@@ -191,8 +196,10 @@ interface HandleError {
 // the request object, don't do this in CI/CD).
 export const handleError: HandleError = (err: ErrorObject) => {
   let status = '';
-  if (!handleError.yargsArgs) {
-    return;
+  if (handleError.yargsArgs === undefined) {
+    throw new Error(
+      'Set handleError.yargsArgs with a yargs.Arguments instance.'
+    );
   }
   if (!handleError.logger) {
     handleError.logger = console;

--- a/src/bin/release-please.ts
+++ b/src/bin/release-please.ts
@@ -228,12 +228,11 @@ let argv: yargs.Arguments;
 if (require.main === module) {
   argv = parser.parse();
   handleError.yargsArgs = argv;
+  process.on('unhandledRejection', err => {
+    handleError(err as ErrorObject);
+  });
+
+  process.on('uncaughtException', err => {
+    handleError(err as ErrorObject);
+  });
 }
-
-process.on('unhandledRejection', err => {
-  handleError(err as ErrorObject);
-});
-
-process.on('uncaughtException', err => {
-  handleError(err as ErrorObject);
-});

--- a/src/bin/release-please.ts
+++ b/src/bin/release-please.ts
@@ -71,12 +71,11 @@ export const parser = yargs
       releaseType(yargs, 'node');
     },
     (argv: ReleasePRFactoryOptions) => {
-      const releasePR = factory.releasePR(argv);
-      releasePR
-        .latestTag()
+      factory
+        .runCommand('latest-tag', argv)
         .catch(handleError)
         .then(latestTag => {
-          console.log(latestTag);
+          if (latestTag) console.log(latestTag);
         });
     }
   )
@@ -179,11 +178,10 @@ export const parser = yargs
   .demandCommand(1)
   .strict(true);
 
-// Only run parser if executed with node bin, this allows
-// for the parser to be easily tested:
-let argv: yargs.Arguments;
-if (require.main === module) {
-  argv = parser.parse();
+interface HandleError {
+  (err: ErrorObject): void;
+  logger?: Console;
+  yargsArgs?: yargs.Arguments;
 }
 
 // The errors returned by octokit currently contain the
@@ -191,22 +189,38 @@ if (require.main === module) {
 // leak. For this reason, we capture exceptions and print
 // a less verbose error message (run with --debug to output
 // the request object, don't do this in CI/CD).
-function handleError(err: ErrorObject) {
+export const handleError: HandleError = (err: ErrorObject) => {
   let status = '';
-  const command = argv?._?.length ? argv._[0] : '';
+  if (!handleError.yargsArgs) {
+    return;
+  }
+  if (!handleError.logger) {
+    handleError.logger = console;
+  }
+  const ya = handleError.yargsArgs;
+  const logger = handleError.logger;
+  const command = ya?._?.length ? ya._[0] : '';
   if (err.status) {
     status = '' + err.status;
   }
-  console.error(
+  logger.error(
     chalk.red(
       `command ${command} failed${status ? ` with status ${status}` : ''}`
     )
   );
-  if (argv?.debug) {
-    console.error('---------');
-    console.error(err.stack);
+  if (ya?.debug) {
+    logger.error('---------');
+    logger.error(err.stack);
   }
   process.exitCode = 1;
+};
+
+// Only run parser if executed with node bin, this allows
+// for the parser to be easily tested:
+let argv: yargs.Arguments;
+if (require.main === module) {
+  argv = parser.parse();
+  handleError.yargsArgs = argv;
 }
 
 process.on('unhandledRejection', err => {

--- a/src/factory.ts
+++ b/src/factory.ts
@@ -16,7 +16,7 @@
 // and GitHub Releases:
 
 import {ReleasePR} from './release-pr';
-import {GitHubRelease, ReleaseResponse} from './github-release';
+import {GitHubRelease, GitHubReleaseResponse} from './github-release';
 import {ReleaseType, getReleasers} from './releasers';
 import {GitHub, GitHubTag} from './github';
 import {
@@ -28,36 +28,98 @@ import {DEFAULT_LABELS} from './constants';
 // eslint-disable-next-line @typescript-eslint/no-var-requires
 const parseGithubRepoUrl = require('parse-github-repo-url');
 
-function runCommand(
-  command: string,
-  options: GitHubReleaseFactoryOptions | ReleasePRFactoryOptions
-): Promise<number | GitHubTag | undefined | ReleaseResponse> {
-  if (isGitHubRelease(command, options)) {
-    return factory.run(githubRelease(options), 'run');
-  } else {
-    const cmd = command === 'release-pr' ? 'run' : 'latestTag';
-    return factory.run(releasePR(options), cmd);
-  }
-}
+// types defining methods available to call on instances
+export type ReleasePRMethod = 'run' | 'latestTag';
+export type GitHubReleaseMethod = 'run';
+export type Method = ReleasePRMethod | GitHubReleaseMethod;
 
-function isGitHubRelease(
-  command: string,
-  options: GitHubReleaseFactoryOptions | ReleasePRFactoryOptions
-): options is GitHubReleaseFactoryOptions {
+// types defining cli commands and their options
+export type ReleasePRCommands = 'release-pr' | 'latest-tag';
+export type GitHubReleaseCommands = 'github-release';
+type Command = ReleasePRCommands | GitHubReleaseCommands;
+type IsReleasePRCmd = {
+  command: Command;
+  options: ReleasePRFactoryOptions;
+};
+type IsGitHubReleaseCmd = {
+  command: Command;
+  options: GitHubReleaseFactoryOptions;
+};
+
+// shorthand aliases for instance/method call return types
+export type ReleasePRRunResult = Promise<number | GitHubTag | undefined>;
+export type GitHubReleaseRunResult = Promise<GitHubReleaseResponse | undefined>;
+export type RunResult = ReleasePRRunResult | GitHubReleaseRunResult;
+
+function isGitHubReleaseCmd(
+  cmdOpts: IsReleasePRCmd | IsGitHubReleaseCmd
+): cmdOpts is IsGitHubReleaseCmd {
+  const {command, options} = cmdOpts;
   return command === 'github-release' && typeof options === 'object';
 }
 
-function run(
-  runnable: ReleasePR,
-  cmd: 'run' | 'latestTag'
-): Promise<number | GitHubTag | undefined>;
-function run(
-  runnable: GitHubRelease,
-  cmd: 'run'
-): Promise<ReleaseResponse | undefined>;
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
-function run(runnable: any, cmd: any = 'run') {
-  return runnable[cmd]();
+function isReleasePRCmd(
+  cmdOpts: IsReleasePRCmd | IsGitHubReleaseCmd
+): cmdOpts is IsReleasePRCmd {
+  const {command, options} = cmdOpts;
+  return (
+    (command === 'release-pr' || command === 'latest-tag') &&
+    typeof options === 'object'
+  );
+}
+
+function runCommand(
+  command: ReleasePRCommands,
+  options: ReleasePRFactoryOptions
+): ReleasePRRunResult;
+function runCommand(
+  command: GitHubReleaseCommands,
+  options: GitHubReleaseFactoryOptions
+): GitHubReleaseRunResult;
+function runCommand(
+  command: Command,
+  options: GitHubReleaseFactoryOptions | ReleasePRFactoryOptions
+): RunResult {
+  let result: RunResult;
+  const cmdOpts = {command, options};
+  if (isReleasePRCmd(cmdOpts)) {
+    let method: ReleasePRMethod = 'run';
+    if (command === 'latest-tag') {
+      method = 'latestTag';
+    }
+    result = factory.call(releasePR(cmdOpts.options), method);
+  } else if (isGitHubReleaseCmd({command, options})) {
+    result = factory.call(githubRelease(cmdOpts.options), 'run');
+  } else {
+    throw new Error(
+      `Invalid command(${cmdOpts.command}) with options(${JSON.stringify(
+        cmdOpts.options
+      )})`
+    );
+  }
+  return result;
+}
+
+function call(instance: ReleasePR, method: ReleasePRMethod): ReleasePRRunResult;
+function call(
+  instance: GitHubRelease,
+  method: GitHubReleaseMethod
+): GitHubReleaseRunResult;
+function call(instance: ReleasePR | GitHubRelease, method: Method): RunResult {
+  if (!(method in instance)) {
+    throw new Error(
+      `No such method(${method}) on ${instance.constructor.name}`
+    );
+  }
+  let result: RunResult;
+  if (instance instanceof ReleasePR) {
+    result = instance[method as ReleasePRMethod]();
+  } else if (instance instanceof GitHubRelease) {
+    result = instance[method as GitHubReleaseMethod]();
+  } else {
+    throw new Error('Unknown instance.');
+  }
+  return result;
 }
 
 function getLabels(label?: string): string[] {
@@ -167,6 +229,6 @@ export const factory = {
   githubRelease,
   releasePR,
   releasePRClass,
-  run,
+  call,
   runCommand,
 };

--- a/src/github-release.ts
+++ b/src/github-release.ts
@@ -21,7 +21,7 @@ import {ReleasePR} from './release-pr';
 // eslint-disable-next-line @typescript-eslint/no-var-requires
 const GITHUB_RELEASE_LABEL = 'autorelease: tagged';
 
-export interface ReleaseResponse {
+export interface GitHubReleaseResponse {
   major: number;
   minor: number;
   patch: number;
@@ -48,7 +48,7 @@ export class GitHubRelease {
     this.releasePR = options.releasePR;
   }
 
-  async run(): Promise<ReleaseResponse | undefined> {
+  async run(): Promise<GitHubReleaseResponse | undefined> {
     const candidate = await this.releasePR.buildRelease(this.changelogPath);
     if (!candidate) {
       checkpoint('Unable to build candidate', CheckpointType.Failure);

--- a/test/factory.ts
+++ b/test/factory.ts
@@ -194,7 +194,7 @@ describe('factory', () => {
         releaseType: 'simple',
       });
       sandbox.stub(runnable, 'run').resolves(47);
-      expect(await factory.run(runnable)).to.equal(47);
+      expect(await factory.run(runnable, 'run')).to.equal(47);
     });
   });
 });

--- a/test/factory.ts
+++ b/test/factory.ts
@@ -14,11 +14,11 @@
 
 import {describe, it, afterEach} from 'mocha';
 import * as assert from 'assert';
-import {factory} from '../src/factory';
+import {factory, ReleasePRCommands} from '../src/factory';
 import * as sinon from 'sinon';
 import {expect} from 'chai';
 import {RequestHeaders} from '@octokit/types';
-import {Ruby} from '../src';
+import {Ruby, ReleasePRFactoryOptions, ReleasePR} from '../src';
 
 const sandbox = sinon.createSandbox();
 
@@ -185,16 +185,103 @@ describe('factory', () => {
       );
     });
   });
-  describe('run', () => {
-    it('runs a runnable', async () => {
-      const runnable = factory.releasePR({
+
+  describe('runCommand', () => {
+    it('errors on bad command', async () => {
+      sandbox.stub(factory, 'call').resolves(undefined);
+      let caught = false;
+      let err: Error;
+      try {
+        await factory.runCommand(
+          'foobar' as ReleasePRCommands,
+          ({bar: 'baz'} as unknown) as ReleasePRFactoryOptions
+        );
+      } catch (e) {
+        err = e;
+        caught = true;
+      }
+      expect(caught).to.be.true;
+      expect(err!.message).to.equal(
+        'Invalid command(foobar) with options({"bar":"baz"})'
+      );
+    });
+  });
+  describe('call', () => {
+    it('calls ReleasePR.run', async () => {
+      const instance = factory.releasePR({
         repoUrl: 'googleapis/simple-test-repo',
-        packageName: 'simple-test-repo',
-        apiUrl: 'https://api.github.com',
         releaseType: 'simple',
       });
-      sandbox.stub(runnable, 'run').resolves(47);
-      expect(await factory.run(runnable, 'run')).to.equal(47);
+      sandbox.stub(instance, 'run').resolves(47);
+      expect(await factory.call(instance, 'run')).to.equal(47);
+    });
+    it('errors with bad method on ReleasePR', async () => {
+      const instance = factory.releasePR({
+        repoUrl: 'googleapis/simple-test-repo',
+        releaseType: 'simple',
+      });
+      let caught = false;
+      let err: Error;
+      try {
+        await factory.call(instance, 'foo' as 'run');
+      } catch (e) {
+        err = e;
+        caught = true;
+      }
+      expect(caught).to.be.true;
+      expect(err!.message).to.equal('No such method(foo) on Simple');
+    });
+    it('calls a GitHubRelease instance', async () => {
+      const instance = factory.githubRelease({
+        repoUrl: 'googleapis/simple-test-repo',
+        releaseType: 'simple',
+      });
+      const ghRelease = {
+        major: 1,
+        minor: 2,
+        patch: 3,
+        version: '1.2.3',
+        sha: 'abc123',
+        html_url: 'https://release.url',
+        upload_url: 'https://upload.url/',
+        name: 'v1.2.3',
+        tag_name: 'v1.2.3',
+        pr: 1,
+        draft: false,
+      };
+      sandbox.stub(instance, 'run').resolves(ghRelease);
+      expect(await factory.call(instance, 'run')).to.eql(ghRelease);
+    });
+    it('errors with bad method on GitHubRelease', async () => {
+      const instance = factory.githubRelease({
+        repoUrl: 'googleapis/simple-test-repo',
+        releaseType: 'simple',
+      });
+      let caught = false;
+      let err: Error;
+      try {
+        await factory.call(instance, 'foo' as 'run');
+      } catch (e) {
+        err = e;
+        caught = true;
+      }
+      expect(caught).to.be.true;
+      expect(err!.message).to.equal('No such method(foo) on GitHubRelease');
+    });
+    it('errors with bad method on unknown', async () => {
+      let caught = false;
+      let err: Error;
+      try {
+        await factory.call(
+          ({foo: () => 'in foo'} as unknown) as ReleasePR,
+          'foo' as 'run'
+        );
+      } catch (e) {
+        err = e;
+        caught = true;
+      }
+      expect(caught).to.be.true;
+      expect(err!.message).to.equal('Unknown instance.');
     });
   });
 });


### PR DESCRIPTION
now that there's an entry point other than `run()` on an instance
(i.e. `ReleasePR.latestTag()`), `runCommand()` needs to be able to
specify what it is. `call()` (formerly `run()`) now accepts this `method`
argument.

Using function overloads as a means to keep a clean call type signature.