### PR TITLE
refactor!: move fork down to GitHub

### DIFF
--- a/src/bin/release-please.ts
+++ b/src/bin/release-please.ts
@@ -20,6 +20,7 @@ import {factory} from '../factory';
 import {getReleaserTypes, ReleaseType} from '../releasers';
 import * as yargs from 'yargs';
 import {GitHubReleaseFactoryOptions, ReleasePRFactoryOptions} from '..';
+import {GH_API_URL} from '../constants';
 
 interface ErrorObject {
   body?: object;
@@ -125,12 +126,17 @@ export const parser = yargs
   .option('token', {describe: 'GitHub token with repo write permissions'})
   .option('api-url', {
     describe: 'URL to use when making API requests',
-    default: 'https://api.github.com',
+    default: GH_API_URL,
     type: 'string',
   })
   .option('default-branch', {
     describe: 'The branch to open release PRs against and tag releases on',
     type: 'string',
+  })
+  .option('fork', {
+    describe: 'should the PR be created from a fork',
+    type: 'boolean',
+    default: false,
   })
   .option('repo-url', {
     describe: 'GitHub URL to generate release for',
@@ -169,11 +175,6 @@ export const parser = yargs
   })
   .option('last-package-version', {
     describe: 'last version # that package was released as',
-  })
-  .option('fork', {
-    describe: 'should the PR be created from a fork',
-    type: 'boolean',
-    default: false,
   })
   .option('snapshot', {
     describe: 'is it a snapshot (or pre-release) being generated?',

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -12,5 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-export const RELEASE_PLEASE = 'release-please';
 export const DEFAULT_LABELS = ['autorelease: pending'];
+export const GH_API_URL = 'https://api.github.com';
+export const RELEASE_PLEASE = 'release-please';

--- a/src/factory.ts
+++ b/src/factory.ts
@@ -128,20 +128,20 @@ function getLabels(label?: string): string[] {
 
 function githubRelease(options: GitHubReleaseFactoryOptions): GitHubRelease {
   const {
-    label,
     repoUrl,
     defaultBranch,
+    fork,
     token,
     apiUrl,
     octokitAPIs,
     releaseType,
+    label,
     path,
     packageName,
     bumpMinorPreMajor,
     releaseAs,
     snapshot,
     monorepoTags,
-    fork,
     changelogSections,
     lastPackageVersion,
     versionFile,
@@ -151,6 +151,7 @@ function githubRelease(options: GitHubReleaseFactoryOptions): GitHubRelease {
   const github = gitHubInstance({
     repoUrl,
     defaultBranch,
+    fork,
     token,
     apiUrl,
     octokitAPIs,
@@ -167,7 +168,6 @@ function githubRelease(options: GitHubReleaseFactoryOptions): GitHubRelease {
     releaseAs,
     snapshot,
     monorepoTags,
-    fork,
     changelogSections,
     lastPackageVersion,
     versionFile,
@@ -204,14 +204,12 @@ function releasePR(options: ReleasePRFactoryOptions): ReleasePR {
 }
 
 export function gitHubInstance(options: GitHubFactoryOptions) {
-  const [owner, repo] = parseGithubRepoUrl(options.repoUrl);
+  const {repoUrl, ...remaining} = options;
+  const [owner, repo] = parseGithubRepoUrl(repoUrl);
   return new GitHub({
     owner,
     repo,
-    defaultBranch: options.defaultBranch,
-    token: options.token,
-    apiUrl: options.apiUrl,
-    octokitAPIs: options.octokitAPIs,
+    ...remaining,
   });
 }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -22,6 +22,7 @@ export {ReleaseCandidate, ReleasePR} from './release-pr';
 // Used by GitHub: Factory and Constructor
 interface GitHubOptions {
   defaultBranch?: string;
+  fork?: boolean;
   token?: string;
   apiUrl?: string;
   octokitAPIs?: OctokitAPIs;
@@ -41,7 +42,6 @@ interface ReleasePROptions {
   releaseAs?: string;
   snapshot?: boolean;
   monorepoTags?: boolean;
-  fork?: boolean;
   changelogSections?: ChangelogSection[];
   // only for Ruby: TODO replace with generic bootstrap option
   lastPackageVersion?: string;

--- a/src/index.ts
+++ b/src/index.ts
@@ -103,9 +103,7 @@ export interface GitHubReleaseFactoryOptions
   extends GitHubReleaseOptions,
     ReleasePROptions,
     ReleasePRFactoryOptions,
-    GitHubFactoryOptions {
-  releaseType?: ReleaseType;
-}
+    GitHubFactoryOptions {}
 
 export {factory} from './factory';
 export {getReleaserTypes, getReleasers} from './releasers';

--- a/src/index.ts
+++ b/src/index.ts
@@ -85,19 +85,24 @@ interface FactoryOptions {
 // GitHub factory/builder options
 export interface GitHubFactoryOptions extends GitHubOptions, FactoryOptions {}
 
+// ReleasePR and GitHubRelease Factory
+interface ReleaserFactory {
+  releaseType?: ReleaseType;
+}
+
 // ReleasePR factory/builder options
-// `releaseType` is required for the ReleaserPR factory. Using a type alias
-// here because the `interface ... extends` syntax produces the following error:
-// "An interface can only extend an identifier/qualified-name with optional
-// type arguments."
-export type ReleasePRFactoryOptions = ReleasePROptions &
-  GitHubFactoryOptions & {releaseType: ReleaseType; label?: string};
+export interface ReleasePRFactoryOptions
+  extends ReleasePROptions,
+    GitHubFactoryOptions,
+    ReleaserFactory {
+  label?: string;
+}
 
 // GitHubRelease factory/builder options
 export interface GitHubReleaseFactoryOptions
   extends GitHubReleaseOptions,
     ReleasePROptions,
-    Omit<ReleasePRFactoryOptions, 'releaseType'>,
+    ReleasePRFactoryOptions,
     GitHubFactoryOptions {
   releaseType?: ReleaseType;
 }

--- a/src/releasers/index.ts
+++ b/src/releasers/index.ts
@@ -46,7 +46,7 @@ export type ReleaseType =
   | 'terraform-module'
   | 'helm';
 
-type Releasers = Partial<Record<ReleaseType, typeof ReleasePR>>;
+type Releasers = Record<ReleaseType, typeof ReleasePR>;
 
 const releasers: Releasers = {
   go: GoYoshi, // TODO(codyoss): refactor this into a more generic go strategy.

--- a/synth.py
+++ b/synth.py
@@ -12,6 +12,7 @@ s.copy(templates, excludes=[
   'CONTRIBUTING.md',
   '.eslintignore',
   '.eslintrc.json',
+  '.mocharc.js',
   '.prettierignore',
   '.prettierrc',
   '.nycrc',

--- a/test/factory.ts
+++ b/test/factory.ts
@@ -82,27 +82,40 @@ describe('factory', () => {
     });
   });
   describe('releasePR', () => {
-    it('returns instance of dynamically loaded releaser', async () => {
+    it('returns a ReleasePR with all the things', async () => {
       const releasePR = factory.releasePR({
         repoUrl: 'googleapis/ruby-test-repo',
+        fork: true,
+        token: 'some-token',
+        apiUrl: 'https://some.api.com',
         packageName: 'ruby-test-repo',
         releaseType: 'ruby',
+        label: 'foo,bar',
+        path: 'some/path',
+        bumpMinorPreMajor: true,
+        releaseAs: '1.2.3',
+        snapshot: true,
+        monorepoTags: true,
+        changelogSections: [{type: 'feat', section: 'Features'}],
+        lastPackageVersion: '0.0.1',
+        versionFile: 'some/ruby/version.rb',
       });
-      expect(releasePR.gh.fork).to.be.false;
-      expect(releasePR.gh.token).to.be.undefined;
+      expect(releasePR.gh.fork).to.be.true;
+      expect(releasePR.gh.token).to.equal('some-token');
       expect(releasePR.gh.owner).to.equal('googleapis');
       expect(releasePR.gh.repo).to.equal('ruby-test-repo');
-      expect(releasePR.gh.apiUrl).to.equal('https://api.github.com');
+      expect(releasePR.gh.apiUrl).to.equal('https://some.api.com');
       expect(releasePR.constructor.name).to.equal('Ruby');
-      expect(releasePR.labels).to.eql(['autorelease: pending']);
-      expect(releasePR.bumpMinorPreMajor).to.be.false;
-      expect(releasePR.path).to.be.undefined;
-      expect(releasePR.monorepoTags).to.be.false;
-      expect(releasePR.releaseAs).to.be.undefined;
-      expect(releasePR.snapshot).to.be.undefined;
-      expect(releasePR.lastPackageVersion).to.be.undefined;
-      expect(releasePR.changelogSections).to.be.undefined;
-      expect((releasePR as Ruby).versionFile).to.equal('');
+      expect(releasePR.labels).to.eql(['foo', 'bar']);
+      expect(releasePR.bumpMinorPreMajor).to.be.true;
+      expect(releasePR.path).to.equal('some/path');
+      expect(releasePR.monorepoTags).to.be.true;
+      expect(releasePR.releaseAs).to.equal('1.2.3');
+      expect(releasePR.snapshot).to.be.true;
+      expect(releasePR.lastPackageVersion).to.equal('0.0.1');
+      expect(releasePR.changelogSections).to.eql([
+        {type: 'feat', section: 'Features'},
+      ]);
       const packageName = await releasePR.getPackageName();
       expect(packageName.name).to.equal('ruby-test-repo');
       expect(packageName.getComponent()).to.equal('ruby-test-repo');
@@ -129,7 +142,10 @@ describe('factory', () => {
       const releaseClass = factory.releasePRClass('ruby');
       expect(releaseClass.name).to.equal('Ruby');
     });
-
+    it('returns base class when no releaseType', () => {
+      const releaseClass = factory.releasePRClass();
+      expect(releaseClass.name).to.equal('ReleasePR');
+    });
     it('throws and error on invalid release type', () => {
       let caught = false;
       try {
@@ -191,7 +207,6 @@ describe('factory', () => {
       expect(ghr.gh.fork).to.be.true;
       expect(ghr.releasePR.constructor.name).to.equal('Ruby');
       expect(ghr.releasePR.labels).to.eql(['foo', 'bar']);
-      expect(ghr.releasePR.path).to.equal('some/path');
       expect(ghr.releasePR.path).to.equal('some/path');
       expect(ghr.releasePR.releaseAs).to.equal('1.2.3');
       expect(ghr.releasePR.bumpMinorPreMajor).to.be.true;

--- a/test/factory.ts
+++ b/test/factory.ts
@@ -35,6 +35,22 @@ describe('factory', () => {
       `https://github.com/${owner}/${repo}.git`,
       `git@github.com:${owner}/${repo}`,
     ];
+    it('returns a fully configured GitHub instance', async () => {
+      const gh = factory.gitHubInstance({
+        repoUrl,
+        fork: true,
+        token: 'my-token',
+        apiUrl: 'my-api-url',
+        defaultBranch: '1.x',
+      });
+      expect(gh.owner).to.equal(owner);
+      expect(gh.repo).to.equal(repo);
+      expect(gh.fork).to.be.true;
+      expect(gh.apiUrl).to.equal('my-api-url');
+      expect(gh.token).to.equal('my-token');
+      const branch = await gh.getDefaultBranch();
+      expect(branch).to.equal('1.x');
+    });
     for (const repoUrl of repoUrls) {
       it(`parses github repo url: ${repoUrl}`, () => {
         const gh = factory.gitHubInstance({repoUrl});
@@ -72,10 +88,14 @@ describe('factory', () => {
         packageName: 'ruby-test-repo',
         releaseType: 'ruby',
       });
+      expect(releasePR.gh.fork).to.be.false;
+      expect(releasePR.gh.token).to.be.undefined;
+      expect(releasePR.gh.owner).to.equal('googleapis');
+      expect(releasePR.gh.repo).to.equal('ruby-test-repo');
+      expect(releasePR.gh.apiUrl).to.equal('https://api.github.com');
       expect(releasePR.constructor.name).to.equal('Ruby');
       expect(releasePR.labels).to.eql(['autorelease: pending']);
       expect(releasePR.bumpMinorPreMajor).to.be.false;
-      expect(releasePR.fork).to.be.false;
       expect(releasePR.path).to.be.undefined;
       expect(releasePR.monorepoTags).to.be.false;
       expect(releasePR.releaseAs).to.be.undefined;
@@ -148,6 +168,7 @@ describe('factory', () => {
       const ghr = factory.githubRelease({
         repoUrl: 'googleapis/simple-test-repo',
         defaultBranch: '1.x',
+        fork: true,
         token: 'some-token',
         apiUrl: 'https://some.api.com',
         releaseType: 'ruby',
@@ -158,7 +179,6 @@ describe('factory', () => {
         releaseAs: '1.2.3',
         snapshot: true,
         monorepoTags: true,
-        fork: true,
         changelogSections: [{type: 'feat', section: 'Features'}],
         lastPackageVersion: '0.0.1',
         versionFile: 'some/ruby/version.rb',
@@ -168,6 +188,7 @@ describe('factory', () => {
       expect(ghr.gh.repo).to.equal('simple-test-repo');
       expect(ghr.gh.token).to.equal('some-token');
       expect(ghr.gh.apiUrl).to.equal('https://some.api.com');
+      expect(ghr.gh.fork).to.be.true;
       expect(ghr.releasePR.constructor.name).to.equal('Ruby');
       expect(ghr.releasePR.labels).to.eql(['foo', 'bar']);
       expect(ghr.releasePR.path).to.equal('some/path');
@@ -175,7 +196,6 @@ describe('factory', () => {
       expect(ghr.releasePR.releaseAs).to.equal('1.2.3');
       expect(ghr.releasePR.bumpMinorPreMajor).to.be.true;
       expect(ghr.releasePR.monorepoTags).to.be.true;
-      expect(ghr.releasePR.fork).to.be.true;
       expect(ghr.releasePR.changelogSections).to.eql([
         {type: 'feat', section: 'Features'},
       ]);

--- a/test/github.ts
+++ b/test/github.ts
@@ -274,6 +274,36 @@ describe('GitHub', () => {
     // Todo - not finding things from other branches
   });
 
+  describe('addLabels', () => {
+    it('labels a PR', async () => {
+      req
+        .post('/repos/fake/fake/issues/1/labels', {labels: ['foo']})
+        .reply(200);
+      const created = await github.addLabels(['foo'], 1);
+      expect(created).to.be.true;
+      req.done();
+    });
+    it('does not label a PR on a forked repo', async () => {
+      const gh = new GitHub({owner: 'fake', repo: 'fake', fork: true});
+      const created = await gh.addLabels(['foo'], 1);
+      expect(created).to.be.false;
+    });
+  });
+
+  describe('removeLabels', () => {
+    it('unlabels a PR', async () => {
+      req.delete('/repos/fake/fake/issues/1/labels/foo').reply(200);
+      const removed = await github.removeLabels(['foo'], 1);
+      expect(removed).to.be.true;
+      req.done();
+    });
+    it('does not unlabel a PR on a forked repo', async () => {
+      const gh = new GitHub({owner: 'fake', repo: 'fake', fork: true});
+      const removed = await gh.removeLabels(['foo'], 1);
+      expect(removed).to.be.false;
+    });
+  });
+
   describe('getFileContents', () => {
     it('should support Github Data API in case of a big file', async () => {
       const simpleAPIResponse = JSON.parse(
@@ -400,8 +430,14 @@ describe('GitHub', () => {
   describe('closePR', () => {
     it('updates a PR to state.closed', async () => {
       req.patch('/repos/fake/fake/pulls/1', {state: 'closed'}).reply(200);
-      await github.closePR(1);
+      const closed = await github.closePR(1);
+      expect(closed).to.be.true;
       req.done();
+    });
+    it('does not close a PR from a forked repo', async () => {
+      const gh = new GitHub({owner: 'fake', repo: 'fake', fork: true});
+      const closed = await gh.closePR(1);
+      expect(closed).to.be.false;
     });
   });
 


### PR DESCRIPTION
fork is a low level GitHub plumbing configuration. GitHub can make the
decision when it will be able or unable to add/remove labels and close
prs.

BREAKING CHANGE: fork is no longer in ReleasePRConstructorOptions, it is
now in GitHubConstructorOptions.