### PR TITLE
refactor: helper/util tweaks to DRY out test code

### DIFF
--- a/__snapshots__/node.js
+++ b/__snapshots__/node.js
@@ -80,3 +80,27 @@ exports['Node run uses detected package name in branch 1'] = `
   ]
 ]
 `
+
+exports['Node getOpenPROptions returns release PR changes with defaultInitialVersion 1'] = `
+## 1.0.0 (1983-10-10)
+
+
+### Bug Fixes
+
+* **deps:** update dependency com.google.cloud:google-cloud-spanner to v1.50.0 ([08ca011](https://www.github.com/googleapis/node-test-repo/commit/08ca01180a91c0a1ba8992b491db9212))
+* **deps:** update dependency com.google.cloud:google-cloud-storage to v1.120.0 ([845db13](https://www.github.com/googleapis/node-test-repo/commit/845db1381b3d5d20151cad2588f85feb))
+---
+
+`
+
+exports['Node getOpenPROptions returns release PR changes with semver patch bump 1'] = `
+### [0.123.5](https://www.github.com/googleapis/node-test-repo/compare/v0.123.4...v0.123.5) (1983-10-10)
+
+
+### Bug Fixes
+
+* **deps:** update dependency com.google.cloud:google-cloud-spanner to v1.50.0 ([08ca011](https://www.github.com/googleapis/node-test-repo/commit/08ca01180a91c0a1ba8992b491db9212))
+* **deps:** update dependency com.google.cloud:google-cloud-storage to v1.120.0 ([845db13](https://www.github.com/googleapis/node-test-repo/commit/845db1381b3d5d20151cad2588f85feb))
+---
+
+`

--- a/src/releasers/python.ts
+++ b/src/releasers/python.ts
@@ -114,8 +114,6 @@ export class Python extends ReleasePR {
     );
     const versionPyFiles = await versionPyFilesSearch;
     versionPyFiles.forEach(path => {
-      const vpath = this.addPath(path);
-      console.log(vpath);
       updates.push(
         new VersionPy({
           path: this.addPath(path),

--- a/test/helpers.ts
+++ b/test/helpers.ts
@@ -17,6 +17,12 @@ import {resolve} from 'path';
 import {Commit} from '../src/graphql-to-commits';
 import * as crypto from 'crypto';
 
+export function dateSafe(content: string): string {
+  return content.replace(
+    /[0-9]{4}-[0-9]{2}-[0-9]{2}/g,
+    '1983-10-10' // use a fake date, so that we don't break daily.
+  );
+}
 /*
  * Given an object of chnages expected to be made by code-suggester API,
  * stringify content in such a way that it works well for snapshots:
@@ -28,10 +34,7 @@ export function stringifyExpectedChanges(expected: [string, object][]): string {
     const obj = update[1] as {[key: string]: string};
     stringified = `${stringified}\n${obj.content.replace(/\r\n/g, '\n')}`;
   }
-  return stringified.replace(
-    /[0-9]{4}-[0-9]{2}-[0-9]{2}/g,
-    '1983-10-10' // use a fake date, so that we don't break daily.
-  );
+  return dateSafe(stringified);
 }
 
 /*

--- a/test/releasers/java-bom.ts
+++ b/test/releasers/java-bom.ts
@@ -21,7 +21,7 @@ import * as suggester from 'code-suggester';
 import * as sinon from 'sinon';
 import {GitHubFileContents, GitHub} from '../../src/github';
 import {buildGitHubFileContent} from './utils';
-import {buildMockCommit} from '../helpers';
+import {buildMockCommit, dateSafe} from '../helpers';
 
 const sandbox = sinon.createSandbox();
 
@@ -118,12 +118,7 @@ describe('JavaBom', () => {
         }
       );
       await releasePR.run();
-      snapshot(
-        JSON.stringify(expectedChanges, null, 2).replace(
-          /[0-9]{4}-[0-9]{2}-[0-9]{2}/,
-          '1983-10-10' // don't save a real date, this will break tests.
-        )
-      );
+      snapshot(dateSafe(JSON.stringify(expectedChanges, null, 2)));
     });
 
     it('creates a snapshot PR', async () => {
@@ -211,12 +206,7 @@ describe('JavaBom', () => {
         }
       );
       await releasePR.run();
-      snapshot(
-        JSON.stringify(expectedChanges, null, 2).replace(
-          /[0-9]{4}-[0-9]{2}-[0-9]{2}/,
-          '1983-10-10' // don't save a real date, this will break tests.
-        )
-      );
+      snapshot(dateSafe(JSON.stringify(expectedChanges, null, 2)));
     });
 
     it('ignores a snapshot release if no snapshot needed', async () => {
@@ -337,12 +327,7 @@ describe('JavaBom', () => {
         }
       );
       await releasePR.run();
-      snapshot(
-        JSON.stringify(expectedChanges, null, 2).replace(
-          /[0-9]{4}-[0-9]{2}-[0-9]{2}/,
-          '1983-10-10' // don't save a real date, this will break tests.
-        )
-      );
+      snapshot(dateSafe(JSON.stringify(expectedChanges, null, 2)));
     });
 
     it('merges conventional commit messages', async () => {
@@ -427,12 +412,7 @@ describe('JavaBom', () => {
         }
       );
       await releasePR.run();
-      snapshot(
-        JSON.stringify(expectedChanges, null, 2).replace(
-          /[0-9]{4}-[0-9]{2}-[0-9]{2}/,
-          '1983-10-10' // don't save a real date, this will break tests.
-        )
-      );
+      snapshot(dateSafe(JSON.stringify(expectedChanges, null, 2)));
     });
   });
 

--- a/test/releasers/java-yoshi.ts
+++ b/test/releasers/java-yoshi.ts
@@ -23,7 +23,7 @@ import * as sinon from 'sinon';
 import {GitHubFileContents, GitHub} from '../../src/github';
 import {expect} from 'chai';
 import {buildGitHubFileContent} from './utils';
-import {buildMockCommit} from '../helpers';
+import {buildMockCommit, dateSafe} from '../helpers';
 import {readFileSync} from 'fs';
 import {resolve} from 'path';
 import {ReleasePR} from '../../src/release-pr';
@@ -129,12 +129,7 @@ describe('JavaYoshi', () => {
       }
     );
     await releasePR.run();
-    snapshot(
-      JSON.stringify(expectedChanges, null, 2).replace(
-        /[0-9]{4}-[0-9]{2}-[0-9]{2}/,
-        '1983-10-10' // don't save a real date, this will break tests.
-      )
-    );
+    snapshot(dateSafe(JSON.stringify(expectedChanges, null, 2)));
 
     expect(addLabelStub.callCount).to.eql(1);
   });
@@ -226,12 +221,7 @@ describe('JavaYoshi', () => {
       }
     );
     await releasePR.run();
-    snapshot(
-      JSON.stringify(expectedChanges, null, 2).replace(
-        /[0-9]{4}-[0-9]{2}-[0-9]{2}/,
-        '1983-10-10' // don't save a real date, this will break tests.
-      )
-    );
+    snapshot(dateSafe(JSON.stringify(expectedChanges, null, 2)));
   });
 
   it('creates a snapshot PR, when latest release sha is head', async () => {
@@ -315,12 +305,7 @@ describe('JavaYoshi', () => {
       }
     );
     await releasePR.run();
-    snapshot(
-      JSON.stringify(expectedChanges, null, 2).replace(
-        /[0-9]{4}-[0-9]{2}-[0-9]{2}/,
-        '1983-10-10' // don't save a real date, this will break tests.
-      )
-    );
+    snapshot(dateSafe(JSON.stringify(expectedChanges, null, 2)));
   });
 
   it('ignores a snapshot release if no snapshot needed', async () => {
@@ -444,12 +429,7 @@ describe('JavaYoshi', () => {
       }
     );
     await releasePR.run();
-    snapshot(
-      JSON.stringify(expectedChanges, null, 2).replace(
-        /[0-9]{4}-[0-9]{2}-[0-9]{2}/,
-        '1983-10-10' // don't save a real date, this will break tests.
-      )
-    );
+    snapshot(dateSafe(JSON.stringify(expectedChanges, null, 2)));
   });
 
   it('handles promotion to 1.0.0', async () => {
@@ -536,12 +516,7 @@ describe('JavaYoshi', () => {
       }
     );
     await releasePR.run();
-    snapshot(
-      JSON.stringify(expectedChanges, null, 2).replace(
-        /[0-9]{4}-[0-9]{2}-[0-9]{2}/,
-        '1983-10-10' // don't save a real date, this will break tests.
-      )
-    );
+    snapshot(dateSafe(JSON.stringify(expectedChanges, null, 2)));
   });
 
   it('creates a release PR against a feature branch', async () => {
@@ -635,18 +610,8 @@ describe('JavaYoshi', () => {
       }
     );
     await releasePR.run();
-    snapshot(
-      JSON.stringify(expectedChanges, null, 2).replace(
-        /[0-9]{4}-[0-9]{2}-[0-9]{2}/,
-        '1983-10-10' // don't save a real date, this will break tests.
-      )
-    );
-    snapshot(
-      JSON.stringify(expectedOptions, null, 2).replace(
-        /[0-9]{4}-[0-9]{2}-[0-9]{2}/,
-        '1983-10-10' // don't save a real date, this will break tests.
-      )
-    );
+    snapshot(dateSafe(JSON.stringify(expectedChanges, null, 2)));
+    snapshot(dateSafe(JSON.stringify(expectedOptions, null, 2)));
   });
 
   describe('latestTag', () => {

--- a/test/releasers/node.ts
+++ b/test/releasers/node.ts
@@ -21,15 +21,20 @@ import * as snapshot from 'snap-shot-it';
 import * as suggester from 'code-suggester';
 import * as sinon from 'sinon';
 import {stubFilesFromFixtures} from './utils';
-import {buildMockCommit} from '../helpers';
+import {buildMockCommit, dateSafe} from '../helpers';
 import {Changelog} from '../../src/updaters/changelog';
 import {PackageJson} from '../../src/updaters/package-json';
 import {SamplesPackageJson} from '../../src/updaters/samples-package-json';
 
 const sandbox = sinon.createSandbox();
 
-function stubFilesToUpdate(gh: GitHub, files: string[]) {
-  stubFilesFromFixtures('./test/releasers/fixtures/node', sandbox, gh, files);
+function stubFilesToUpdate(github: GitHub, files: string[]) {
+  stubFilesFromFixtures({
+    fixturePath: './test/releasers/fixtures/node',
+    sandbox,
+    github,
+    files,
+  });
 }
 
 const LATEST_TAG = {
@@ -77,9 +82,7 @@ describe('Node', () => {
         github: new GitHub({owner: 'googleapis', repo: 'node-test-repo'}),
       });
       mockRequest(releasePR);
-      // this stub is required only because Node lookupPackageName calls
-      // getFileContentsOnBranch('package.json'). Otherwise this test
-      // doesn't rely on getting the contents of each Update file.
+      // for Node.getPackageName
       stubFilesToUpdate(releasePR.gh, ['package.json']);
 
       // no latestTag to pass to getOpenPROptions (never found a release)
@@ -92,21 +95,7 @@ describe('Node', () => {
       expect(openPROptions).to.have.property('includePackageName').to.be.false;
       expect(openPROptions).to.have.property('changelogEntry');
 
-      const normalizedChangelog = openPROptions!.changelogEntry.replace(
-        /[0-9]{4}-[0-9]{2}-[0-9]{2}/,
-        '1983-10-10'
-      );
-      const expectedChangelog = `
-## ${expectedVersion} (1983-10-10)
-
-
-### Bug Fixes
-
-* **deps:** update dependency com.google.cloud:google-cloud-spanner to v1.50.0 ([08ca011](https://www.github.com/googleapis/node-test-repo/commit/${COMMITS[1].sha}))
-* **deps:** update dependency com.google.cloud:google-cloud-storage to v1.120.0 ([845db13](https://www.github.com/googleapis/node-test-repo/commit/${COMMITS[0].sha}))
----
-`.substring(1); // leading \n is aesthetic
-      expect(normalizedChangelog).to.equal(expectedChangelog);
+      snapshot(dateSafe(openPROptions!.changelogEntry));
 
       const perUpdateChangelog = openPROptions!.changelogEntry.substring(
         0,
@@ -148,9 +137,7 @@ describe('Node', () => {
         github: new GitHub({owner: 'googleapis', repo: 'node-test-repo'}),
       });
       mockRequest(releasePR);
-      // this stub is required only because Node lookupPackageName calls
-      // getFileContentsOnBranch('package.json'). Otherwise this test
-      // doesn't rely on getting the contents of each Update file.
+      // for Node.getPackageName
       stubFilesToUpdate(releasePR.gh, ['package.json']);
 
       // found last release (LATEST_TAG) so releaser should semver bump.
@@ -165,21 +152,7 @@ describe('Node', () => {
       expect(openPROptions).to.have.property('includePackageName').to.be.false;
       expect(openPROptions).to.have.property('changelogEntry');
 
-      const normalizedChangelog = openPROptions!.changelogEntry.replace(
-        /[0-9]{4}-[0-9]{2}-[0-9]{2}/,
-        '1983-10-10'
-      );
-      const expectedChangelog = `
-### [${expectedVersion}](https://www.github.com/googleapis/node-test-repo/compare/v0.123.4...v${expectedVersion}) (1983-10-10)
-
-
-### Bug Fixes
-
-* **deps:** update dependency com.google.cloud:google-cloud-spanner to v1.50.0 ([08ca011](https://www.github.com/googleapis/node-test-repo/commit/${COMMITS[1].sha}))
-* **deps:** update dependency com.google.cloud:google-cloud-storage to v1.120.0 ([845db13](https://www.github.com/googleapis/node-test-repo/commit/${COMMITS[0].sha}))
----
-`.substring(1); // leading \n is aesthetic
-      expect(normalizedChangelog).to.equal(expectedChangelog);
+      snapshot(dateSafe(openPROptions!.changelogEntry));
 
       const perUpdateChangelog = openPROptions!.changelogEntry.substring(
         0,
@@ -219,9 +192,7 @@ describe('Node', () => {
         github: new GitHub({owner: 'googleapis', repo: 'node-test-repo'}),
       });
       mockRequest(releasePR);
-      // this stub is required only because Node lookupPackageName calls
-      // getFileContentsOnBranch('package.json'). Otherwise this test
-      // doesn't rely on getting the contents of each Update file.
+      // for Node.getPackageName
       stubFilesToUpdate(releasePR.gh, ['package.json']);
 
       const openPROptions = await releasePR.getOpenPROptions(
@@ -253,12 +224,7 @@ describe('Node', () => {
       stubFilesToUpdate(releasePR.gh, ['package.json']);
       const pr = await releasePR.run();
       assert.strictEqual(pr, 22);
-      snapshot(
-        JSON.stringify(expectedChanges, null, 2).replace(
-          /[0-9]{4}-[0-9]{2}-[0-9]{2}/,
-          '1983-10-10' // don't save a real date, this will break tests.
-        )
-      );
+      snapshot(dateSafe(JSON.stringify(expectedChanges, null, 2)));
     });
 
     it('creates a release PR with package-lock.json', async () => {
@@ -281,12 +247,7 @@ describe('Node', () => {
       mockRequest(releasePR);
       stubFilesToUpdate(releasePR.gh, ['package.json', 'package-lock.json']);
       await releasePR.run();
-      snapshot(
-        JSON.stringify(expectedChanges, null, 2).replace(
-          /[0-9]{4}-[0-9]{2}-[0-9]{2}/,
-          '1983-10-10' // don't save a real date, this will break tests.
-        )
-      );
+      snapshot(dateSafe(JSON.stringify(expectedChanges, null, 2)));
     });
 
     it('creates release PR relative to a path', async () => {
@@ -310,12 +271,7 @@ describe('Node', () => {
         'package-lock.json',
       ]);
       await releasePR.run();
-      snapshot(
-        JSON.stringify(expectedChanges, null, 2).replace(
-          /[0-9]{4}-[0-9]{2}-[0-9]{2}/,
-          '1983-10-10' // don't save a real date, this will break tests.
-        )
-      );
+      snapshot(dateSafe(JSON.stringify(expectedChanges, null, 2)));
     });
 
     it('does not support snapshot releases', async () => {
@@ -350,12 +306,7 @@ describe('Node', () => {
       stubFilesToUpdate(releasePR.gh, ['package.json']);
       const pr = await releasePR.run();
       assert.strictEqual(pr, 22);
-      snapshot(
-        JSON.stringify(expectedChanges, null, 2).replace(
-          /[0-9]{4}-[0-9]{2}-[0-9]{2}/,
-          '1983-10-10' // don't save a real date, this will break tests.
-        )
-      );
+      snapshot(dateSafe(JSON.stringify(expectedChanges, null, 2)));
       expect(expectedBranch).to.eql('release-node-test-repo-v0.123.5');
     });
   });

--- a/test/releasers/python.ts
+++ b/test/releasers/python.ts
@@ -21,7 +21,7 @@ import * as snapshot from 'snap-shot-it';
 import * as suggester from 'code-suggester';
 import * as sinon from 'sinon';
 import {stubFilesFromFixtures} from './utils';
-import {buildMockCommit} from '../helpers';
+import {buildMockCommit, dateSafe} from '../helpers';
 import {Changelog} from '../../src/updaters/changelog';
 import {SetupCfg} from '../../src/updaters/python/setup-cfg';
 import {SetupPy} from '../../src/updaters/python/setup-py';
@@ -29,8 +29,13 @@ import {VersionPy} from '../../src/updaters/python/version-py';
 
 const sandbox = sinon.createSandbox();
 
-function stubFilesToUpdate(gh: GitHub, files: string[]) {
-  stubFilesFromFixtures('./test/updaters/fixtures/', sandbox, gh, files);
+function stubFilesToUpdate(github: GitHub, files: string[]) {
+  stubFilesFromFixtures({
+    fixturePath: './test/updaters/fixtures',
+    sandbox,
+    github,
+    files,
+  });
 }
 
 const LATEST_TAG = {
@@ -86,12 +91,7 @@ describe('Python', () => {
       expect(openPROptions).to.have.property('includePackageName').to.be.false;
       expect(openPROptions).to.have.property('changelogEntry');
 
-      snapshot(
-        openPROptions!.changelogEntry.replace(
-          /[0-9]{4}-[0-9]{2}-[0-9]{2}/,
-          '1983-10-10'
-        )
-      );
+      snapshot(dateSafe(openPROptions!.changelogEntry));
 
       const perUpdateChangelog = openPROptions!.changelogEntry.substring(
         0,
@@ -146,12 +146,7 @@ describe('Python', () => {
       expect(openPROptions).to.have.property('includePackageName').to.be.false;
       expect(openPROptions).to.have.property('changelogEntry');
 
-      snapshot(
-        openPROptions!.changelogEntry.replace(
-          /[0-9]{4}-[0-9]{2}-[0-9]{2}/,
-          '1983-10-10'
-        )
-      );
+      snapshot(dateSafe(openPROptions!.changelogEntry));
 
       const perUpdateChangelog = openPROptions!.changelogEntry.substring(
         0,
@@ -229,12 +224,7 @@ describe('Python', () => {
       ]);
       const pr = await releasePR.run();
       assert.strictEqual(pr, 22);
-      snapshot(
-        JSON.stringify(expectedChanges, null, 2).replace(
-          /[0-9]{4}-[0-9]{2}-[0-9]{2}/,
-          '1983-10-10' // don't save a real date, this will break tests.
-        )
-      );
+      snapshot(dateSafe(JSON.stringify(expectedChanges, null, 2)));
     });
 
     it('creates a release PR relative to a path', async () => {
@@ -263,12 +253,7 @@ describe('Python', () => {
       ]);
       const pr = await releasePR.run();
       assert.strictEqual(pr, 22);
-      snapshot(
-        JSON.stringify(expectedChanges, null, 2).replace(
-          /[0-9]{4}-[0-9]{2}-[0-9]{2}/,
-          '1983-10-10' // don't save a real date, this will break tests.
-        )
-      );
+      snapshot(dateSafe(JSON.stringify(expectedChanges, null, 2)));
     });
   });
 });

--- a/test/releasers/utils.ts
+++ b/test/releasers/utils.ts
@@ -36,31 +36,67 @@ export function buildGitHubFileRaw(content: string): GitHubFileContents {
   };
 }
 
-/**
- * Stub files on github with fixtures.
- *
- * @param fixturePath - Parent dir of fixture files. Fixture files must be
- *  direct children (no sub folders).
- * @param sandbox - created in test file.
- * @param gh - GitHub instance's `getFileContentsOnBranch` to stub
- * @param files - list of mock/repo/full/path/filename.ext. The stub file is
- *   then read from fixturePath/filename.ext.
- * @param defaultBranch - branch arg to `getFileContentsOnBranch`
- */
-export function stubFilesFromFixtures(
-  fixturePath: string,
-  sandbox: SinonSandbox,
-  gh: GitHub,
-  files: string[],
-  defaultBranch = 'master'
-) {
-  const stub = sandbox.stub(gh, 'getFileContentsOnBranch');
+export interface StubFiles {
+  sandbox: SinonSandbox;
+  github: GitHub;
+
+  // "master" TODO update all test code to use "main"
+  defaultBranch?: string;
+
+  // Example1: test/updaters/fixtures/python
+  // Example2: test/fixtures/releaser/repo
+  fixturePath: string;
+
+  // list of files in the mocked repo relative to the repo root. These should
+  // have corresponding fixture files to use as stubbed content.
+  // Example1: ["setup.py, "src/foolib/version.py"]
+  // Example2: ["python/setup.py", "python/src/foolib/version.py"]
+  files: string[];
+
+  // If true, the fixture files are assumed to exist directly beneath
+  // Example (following Example1 above)
+  // - test/updaters/fixtures/python/setup.py
+  // - test/updaters/fixtures/python/version.py
+  //
+  // if false, the fixture files are assumed to exist under fixturePath *with*
+  // their relative path prefix.
+  // Example (following Example2 above)
+  // - test/fixtures/releaser/repo/python/setup.py
+  // - test/fixtures/releaser/python/src/foolib/version.py
+  flatten?: boolean;
+
+  // Inline content for files to stub.
+  // Example: [
+  //  ['pkg1/package.json', '{"version":"1.2.3","name":"@foo/pkg1"}']
+  //  ['py/setup.py', 'version = "3.2.1"\nname = "pylib"']
+  // ]
+  inlineFiles?: [string, string][];
+}
+
+export function stubFilesFromFixtures(options: StubFiles) {
+  const {fixturePath, sandbox, github, files} = options;
+  const inlineFiles = options.inlineFiles ?? [];
+  const overlap = inlineFiles.filter(f => files.includes(f[0]));
+  if (overlap.length > 0) {
+    throw new Error(
+      'Overlap between files and inlineFiles: ' + JSON.stringify(overlap)
+    );
+  }
+  const defaultBranch = options.defaultBranch ?? 'master';
+  const flatten = options.flatten ?? true;
+  const stub = sandbox.stub(github, 'getFileContentsOnBranch');
   for (const file of files) {
-    const parts = file.split('/');
-    const name = parts[parts.length - 1];
+    let fixtureFile = file;
+    if (flatten) {
+      const parts = file.split('/');
+      fixtureFile = parts[parts.length - 1];
+    }
     stub
       .withArgs(file, defaultBranch)
-      .resolves(buildGitHubFileContent(fixturePath, name));
+      .resolves(buildGitHubFileContent(fixturePath, fixtureFile));
+  }
+  for (const [file, content] of inlineFiles) {
+    stub.withArgs(file, defaultBranch).resolves(buildGitHubFileRaw(content));
   }
   stub.rejects(Object.assign(Error('not found'), {status: 404}));
 }


### PR DESCRIPTION
- DRY out 1983-10-10 with factored out dateSafe helper
- convert long string asserts in node test to snapshots
- stubFilesToUpdate util enhancements (usage coming in subsequent PRs):
  - `flatten`: find fixture files matching repo structure
  - `inlineFiles`: stub files from content input instead of file system.