### PR TITLE
fix: only add the target branch to PR title for non-default branches

### DIFF
--- a/src/github.ts
+++ b/src/github.ts
@@ -164,6 +164,7 @@ export class GitHub {
   repo: string;
   apiUrl: string;
   fork: boolean;
+  repositoryDefaultBranch?: string;
 
   constructor(options: GitHubConstructorOptions) {
     this.defaultBranch = options.defaultBranch;
@@ -1080,10 +1081,29 @@ export class GitHub {
     return `${this.owner}:${baseBranch}`;
   }
 
+  /**
+   * Returns the branch we are targetting for releases. Defaults
+   * to the repository's default/primary branch.
+   *
+   * @returns {string}
+   */
   async getDefaultBranch(): Promise<string> {
     if (this.defaultBranch) {
       return this.defaultBranch;
     }
+    return this.getRepositoryDefaultBranch();
+  }
+
+  /**
+   * Returns the repository's default/primary branch.
+   *
+   * @returns {string}
+   */
+  async getRepositoryDefaultBranch(): Promise<string> {
+    if (this.repositoryDefaultBranch) {
+      return this.repositoryDefaultBranch;
+    }
+
     const {data} = await this.octokit.repos.get({
       repo: this.repo,
       owner: this.owner,
@@ -1091,8 +1111,10 @@ export class GitHub {
         Authorization: `token ${this.token}`,
       },
     });
-    this.defaultBranch = (data as {default_branch: string}).default_branch;
-    return this.defaultBranch as string;
+    this.repositoryDefaultBranch = (data as {
+      default_branch: string;
+    }).default_branch;
+    return this.repositoryDefaultBranch as string;
   }
 
   async closePR(prNumber: number): Promise<boolean> {

--- a/src/releasers/java-yoshi.ts
+++ b/src/releasers/java-yoshi.ts
@@ -317,6 +317,14 @@ export class JavaYoshi extends ReleasePR {
     includePackageName: boolean
   ): Promise<string> {
     const defaultBranch = await this.gh.getDefaultBranch();
+    const repoDefaultBranch = await this.gh.getRepositoryDefaultBranch();
+
+    // If we are proposing a release to a non-default branch, add the target
+    // branch in the pull request title.
+    // TODO: consider pushing this change up to the default pull request title
+    if (repoDefaultBranch === defaultBranch) {
+      return super.buildPullRequestTitle(version, includePackageName);
+    }
     const packageName = await this.getPackageName();
     const pullRequestTitle = includePackageName
       ? PullRequestTitle.ofComponentTargetBranchVersion(

--- a/test/releasers/java-yoshi.ts
+++ b/test/releasers/java-yoshi.ts
@@ -48,7 +48,7 @@ describe('JavaYoshi', () => {
     });
 
     sandbox
-      .stub(releasePR.gh, 'getDefaultBranch')
+      .stub(releasePR.gh, 'getRepositoryDefaultBranch')
       .returns(Promise.resolve('master'));
 
     // No open release PRs, so create a new release PR
@@ -120,17 +120,19 @@ describe('JavaYoshi', () => {
     // We stub the entire suggester API, asserting only that the
     // the appropriate changes are proposed:
     let expectedChanges = null;
+    let prTitle = null;
     sandbox.replace(
       suggester,
       'createPullRequest',
-      (_octokit, changes): Promise<number> => {
+      (_octokit, changes, options): Promise<number> => {
         expectedChanges = [...(changes as Map<string, object>)]; // Convert map to key/value pairs.
+        prTitle = options.title;
         return Promise.resolve(22);
       }
     );
     await releasePR.run();
     snapshot(dateSafe(JSON.stringify(expectedChanges, null, 2)));
-
+    expect(prTitle).to.eql('chore: release 0.20.4');
     expect(addLabelStub.callCount).to.eql(1);
   });
 
@@ -142,7 +144,7 @@ describe('JavaYoshi', () => {
     });
 
     sandbox
-      .stub(releasePR.gh, 'getDefaultBranch')
+      .stub(releasePR.gh, 'getRepositoryDefaultBranch')
       .returns(Promise.resolve('master'));
 
     // No open release PRs, so create a new release PR
@@ -232,7 +234,7 @@ describe('JavaYoshi', () => {
     });
 
     sandbox
-      .stub(releasePR.gh, 'getDefaultBranch')
+      .stub(releasePR.gh, 'getRepositoryDefaultBranch')
       .returns(Promise.resolve('master'));
 
     // No open release PRs, so create a new release PR
@@ -316,7 +318,7 @@ describe('JavaYoshi', () => {
     });
 
     sandbox
-      .stub(releasePR.gh, 'getDefaultBranch')
+      .stub(releasePR.gh, 'getRepositoryDefaultBranch')
       .returns(Promise.resolve('master'));
 
     sandbox
@@ -350,7 +352,7 @@ describe('JavaYoshi', () => {
     });
 
     sandbox
-      .stub(releasePR.gh, 'getDefaultBranch')
+      .stub(releasePR.gh, 'getRepositoryDefaultBranch')
       .returns(Promise.resolve('master'));
 
     // No open release PRs, so create a new release PR
@@ -439,7 +441,7 @@ describe('JavaYoshi', () => {
     });
 
     sandbox
-      .stub(releasePR.gh, 'getDefaultBranch')
+      .stub(releasePR.gh, 'getRepositoryDefaultBranch')
       .returns(Promise.resolve('master'));
 
     // No open release PRs, so create a new release PR
@@ -530,6 +532,10 @@ describe('JavaYoshi', () => {
       packageName: 'java-trace',
     });
 
+    sandbox
+      .stub(releasePR.gh, 'getRepositoryDefaultBranch')
+      .returns(Promise.resolve('master'));
+
     // No open release PRs, so create a new release PR
     sandbox
       .stub(releasePR.gh, 'findOpenReleasePRs')
@@ -600,16 +606,19 @@ describe('JavaYoshi', () => {
     // the appropriate changes are proposed:
     let expectedChanges = null;
     let expectedOptions = null;
+    let prTitle = null;
     sandbox.replace(
       suggester,
       'createPullRequest',
       (_octokit, changes, options): Promise<number> => {
         expectedOptions = options;
         expectedChanges = [...(changes as Map<string, object>)]; // Convert map to key/value pairs.
+        prTitle = options.title;
         return Promise.resolve(22);
       }
     );
     await releasePR.run();
+    expect(prTitle).to.eql('chore(1.x): release 0.20.4');
     snapshot(dateSafe(JSON.stringify(expectedChanges, null, 2)));
     snapshot(dateSafe(JSON.stringify(expectedOptions, null, 2)));
   });
@@ -625,7 +634,7 @@ describe('JavaYoshi', () => {
         github: new GitHub({owner: 'googleapis', repo: 'java-trace'}),
       });
 
-      sandbox.stub(releasePR.gh, 'getDefaultBranch').resolves('main');
+      sandbox.stub(releasePR.gh, 'getRepositoryDefaultBranch').resolves('main');
     });
 
     it('returns a stable branch pull request', async () => {


### PR DESCRIPTION
To build this, we needed to separate the GitHub methods for returning the target branch `getDefaultBranch()` from `getRepositoryDefaultBranch()`.

We should probably rename our usage of `getDefaultBranch()` to `getTargetBranch()`
