### PR TITLE
refactor(manifest): code layout, file format

### DIFF
--- a/src/constants.ts
+++ b/src/constants.ts
@@ -15,3 +15,5 @@
 export const DEFAULT_LABELS = ['autorelease: pending'];
 export const GH_API_URL = 'https://api.github.com';
 export const RELEASE_PLEASE = 'release-please';
+export const RELEASE_PLEASE_CONFIG = `${RELEASE_PLEASE}-config.json`;
+export const RELEASE_PLEASE_MANIFEST = `.${RELEASE_PLEASE}-manifest.json`;

--- a/src/index.ts
+++ b/src/index.ts
@@ -16,6 +16,7 @@ import {OctokitAPIs, GitHub} from './github';
 import {ReleaseType} from './releasers';
 import {ReleasePR} from './release-pr';
 import {ChangelogSection} from './conventional-commits';
+import {Checkpoint} from './util/checkpoint';
 
 export {ReleaseCandidate, ReleasePR} from './release-pr';
 
@@ -60,6 +61,21 @@ export interface GitHubConstructorOptions extends GitHubOptions {
 interface ReleaserConstructorOptions {
   github: GitHub;
 }
+
+interface ManifestOptions {
+  configFile?: string;
+  manifestFile?: string;
+}
+
+export interface ManifestConstructorOptions
+  extends ReleaserConstructorOptions,
+    ManifestOptions {
+  checkpoint?: Checkpoint;
+}
+
+export interface ManifestFactoryOptions
+  extends GitHubFactoryOptions,
+    ManifestOptions {}
 
 // ReleasePR Constructor options
 export interface ReleasePRConstructorOptions

--- a/src/manifest.ts
+++ b/src/manifest.ts
@@ -1,0 +1,176 @@
+// Copyright 2021 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import {GitHub, GitHubFileContents} from './github';
+import {ReleaseType} from './releasers';
+import {RELEASE_PLEASE_CONFIG, RELEASE_PLEASE_MANIFEST} from './constants';
+import {ManifestConstructorOptions} from '.';
+import {ChangelogSection} from './conventional-commits';
+import {CheckpointType, checkpoint, Checkpoint} from './util/checkpoint';
+import {GitHubReleaseResponse} from './github-release';
+
+interface ReleaserConfig {
+  'release-type'?: ReleaseType;
+  'bump-minor-pre-major'?: boolean;
+  'changelog-sections'?: ChangelogSection[];
+}
+
+interface ReleaserPackageConfig extends ReleaserConfig {
+  'package-name'?: string;
+}
+
+export interface ManifestConfig extends ReleaserConfig {
+  packages: Record<string, ReleaserPackageConfig>;
+}
+
+export class Manifest {
+  gh: GitHub;
+  configFileName: string;
+  manifestFileName: string;
+  checkpoint: Checkpoint;
+  configFile?: GitHubFileContents;
+  headManifest?: GitHubFileContents;
+
+  constructor(options: ManifestConstructorOptions) {
+    this.gh = options.github;
+    this.configFileName = options.configFile || RELEASE_PLEASE_CONFIG;
+    this.manifestFileName = options.manifestFile || RELEASE_PLEASE_MANIFEST;
+    this.checkpoint = options.checkpoint || checkpoint;
+  }
+
+  protected async getFile(
+    fileName: string,
+    sha?: string
+  ): Promise<GitHubFileContents> {
+    let data;
+    try {
+      if (sha) {
+        data = await this.gh.getFileContentsWithSimpleAPI(fileName, sha, false);
+      } else {
+        data = await this.gh.getFileContents(fileName);
+      }
+    } catch (e) {
+      this.checkpoint(
+        `Failed to get ${fileName} at ${sha ?? 'HEAD'}: ${e.status}`,
+        CheckpointType.Failure
+      );
+      throw e;
+    }
+    return data;
+  }
+
+  protected async getManifest(sha?: string): Promise<GitHubFileContents> {
+    if (sha === undefined) {
+      if (!this.headManifest) {
+        this.headManifest = await this.getFile(this.manifestFileName, sha);
+      }
+      return this.headManifest;
+    }
+    return await this.getFile(this.manifestFileName, sha);
+  }
+
+  protected async getConfig(): Promise<GitHubFileContents> {
+    if (!this.configFile) {
+      this.configFile = await this.getFile(this.configFileName);
+    }
+    return this.configFile;
+  }
+
+  private async validateJsonFile<T extends object>(
+    getFileMethod: 'getConfig' | 'getManifest',
+    fileName: string
+  ): Promise<{valid: true; obj: T} | {valid: false; obj: undefined}> {
+    let response: {valid: true; obj: T} | {valid: false; obj: undefined} = {
+      valid: false,
+      obj: undefined,
+    };
+    const file = await this[getFileMethod]();
+    try {
+      const obj: T = JSON.parse(file.parsedContent);
+      if (obj.constructor.name === 'Object') {
+        response = {valid: true, obj: obj};
+      }
+    } catch (e) {
+      this.checkpoint(`Invalid JSON in ${fileName}`, CheckpointType.Failure);
+    }
+    return response;
+  }
+
+  protected async validate(): Promise<boolean> {
+    const configValidation = await this.validateJsonFile<ManifestConfig>(
+      'getConfig',
+      this.configFileName
+    );
+    let validConfig = false;
+    if (configValidation.valid) {
+      validConfig = !!Object.keys(configValidation.obj.packages ?? {}).length;
+      if (!validConfig) {
+        this.checkpoint(
+          `No packages found: ${this.configFileName}`,
+          CheckpointType.Failure
+        );
+      }
+    }
+
+    const manifestValidation = await this.validateJsonFile<
+      Record<string, string>
+    >('getManifest', this.manifestFileName);
+    let validManifest = false;
+    if (manifestValidation.valid) {
+      validManifest = true;
+      const versions = manifestValidation.obj;
+      for (const version in versions) {
+        if (typeof versions[version] !== 'string') {
+          validManifest = false;
+          this.checkpoint(
+            `${this.manifestFileName} must only contain string values`,
+            CheckpointType.Failure
+          );
+          break;
+        }
+      }
+    }
+    return validConfig && validManifest;
+  }
+
+  async pullRequest(): Promise<number | undefined> {
+    const valid = await this.validate();
+    if (!valid) {
+      return;
+    }
+    return 1;
+  }
+
+  async githubRelease(): Promise<GitHubReleaseResponse[] | undefined> {
+    const valid = await this.validate();
+    if (!valid) {
+      return;
+    }
+    return [
+      {
+        major: 1,
+        minor: 1,
+        patch: 1,
+        version: '1.1.1',
+        sha: 'abc123',
+        html_url: 'https://release.url',
+        name: 'foo foo-v1.1.1',
+        tag_name: 'foo-v1.1.1',
+        upload_url: 'https://upload.url/',
+        pr: 1,
+        draft: false,
+      },
+    ];
+  }
+}

--- a/src/util/checkpoint.ts
+++ b/src/util/checkpoint.ts
@@ -20,7 +20,11 @@ export enum CheckpointType {
   Failure = 'failure',
 }
 
-export function checkpoint(msg: string, type: CheckpointType) {
+export type Checkpoint = (msg: string, type: CheckpointType) => void;
+export const checkpoint: Checkpoint = function (
+  msg: string,
+  type: CheckpointType
+) {
   const prefix =
     type === CheckpointType.Success
       ? chalk.green(figures.tick)
@@ -28,4 +32,4 @@ export function checkpoint(msg: string, type: CheckpointType) {
   if (process.env.ENVIRONMENT !== 'test') {
     console.info(`${prefix} ${msg}`);
   }
-}
+};

--- a/test/manifest.ts
+++ b/test/manifest.ts
@@ -1,0 +1,183 @@
+// Copyright 2021 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import {describe, it, afterEach} from 'mocha';
+
+import {Manifest} from '../src/manifest';
+import * as sinon from 'sinon';
+import {GitHub} from '../src/github';
+import {stubFilesFromFixtures} from './releasers/utils';
+import {expect} from 'chai';
+import {CheckpointType} from '../src/util/checkpoint';
+
+const fixturePath = './test/fixtures/manifest/repo';
+const defaultBranch = 'main';
+const sandbox = sinon.createSandbox();
+
+describe('Manifest', () => {
+  afterEach(() => {
+    sandbox.restore();
+  });
+
+  describe('validate', () => {
+    const entryPoints: ('pullRequest' | 'githubRelease')[] = [
+      'pullRequest',
+      'githubRelease',
+    ];
+    const invalidConfigs = [
+      {
+        setupName: 'invalid json',
+        manifest: 'foo',
+        config: 'bar',
+        expectedLogs: [
+          [
+            'Invalid JSON in release-please-config.json',
+            CheckpointType.Failure,
+          ],
+          [
+            'Invalid JSON in .release-please-manifest.json',
+            CheckpointType.Failure,
+          ],
+        ],
+      },
+      {
+        setupName: 'no config.packages, bad manifest format',
+        manifest: '{"path": 1}',
+        config: '{"release-type": "node"}',
+        expectedLogs: [
+          [
+            'No packages found: release-please-config.json',
+            CheckpointType.Failure,
+          ],
+          [
+            '.release-please-manifest.json must only contain string values',
+            CheckpointType.Failure,
+          ],
+        ],
+      },
+      {
+        setupName: 'valid config, invalid manifest',
+        manifest: '{"path": 1}',
+        config: '{"packages":{"foo":{}}}',
+        expectedLogs: [
+          [
+            '.release-please-manifest.json must only contain string values',
+            CheckpointType.Failure,
+          ],
+        ],
+      },
+      {
+        setupName: 'valid config, valid manifest',
+        manifest: '{"foo": "1.2.3"}',
+        config: '{"packages":{"foo":{}}}',
+        expectedLogs: [],
+      },
+    ];
+    for (const method of entryPoints) {
+      for (const test of invalidConfigs) {
+        const {config, manifest, expectedLogs, setupName} = test;
+        it(`validates manifest and config in ${method} for ${setupName}`, async () => {
+          const github = new GitHub({
+            owner: 'fake',
+            repo: 'repo',
+            defaultBranch,
+          });
+          stubFilesFromFixtures({
+            sandbox,
+            github,
+            defaultBranch,
+            fixturePath,
+            flatten: false,
+            files: [],
+            inlineFiles: [
+              ['release-please-config.json', config],
+              ['.release-please-manifest.json', manifest],
+            ],
+          });
+          const logs: [string, CheckpointType][] = [];
+          const checkpoint = (msg: string, type: CheckpointType) =>
+            logs.push([msg, type]);
+
+          const m = new Manifest({github, checkpoint});
+          const result = await m[method]();
+
+          if (expectedLogs.length > 0) {
+            expect(result).to.be.undefined;
+          }
+          expect(logs).to.eql(expectedLogs);
+        });
+      }
+      it(`missing config in ${method}`, async () => {
+        const github = new GitHub({
+          owner: 'fake',
+          repo: 'repo',
+          defaultBranch,
+        });
+        sandbox
+          .stub(github, 'getFileContentsOnBranch')
+          .rejects(Object.assign(Error('not found'), {status: 404}));
+        const logs: [string, CheckpointType][] = [];
+        const checkpoint = (msg: string, type: CheckpointType) =>
+          logs.push([msg, type]);
+        const m = new Manifest({github, checkpoint});
+        let caught = false;
+        try {
+          await m[method]();
+        } catch (e) {
+          caught = true;
+        }
+        expect(caught).to.be.true;
+        expect(logs).to.eql([
+          [
+            'Failed to get release-please-config.json at HEAD: 404',
+            CheckpointType.Failure,
+          ],
+        ]);
+      });
+      it(`missing manifest in ${method}`, async () => {
+        const github = new GitHub({
+          owner: 'fake',
+          repo: 'repo',
+          defaultBranch,
+        });
+        const stub = sandbox.stub(github, 'getFileContentsOnBranch');
+        stub.withArgs('release-please-config.json', defaultBranch).resolves({
+          sha: '',
+          content: '',
+          parsedContent: '{"packages": {"path":{}}}',
+        });
+        stub
+          .withArgs('.release-please-manifest.json', defaultBranch)
+          .rejects(Object.assign(Error('not found'), {status: 404}));
+        const logs: [string, CheckpointType][] = [];
+        const checkpoint = (msg: string, type: CheckpointType) =>
+          logs.push([msg, type]);
+        const m = new Manifest({github, checkpoint});
+        let caught = false;
+        try {
+          await m[method]();
+        } catch (e) {
+          caught = true;
+        }
+        expect(caught).to.be.true;
+        expect(logs).to.eql([
+          [
+            'Failed to get .release-please-manifest.json at HEAD: 404',
+            CheckpointType.Failure,
+          ],
+        ]);
+      });
+    }
+  });
+});


### PR DESCRIPTION
The Manifest class uses a manifest.json file to track version info for
one or more packages* in a repo. The structure is an object of this
shape:

`{"<packagePath>": "<version>"}`

The manifest file must exist at least at the tip of the `defaultBranch`
even if it is empty at first. The Manifest class will attempt to find
the last merged Release PR and use the package versions set in the
manifest at that time as the current versions. Failing to find a package
version it will read the manifest at the tip of the `defaultBranch` to
see if a version has been added. "packagePath" additions are the only
change considered (changed or deleted packagePath entries are ignored).
If a version still cannot be determined then the Manifest falls back to
the individual ReleasePR instance's `defaultInitialVersion()`.

Configuration for the Manifest class is split. It needs the basic
options required to create a GitHub instance but then reads a
config.json file from the tip of the `defaultBranch` in the repository
to know what packagePaths it manages and what their specific ReleasePR
instance configuration should be. To start, only a subset of the current
ReleasePR options are supported. Also, top level ReleasePR options can
be set which will be the default values used by any configured packages.

An absurd configuration to demonstrate functionality:
```
{
  // optional package default overrides
  "release-type": "python", // default "node"
  "bump-minor-pre-major": true, // default false

  // default is conventional-changelog-conventionalcommits default
  // preset
  "changelog-sections": [
    {
      type: 'feat',
      section: 'Fancy Features Section'
    }
  ]

  // packages inheret above config but can override
  packages: {
    // path/to/package
    "py/foo": {
      // required for releasers that don't implement src lookup
      "package-name": "foopy",
      "bump-minor-pre-major": false
    },
    "node/pkg1": {
      "release-type": "node",
      "changelog-sections": [
        {
          type: 'feat',
          section: 'Node Features Section'
        },
        {
          type: 'fix',
          section: 'Node Bugs Section'
        }
      ]
    }
  }

}
```

This PR is just a skeleton to consider code layout and the
manifest/config design. The implementation to follow is:

- `pullRequest` - Get all the commits since last release and parcel
them out per package. Pass them along with current version info to a
releaser instance per package and get back the updates needed for a PR.
Update the manifest with new versions and open a PR.

- `githubRelease`: pass the single commit that is the last merged
Release PR into CommitSplit to determine which packages were updated.
Create a Release/Tag for each of these

- connect to factory/cli and profit

\* In the release-please domain a package is a collection of
configuration options ("release-type", "package-name", "path") - the
unique/natural key is "path" which identifies a directory under the
repository root where relevant package metadata files live. All the
source code for this package must also have this path as an ancestor.
