### PR TITLE
refactor: move changelogPath down to ReleasePR

### DIFF
--- a/__snapshots__/python.js
+++ b/__snapshots__/python.js
@@ -204,7 +204,207 @@ fork: false
 message: chore: release 0.123.5
 `
 
-exports['Python run creates a release PR: changes'] = `
+exports['Python run creates a release PR with custom config: changes'] = `
+
+filename: projects/python/HISTORY.md
+# Changelog
+
+## [0.124.0](https://www.github.com/googleapis/py-test-repo/compare/v0.123.4...v0.124.0) (1983-10-10)
+
+
+### ⚠ BREAKING CHANGES
+
+* still no major version
+
+### Features
+
+* still no major version ([c0d3c41](https://www.github.com/googleapis/py-test-repo/commit/c0d3c4181ecf6c7337a39da1755805b2))
+
+
+### Bug Fixes
+
+* **deps:** update dependency com.google.cloud:google-cloud-spanner to v1.50.0 ([08ca011](https://www.github.com/googleapis/py-test-repo/commit/08ca01180a91c0a1ba8992b491db9212))
+* **deps:** update dependency com.google.cloud:google-cloud-storage to v1.120.0 ([845db13](https://www.github.com/googleapis/py-test-repo/commit/845db1381b3d5d20151cad2588f85feb))
+
+filename: projects/python/setup.cfg
+# Copyright 2020 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+[metadata]
+name = google-crc32c
+version = 0.124.0
+description = A python wrapper of the C library 'Google CRC32C'
+url = https://github.com/googleapis/python-crc32c
+long_description = file: README.md
+long_description_content_type = text/markdown
+author = Google LLC
+author_email = googleapis-packages@google.com
+
+license = Apache 2.0
+platforms = Posix, MacOS X, Windows
+classifiers =
+    Development Status :: 4 - Beta
+    Intended Audience :: Developers
+    License :: OSI Approved :: Apache Software License
+    Operating System :: OS Independent
+    Programming Language :: Python :: 3
+    Programming Language :: Python :: 3.5
+    Programming Language :: Python :: 3.6
+    Programming Language :: Python :: 3.7
+    Programming Language :: Python :: 3.8
+    
+[options]
+zip_safe = True
+python_requires = >=3.5
+
+[options.extras_require]
+testing = pytest
+
+
+filename: projects/python/setup.py
+# Copyright 2018 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import io
+import os
+
+import setuptools
+
+name = "google-cloud-automl"
+description = "Cloud AutoML API client library"
+version = "0.124.0"
+release_status = "Development Status :: 3 - Alpha"
+dependencies = [
+    "google-api-core[grpc] >= 1.14.0, < 2.0.0dev",
+    'enum34; python_version < "3.4"',
+]
+extras = {
+    "pandas": ["pandas>=0.24.0"],
+    "storage": ["google-cloud-storage >= 1.18.0, < 2.0.0dev"],
+}
+
+package_root = os.path.abspath(os.path.dirname(__file__))
+
+readme_filename = os.path.join(package_root, "README.rst")
+with io.open(readme_filename, encoding="utf-8") as readme_file:
+    readme = readme_file.read()
+
+packages = [
+    package for package in setuptools.find_packages() if package.startswith("google")
+]
+
+namespaces = ["google"]
+if "google.cloud" in packages:
+    namespaces.append("google.cloud")
+
+setuptools.setup(
+    name=name,
+    version=version,
+    description=description,
+    long_description=readme,
+    author="Google LLC",
+    author_email="googleapis-packages@oogle.com",
+    license="Apache 2.0",
+    url="https://github.com/GoogleCloudPlatform/google-cloud-python",
+    classifiers=[
+        release_status,
+        "Intended Audience :: Developers",
+        "License :: OSI Approved :: Apache Software License",
+        "Programming Language :: Python",
+        "Programming Language :: Python :: 2",
+        "Programming Language :: Python :: 2.7",
+        "Programming Language :: Python :: 3",
+        "Programming Language :: Python :: 3.5",
+        "Programming Language :: Python :: 3.6",
+        "Programming Language :: Python :: 3.7",
+        "Operating System :: OS Independent",
+        "Topic :: Internet",
+    ],
+    platforms="Posix; MacOS X; Windows",
+    packages=packages,
+    namespace_packages=namespaces,
+    install_requires=dependencies,
+    extras_require=extras,
+    python_requires=">=2.7,!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*",
+    include_package_data=True,
+    zip_safe=False,
+)
+filename: projects/python/src/version.py
+# Copyright 2020 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+__version__ = '0.124.0'
+
+`
+
+exports['Python run creates a release PR with custom config: options'] = `
+
+upstreamOwner: googleapis
+upstreamRepo: py-test-repo
+title: chore: release google-cloud-automl 0.124.0
+branch: release-google-cloud-automl-v0.124.0
+description: :robot: I have created a release \\*beep\\* \\*boop\\*
+---
+## [0.124.0](https://www.github.com/googleapis/py-test-repo/compare/v0.123.4...v0.124.0) (1983-10-10)
+
+
+### ⚠ BREAKING CHANGES
+
+* still no major version
+
+### Features
+
+* still no major version ([c0d3c41](https://www.github.com/googleapis/py-test-repo/commit/c0d3c4181ecf6c7337a39da1755805b2))
+
+
+### Bug Fixes
+
+* **deps:** update dependency com.google.cloud:google-cloud-spanner to v1.50.0 ([08ca011](https://www.github.com/googleapis/py-test-repo/commit/08ca01180a91c0a1ba8992b491db9212))
+* **deps:** update dependency com.google.cloud:google-cloud-storage to v1.120.0 ([845db13](https://www.github.com/googleapis/py-test-repo/commit/845db1381b3d5d20151cad2588f85feb))
+---
+
+
+This PR was generated with [Release Please](https://github.com/googleapis/release-please). See [documentation](https://github.com/googleapis/release-please#release-please).
+primary: master
+force: true
+fork: false
+message: chore: release google-cloud-automl 0.124.0
+`
+
+exports['Python run creates a release PR with defaults: changes'] = `
 
 filename: CHANGELOG.md
 # Changelog
@@ -361,7 +561,7 @@ __version__ = '0.123.5'
 
 `
 
-exports['Python run creates a release PR: options'] = `
+exports['Python run creates a release PR with defaults: options'] = `
 
 upstreamOwner: googleapis
 upstreamRepo: py-test-repo

--- a/__snapshots__/ruby.js
+++ b/__snapshots__/ruby.js
@@ -1,0 +1,161 @@
+exports['Ruby run creates a release PR relative to a path: changes'] = `
+
+filename: projects/ruby/CHANGELOG.md
+# Changelog
+
+### [0.5.1](https://www.github.com/googleapis/ruby-test-repo/compare/v0.5.0...v0.5.1) (1983-10-10)
+
+
+### Bug Fixes
+
+* **deps:** update dependency com.google.cloud:google-cloud-spanner to v1.50.0 ([08ca011](https://www.github.com/googleapis/ruby-test-repo/commit/08ca01180a91c0a1ba8992b491db9212))
+* **deps:** update dependency com.google.cloud:google-cloud-storage to v1.120.0 ([845db13](https://www.github.com/googleapis/ruby-test-repo/commit/845db1381b3d5d20151cad2588f85feb))
+
+`
+
+exports['Ruby run creates a release PR relative to a path: options'] = `
+
+upstreamOwner: googleapis
+upstreamRepo: ruby-test-repo
+title: chore: release 0.5.1
+branch: release-v0.5.1
+description: :robot: I have created a release \\*beep\\* \\*boop\\*
+---
+### [0.5.1](https://www.github.com/googleapis/ruby-test-repo/compare/v0.5.0...v0.5.1) (1983-10-10)
+
+
+### Bug Fixes
+
+* **deps:** update dependency com.google.cloud:google-cloud-spanner to v1.50.0 ([08ca011](https://www.github.com/googleapis/ruby-test-repo/commit/08ca01180a91c0a1ba8992b491db9212))
+* **deps:** update dependency com.google.cloud:google-cloud-storage to v1.120.0 ([845db13](https://www.github.com/googleapis/ruby-test-repo/commit/845db1381b3d5d20151cad2588f85feb))
+---
+
+
+This PR was generated with [Release Please](https://github.com/googleapis/release-please). See [documentation](https://github.com/googleapis/release-please#release-please).
+primary: master
+force: true
+fork: false
+message: chore: release 0.5.1
+`
+
+exports['Ruby run creates a release PR with custom config: changes'] = `
+
+filename: projects/ruby/HISTORY.md
+# Changelog
+
+## [0.6.0](https://www.github.com/googleapis/ruby-test-repo/compare/v0.5.0...v0.6.0) (1983-10-10)
+
+
+### ⚠ BREAKING CHANGES
+
+* still no major version
+
+### Features
+
+* still no major version ([c0d3c41](https://www.github.com/googleapis/ruby-test-repo/commit/c0d3c4181ecf6c7337a39da1755805b2))
+
+
+### Bug Fixes
+
+* **deps:** update dependency com.google.cloud:google-cloud-spanner to v1.50.0 ([08ca011](https://www.github.com/googleapis/ruby-test-repo/commit/08ca01180a91c0a1ba8992b491db9212))
+* **deps:** update dependency com.google.cloud:google-cloud-storage to v1.120.0 ([845db13](https://www.github.com/googleapis/ruby-test-repo/commit/845db1381b3d5d20151cad2588f85feb))
+
+`
+
+exports['Ruby run creates a release PR with custom config: options'] = `
+
+upstreamOwner: googleapis
+upstreamRepo: ruby-test-repo
+title: chore: release google-cloud-automl 0.6.0
+branch: release-google-cloud-automl-v0.6.0
+description: :robot: I have created a release \\*beep\\* \\*boop\\*
+---
+## [0.6.0](https://www.github.com/googleapis/ruby-test-repo/compare/v0.5.0...v0.6.0) (1983-10-10)
+
+
+### ⚠ BREAKING CHANGES
+
+* still no major version
+
+### Features
+
+* still no major version ([c0d3c41](https://www.github.com/googleapis/ruby-test-repo/commit/c0d3c4181ecf6c7337a39da1755805b2))
+
+
+### Bug Fixes
+
+* **deps:** update dependency com.google.cloud:google-cloud-spanner to v1.50.0 ([08ca011](https://www.github.com/googleapis/ruby-test-repo/commit/08ca01180a91c0a1ba8992b491db9212))
+* **deps:** update dependency com.google.cloud:google-cloud-storage to v1.120.0 ([845db13](https://www.github.com/googleapis/ruby-test-repo/commit/845db1381b3d5d20151cad2588f85feb))
+---
+
+
+This PR was generated with [Release Please](https://github.com/googleapis/release-please). See [documentation](https://github.com/googleapis/release-please#release-please).
+primary: master
+force: true
+fork: false
+message: chore: release google-cloud-automl 0.6.0
+`
+
+exports['Ruby run creates a release PR with defaults: changes'] = `
+
+filename: CHANGELOG.md
+# Changelog
+
+### [0.5.1](https://www.github.com/googleapis/ruby-test-repo/compare/v0.5.0...v0.5.1) (1983-10-10)
+
+
+### Bug Fixes
+
+* **deps:** update dependency com.google.cloud:google-cloud-spanner to v1.50.0 ([08ca011](https://www.github.com/googleapis/ruby-test-repo/commit/08ca01180a91c0a1ba8992b491db9212))
+* **deps:** update dependency com.google.cloud:google-cloud-storage to v1.120.0 ([845db13](https://www.github.com/googleapis/ruby-test-repo/commit/845db1381b3d5d20151cad2588f85feb))
+
+filename: version.rb
+# Copyright 2019 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+module Google
+  module Cloud
+    module Bigtable
+      VERSION = "0.5.1".freeze
+    end
+  end
+end
+
+`
+
+exports['Ruby run creates a release PR with defaults: options'] = `
+
+upstreamOwner: googleapis
+upstreamRepo: ruby-test-repo
+title: chore: release 0.5.1
+branch: release-v0.5.1
+description: :robot: I have created a release \\*beep\\* \\*boop\\*
+---
+### [0.5.1](https://www.github.com/googleapis/ruby-test-repo/compare/v0.5.0...v0.5.1) (1983-10-10)
+
+
+### Bug Fixes
+
+* **deps:** update dependency com.google.cloud:google-cloud-spanner to v1.50.0 ([08ca011](https://www.github.com/googleapis/ruby-test-repo/commit/08ca01180a91c0a1ba8992b491db9212))
+* **deps:** update dependency com.google.cloud:google-cloud-storage to v1.120.0 ([845db13](https://www.github.com/googleapis/ruby-test-repo/commit/845db1381b3d5d20151cad2588f85feb))
+---
+
+
+This PR was generated with [Release Please](https://github.com/googleapis/release-please). See [documentation](https://github.com/googleapis/release-please#release-please).
+primary: master
+force: true
+fork: false
+message: chore: release 0.5.1
+`

--- a/src/factory.ts
+++ b/src/factory.ts
@@ -173,6 +173,7 @@ function githubRelease(options: GitHubReleaseFactoryOptions): GitHubRelease {
     snapshot,
     monorepoTags,
     changelogSections,
+    changelogPath,
     lastPackageVersion,
     versionFile,
     ...GHRFactoryOptions
@@ -188,6 +189,7 @@ function githubRelease(options: GitHubReleaseFactoryOptions): GitHubRelease {
     snapshot,
     monorepoTags,
     changelogSections,
+    changelogPath,
     lastPackageVersion,
     versionFile,
   });

--- a/src/github-release.ts
+++ b/src/github-release.ts
@@ -36,20 +36,18 @@ export interface GitHubReleaseResponse {
 }
 
 export class GitHubRelease {
-  changelogPath: string;
   releasePR: ReleasePR;
   gh: GitHub;
   draft: boolean;
 
   constructor(options: GitHubReleaseConstructorOptions) {
     this.draft = !!options.draft;
-    this.changelogPath = options.changelogPath ?? 'CHANGELOG.md';
     this.gh = options.github;
     this.releasePR = options.releasePR;
   }
 
   async run(): Promise<GitHubReleaseResponse | undefined> {
-    const candidate = await this.releasePR.buildRelease(this.changelogPath);
+    const candidate = await this.releasePR.buildRelease();
     if (!candidate) {
       checkpoint('Unable to build candidate', CheckpointType.Failure);
       return undefined;

--- a/src/index.ts
+++ b/src/index.ts
@@ -31,7 +31,6 @@ interface GitHubOptions {
 
 // Used by GitHubRelease: Factory and Constructor
 interface GitHubReleaseOptions {
-  changelogPath?: string;
   draft?: boolean;
 }
 
@@ -44,6 +43,7 @@ interface ReleasePROptions {
   snapshot?: boolean;
   monorepoTags?: boolean;
   changelogSections?: ChangelogSection[];
+  changelogPath?: string;
   // only for Ruby: TODO replace with generic bootstrap option
   lastPackageVersion?: string;
   // for Ruby: TODO refactor to find version.rb like Python finds version.py

--- a/src/release-pr.ts
+++ b/src/release-pr.ts
@@ -81,6 +81,7 @@ export class ReleasePR {
   snapshot?: boolean;
   lastPackageVersion?: string;
   changelogSections?: ChangelogSection[];
+  changelogPath = 'CHANGELOG.md';
 
   constructor(options: ReleasePRConstructorOptions) {
     this.bumpMinorPreMajor = options.bumpMinorPreMajor || false;
@@ -98,6 +99,7 @@ export class ReleasePR {
     this.gh = options.github;
 
     this.changelogSections = options.changelogSections;
+    this.changelogPath = options.changelogPath ?? this.changelogPath;
   }
 
   // A releaser can override this method to automatically detect the
@@ -379,9 +381,7 @@ export class ReleasePR {
     }
   }
   // Logic for determining what to include in a GitHub release.
-  async buildRelease(
-    changelogPath: string
-  ): Promise<CandidateRelease | undefined> {
+  async buildRelease(): Promise<CandidateRelease | undefined> {
     await this.validateConfiguration();
     const packageName = await this.getPackageName();
     const mergedPR = await this.findMergedRelease();
@@ -398,7 +398,7 @@ export class ReleasePR {
 
     const tag = this.formatReleaseTagName(version, packageName);
     const changelogContents = (
-      await this.gh.getFileContents(this.addPath(changelogPath))
+      await this.gh.getFileContents(this.addPath(this.changelogPath))
     ).parsedContent;
     const notes = extractReleaseNotes(changelogContents, version);
 

--- a/src/releasers/go-yoshi.ts
+++ b/src/releasers/go-yoshi.ts
@@ -13,12 +13,7 @@
 // limitations under the License.
 
 import {ReleasePR, ReleaseCandidate} from '../release-pr';
-import {Octokit} from '@octokit/rest';
-import {PromiseValue} from 'type-fest';
 import {ConventionalChangelogCommit} from '@conventional-commits/parser';
-type PullsListResponseItems = PromiseValue<
-  ReturnType<InstanceType<typeof Octokit>['pulls']['list']>
->['data'];
 
 import {ConventionalCommits} from '../conventional-commits';
 import {checkpoint, CheckpointType} from '../util/checkpoint';
@@ -44,6 +39,8 @@ const SUB_MODULES = [
 const REGEN_PR_REGEX = /.*auto-regenerate.*/;
 
 export class GoYoshi extends ReleasePR {
+  changelogPath = 'CHANGES.md';
+
   protected async _run(): Promise<number | undefined> {
     const packageName = await this.getPackageName();
     const latestTag = await this.latestTag(
@@ -128,7 +125,7 @@ export class GoYoshi extends ReleasePR {
 
     updates.push(
       new Changelog({
-        path: this.addPath('CHANGES.md'),
+        path: this.addPath(this.changelogPath),
         changelogEntry,
         version: candidate.version,
         packageName: packageName.name,

--- a/src/releasers/helm.ts
+++ b/src/releasers/helm.ts
@@ -77,7 +77,7 @@ export class Helm extends ReleasePR {
 
     updates.push(
       new Changelog({
-        path: this.addPath('CHANGELOG.md'),
+        path: this.addPath(this.changelogPath),
         changelogEntry,
         version: candidate.version,
         packageName: packageName.name,

--- a/src/releasers/java-bom.ts
+++ b/src/releasers/java-bom.ts
@@ -150,7 +150,7 @@ export class JavaBom extends ReleasePR {
     if (!this.snapshot) {
       updates.push(
         new Changelog({
-          path: 'CHANGELOG.md',
+          path: this.changelogPath,
           changelogEntry,
           versions: candidateVersions,
           version: candidate.version,

--- a/src/releasers/java-yoshi.ts
+++ b/src/releasers/java-yoshi.ts
@@ -165,7 +165,7 @@ export class JavaYoshi extends ReleasePR {
     if (!this.snapshot) {
       updates.push(
         new Changelog({
-          path: 'CHANGELOG.md',
+          path: this.changelogPath,
           changelogEntry,
           versions: candidateVersions,
           version: candidate.version,

--- a/src/releasers/node.ts
+++ b/src/releasers/node.ts
@@ -92,7 +92,7 @@ export class Node extends ReleasePR {
 
     updates.push(
       new Changelog({
-        path: this.addPath('CHANGELOG.md'),
+        path: this.addPath(this.changelogPath),
         changelogEntry,
         version: candidate.version,
         packageName,

--- a/src/releasers/ocaml.ts
+++ b/src/releasers/ocaml.ts
@@ -120,7 +120,7 @@ export class OCaml extends ReleasePR {
 
     updates.push(
       new Changelog({
-        path: this.addPath('CHANGELOG.md'),
+        path: this.addPath(this.changelogPath),
         changelogEntry,
         version: candidate.version,
         packageName: packageName.name,

--- a/src/releasers/php-yoshi.ts
+++ b/src/releasers/php-yoshi.ts
@@ -108,7 +108,7 @@ export class PHPYoshi extends ReleasePR {
 
     updates.push(
       new Changelog({
-        path: 'CHANGELOG.md',
+        path: this.changelogPath,
         changelogEntry,
         version: candidate.version,
         packageName: packageName.name,

--- a/src/releasers/python.ts
+++ b/src/releasers/python.ts
@@ -83,7 +83,7 @@ export class Python extends ReleasePR {
     const packageName = await this.getPackageName();
     updates.push(
       new Changelog({
-        path: this.addPath('CHANGELOG.md'),
+        path: this.addPath(this.changelogPath),
         changelogEntry,
         version: candidate.version,
         packageName: packageName.name,

--- a/src/releasers/ruby.ts
+++ b/src/releasers/ruby.ts
@@ -80,7 +80,7 @@ export class Ruby extends ReleasePR {
 
     updates.push(
       new Changelog({
-        path: this.addPath('CHANGELOG.md'),
+        path: this.addPath(this.changelogPath),
         changelogEntry,
         version: candidate.version,
         packageName: packageName.name,

--- a/src/releasers/rust.ts
+++ b/src/releasers/rust.ts
@@ -82,7 +82,7 @@ export class Rust extends ReleasePR {
 
     updates.push(
       new Changelog({
-        path: this.addPath('CHANGELOG.md'),
+        path: this.addPath(this.changelogPath),
         changelogEntry,
         version: candidate.version,
         packageName: this.packageName,

--- a/src/releasers/simple.ts
+++ b/src/releasers/simple.ts
@@ -71,7 +71,7 @@ export class Simple extends ReleasePR {
 
     updates.push(
       new Changelog({
-        path: 'CHANGELOG.md',
+        path: this.changelogPath,
         changelogEntry,
         version: candidate.version,
         packageName: packageName.name,

--- a/src/releasers/terraform-module.ts
+++ b/src/releasers/terraform-module.ts
@@ -72,7 +72,7 @@ export class TerraformModule extends ReleasePR {
 
     updates.push(
       new Changelog({
-        path: this.addPath('CHANGELOG.md'),
+        path: this.addPath(this.changelogPath),
         changelogEntry,
         version: candidate.version,
         packageName: packageName.name,

--- a/test/cli.ts
+++ b/test/cli.ts
@@ -170,7 +170,6 @@ describe('CLI', () => {
       assert.ok(instanceToRun! instanceof GitHubRelease);
       assert.strictEqual(instanceToRun.gh.owner, 'googleapis');
       assert.strictEqual(instanceToRun.gh.repo, 'release-please-cli');
-      assert.strictEqual(instanceToRun.changelogPath, 'CHANGELOG.md');
 
       const jsonPkg = `{"name": "${pkgName}"}`;
       sandbox.stub(instanceToRun.releasePR.gh, 'getFileContents').resolves({
@@ -182,6 +181,7 @@ describe('CLI', () => {
         (await instanceToRun.releasePR.getPackageName()).name,
         'cli-package'
       );
+      assert.strictEqual(instanceToRun.releasePR.changelogPath, 'CHANGELOG.md');
       // Defaults to Node.js release type:
       assert.strictEqual(instanceToRun.releasePR.constructor.name, 'Node');
     });

--- a/test/github-release.ts
+++ b/test/github-release.ts
@@ -185,11 +185,11 @@ describe('GitHubRelease', () => {
         path: 'bigquery',
         packageName: 'bigquery',
         monorepoTags: true,
+        changelogPath: 'CHANGES.md',
       });
       const release = new GitHubRelease({
         github,
         releasePR,
-        changelogPath: 'CHANGES.md',
       });
       const created = await release.run();
 
@@ -223,11 +223,11 @@ describe('GitHubRelease', () => {
         path: 'src/apis/foo',
         packageName: 'foo',
         monorepoTags: true,
+        changelogPath: 'CHANGES.md',
       });
       const release = new GitHubRelease({
         github,
         releasePR,
-        changelogPath: 'CHANGES.md',
       });
       const created = await release.run();
 

--- a/test/releasers/ruby.ts
+++ b/test/releasers/ruby.ts
@@ -1,0 +1,116 @@
+// Copyright 2021 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import * as assert from 'assert';
+import {describe, it, afterEach} from 'mocha';
+import {GitHub} from '../../src/github';
+import * as sinon from 'sinon';
+import {stubFilesFromFixtures} from './utils';
+import {buildMockCommit, stubSuggesterWithSnapshot} from '../helpers';
+import {Ruby} from '../../src';
+
+const sandbox = sinon.createSandbox();
+
+function stubFilesToUpdate(github: GitHub, files: string[]) {
+  stubFilesFromFixtures({
+    fixturePath: './test/updaters/fixtures',
+    sandbox,
+    github,
+    files,
+  });
+}
+
+const LATEST_TAG = {
+  name: 'v0.5.0',
+  sha: 'da6e52d956c1e35d19e75e0f2fdba439739ba364',
+  version: '0.5.0',
+};
+
+const COMMITS = [
+  buildMockCommit(
+    'fix(deps): update dependency com.google.cloud:google-cloud-storage to v1.120.0'
+  ),
+  buildMockCommit(
+    'fix(deps): update dependency com.google.cloud:google-cloud-spanner to v1.50.0'
+  ),
+  buildMockCommit('chore: update common templates'),
+];
+
+function stubGithub(releasePR: Ruby, commits = COMMITS) {
+  sandbox.stub(releasePR.gh, 'getDefaultBranch').resolves('master');
+  // No open release PRs, so create a new release PR
+  sandbox.stub(releasePR.gh, 'findOpenReleasePRs').returns(Promise.resolve([]));
+  sandbox
+    .stub(releasePR.gh, 'findMergedReleasePR')
+    .returns(Promise.resolve(undefined));
+  sandbox.stub(releasePR, 'latestTag').resolves(LATEST_TAG);
+  sandbox.stub(releasePR.gh, 'commitsSinceSha').resolves(commits);
+  sandbox.stub(releasePR.gh, 'addLabels');
+}
+
+describe('Ruby', () => {
+  afterEach(() => {
+    sandbox.restore();
+  });
+  const pkgName = 'google-cloud-automl';
+
+  describe('run', () => {
+    it('creates a release PR with defaults', async function () {
+      const releasePR = new Ruby({
+        versionFile: 'version.rb',
+        github: new GitHub({owner: 'googleapis', repo: 'ruby-test-repo'}),
+        packageName: pkgName,
+      });
+
+      stubSuggesterWithSnapshot(sandbox, this.test!.fullTitle());
+      stubGithub(releasePR);
+      stubFilesToUpdate(releasePR.gh, ['version.rb']);
+      const pr = await releasePR.run();
+      assert.strictEqual(pr, 22);
+    });
+
+    it('creates a release PR relative to a path', async function () {
+      const releasePR = new Ruby({
+        github: new GitHub({owner: 'googleapis', repo: 'ruby-test-repo'}),
+        packageName: pkgName,
+        path: 'projects/ruby',
+      });
+
+      stubSuggesterWithSnapshot(sandbox, this.test!.fullTitle());
+      stubGithub(releasePR);
+      stubFilesToUpdate(releasePR.gh, ['version.rb']);
+      const pr = await releasePR.run();
+      assert.strictEqual(pr, 22);
+    });
+
+    it('creates a release PR with custom config', async function () {
+      const releasePR = new Ruby({
+        github: new GitHub({owner: 'googleapis', repo: 'ruby-test-repo'}),
+        packageName: pkgName,
+        path: 'projects/ruby',
+        bumpMinorPreMajor: true,
+        monorepoTags: true,
+        changelogPath: 'HISTORY.md',
+      });
+
+      stubSuggesterWithSnapshot(sandbox, this.test!.fullTitle());
+      const commits = [buildMockCommit('feat!: still no major version')];
+      commits.push(...COMMITS);
+      stubGithub(releasePR, commits);
+      stubFilesToUpdate(releasePR.gh, ['projects/ruby/version.rb']);
+      const pr = await releasePR.run();
+      assert.strictEqual(pr, 22);
+    });
+  });
+});


### PR DESCRIPTION
The releasers already know where their changelog is. It should be
configurable for the `release-pr` command as well.

Also cleaned up test/releasers/python.ts a bit and tested the custom and
default changelogPath settings there.
