### PR TITLE
fix(pagination): looking for pending PRs had no pagination limit

### DIFF
--- a/src/release-pr.ts
+++ b/src/release-pr.ts
@@ -133,7 +133,12 @@ export class ReleasePR {
       );
       return;
     }
-    const mergedPR = await this.gh.findMergedReleasePR(this.labels);
+    const mergedPR = await this.gh.findMergedReleasePR(
+      this.labels,
+      undefined,
+      true,
+      100
+    );
     if (mergedPR) {
       // a PR already exists in the autorelease: pending state.
       checkpoint(


### PR DESCRIPTION
The check for outstanding release PRs would iterate over all PRs on a repo by default.