### PR TITLE
build: ignore .mocharc.js

### DIFF
--- a/synth.py
+++ b/synth.py
@@ -18,5 +18,6 @@ s.copy(templates, excludes=[
   '.nycrc',
   '.kokoro/presubmit/node10/system-test.cfg',
   '.kokoro/continuous/node10/system-test.cfg',
-  '.kokoro/system-test.sh'
+  '.kokoro/system-test.sh',
+  '.mocharc.js'
 ])


### PR DESCRIPTION
@joeldodge79 added a couple improvements to `.mocharc.js`, such as an `unhandledRejection` handler, which I'm not quite ready to roll out to all our libraries (since I know there are some codebases where we don't want this behavior, e.g., telemetry).