### PR TITLE
refactor: commit split only needs / sep

### DIFF
--- a/src/commit-split.ts
+++ b/src/commit-split.ts
@@ -13,11 +13,8 @@
 // limitations under the License.
 
 import {Commit} from './graphql-to-commits';
-import {relative} from 'path';
 
 export interface CommitSplitOptions {
-  // Defaults to './'
-  root?: string;
   // Include empty git commits: each empty commit is included
   // in the list of commits for each path.
   // This allows using the `git commit --allow-empty` workflow
@@ -41,17 +38,15 @@ export interface CommitSplitOptions {
 }
 
 export class CommitSplit {
-  root: string;
   includeEmpty: boolean;
   packagePaths?: string[];
   constructor(opts?: CommitSplitOptions) {
     opts = opts || {};
-    this.root = opts.root || './';
     this.includeEmpty = !!opts.includeEmpty;
     if (opts.packagePaths) {
       const paths: string[] = [];
       for (let newPath of opts.packagePaths) {
-        newPath = newPath.replace(/[/\\]$/, '');
+        newPath = newPath.replace(/\/$/, '');
         for (const exPath of paths) {
           if (newPath.indexOf(exPath) >= 0 || exPath.indexOf(newPath) >= 0) {
             throw new Error(
@@ -71,8 +66,7 @@ export class CommitSplit {
       const dedupe: Set<string> = new Set();
       for (let i = 0; i < commit.files.length; i++) {
         const file: string = commit.files[i];
-        const path = relative(this.root, file);
-        const splitPath = path.split(/[/\\]/);
+        const splitPath = file.split('/');
         // indicates that we have a top-level file and not a folder
         // in this edge-case we should not attempt to update the path.
         if (splitPath.length === 1) continue;
@@ -80,7 +74,7 @@ export class CommitSplit {
         let pkgName;
         if (this.packagePaths) {
           // only track paths under this.packagePaths
-          pkgName = this.packagePaths.find(p => path.indexOf(p) >= 0);
+          pkgName = this.packagePaths.find(p => file.indexOf(p) >= 0);
         } else {
           // track paths by top level folder
           pkgName = splitPath[0];

--- a/test/commit-split.ts
+++ b/test/commit-split.ts
@@ -67,30 +67,30 @@ describe('CommitSplit', () => {
     usePackagePaths: boolean
   ): [ExpectedCommitSplit, PackagePaths, Commit[]] => {
     const pkgsPath = 'packages';
-    const fooPath = path.join(pkgsPath, 'foo');
-    const barPath = path.join(pkgsPath, 'bar');
+    const fooPath = pkgsPath + '/foo';
+    const barPath = pkgsPath + '/bar';
     const bazPath = 'python';
     const somePath = 'some';
     const fooCommit = buildMockCommit('fix(foo): fix foo', [
-      path.join(fooPath, 'foo.ts'),
+      fooPath + '/foo.ts',
     ]);
     const barCommit = buildMockCommit('fix(bar): fix bar', [
-      path.join(barPath, 'bar.ts'),
+      barPath + '/bar.ts',
     ]);
     const bazCommit = buildMockCommit('fix(baz): fix baz', [
-      path.join(bazPath, 'baz', 'baz.py'),
+      bazPath + '/baz/baz.py',
     ]);
     const foobarCommit = buildMockCommit('fix(foobar): fix foobar', [
-      path.join(fooPath, 'foo.ts'),
-      path.join(barPath, 'bar.ts'),
+      fooPath + '/foo.ts',
+      barPath + '/bar.ts',
     ]);
     const foobarbazCommit = buildMockCommit('fix(foobarbaz): fix foobarbaz', [
-      path.join(fooPath, 'foo.ts'),
-      path.join(barPath, 'bar.ts'),
-      path.join(bazPath, 'baz', 'baz.py'),
+      fooPath + '/foo.ts',
+      barPath + '/bar.ts',
+      bazPath + '/baz/baz.py',
     ]);
     const someCommit = buildMockCommit('fix(some): fix something', [
-      path.join(somePath, 'other', 'file.ts'),
+      somePath + '/other/file.ts',
     ]);
     const emptyCommit = buildMockCommit(
       'chore: empty\n\nrelease-packages/foo-as: 1.2.3',


### PR DESCRIPTION
All file paths coming back from GitHub GraphQL API calls will have the
`/` separator, no need to handle other platform separators

`root` is unused - remove to avoid the use of path.relative which seems to
normalize any hard-coded `/` separators into path.sep