### PR TITLE
fix(node): PackageJson updater sets this.contents

### DIFF
--- a/src/github.ts
+++ b/src/github.ts
@@ -1191,10 +1191,10 @@ export class GitHub {
    * @returns {string}
    */
   async getDefaultBranch(): Promise<string> {
-    if (this.defaultBranch) {
-      return this.defaultBranch;
+    if (!this.defaultBranch) {
+      this.defaultBranch = await this.getRepositoryDefaultBranch();
     }
-    return this.getRepositoryDefaultBranch();
+    return this.defaultBranch;
   }
 
   /**

--- a/src/updaters/package-json.ts
+++ b/src/updaters/package-json.ts
@@ -31,6 +31,7 @@ export class PackageJson implements Update {
     this.changelogEntry = options.changelogEntry;
     this.version = options.version;
     this.packageName = options.packageName;
+    this.contents = options.contents;
   }
 
   updateContent(content: string): string {

--- a/test/github.ts
+++ b/test/github.ts
@@ -128,6 +128,15 @@ describe('GitHub', () => {
     });
   });
 
+  describe('getRepositoryDefaultBranch', () => {
+    it('gets default repository branch', async () => {
+      const branch = await github.getRepositoryDefaultBranch();
+      expect(branch).to.equal('main');
+      const branchAgain = await github.getRepositoryDefaultBranch();
+      expect(branchAgain).to.equal('main');
+    });
+  });
+
   describe('normalizePrefix', () => {
     it('removes a leading slash', async () => {
       expect(github.normalizePrefix('/test')).to.equal('test');


### PR DESCRIPTION
The node releaser passes contents it retrieves ahead of time for
"package.json" into the PackageJson update to avoid an exra call. This
was not being persisted.

Switched node releaser test to use a mock so we have stricter checks on
how GitHub is being called.