### PR TITLE
refactor(manifest): manifest handling cleanup

### DIFF
--- a/__snapshots__/manifest.js
+++ b/__snapshots__/manifest.js
@@ -116,6 +116,124 @@ fork: false
 message: chore: release
 `
 
+exports['Manifest pullRequest boostraps from HEAD manifest if manifest was deleted in last release PR: changes'] = `
+
+filename: node/pkg1/CHANGELOG.md
+# Changelog
+
+## [4.0.0](https://www.github.com/fake/repo/compare/v3.2.1...v4.0.0) (1983-10-10)
+
+
+### ⚠ BREAKING CHANGES
+
+* **@node/pkg1:** major new feature
+
+### Features
+
+* **@node/pkg1:** major new feature ([e3ab0ab](https://www.github.com/fake/repo/commit/e3ab0abfd66e66324f685ceeececf35c))
+
+filename: node/pkg1/package.json
+{
+  "name": "@node/pkg1",
+  "version": "4.0.0"
+}
+
+filename: node/pkg2/CHANGELOG.md
+# Changelog
+
+## [0.2.0](https://www.github.com/fake/repo/compare/v0.1.2...v0.2.0) (1983-10-10)
+
+
+### Features
+
+* **@node/pkg2:** new feature ([6cefc4f](https://www.github.com/fake/repo/commit/6cefc4f5b1f432a24f7c066c5dd95e68))
+
+filename: node/pkg2/package.json
+{
+  "name": "@node/pkg2",
+  "version": "0.2.0"
+}
+
+filename: python/CHANGELOG.md
+# Changelog
+
+### [1.2.4](https://www.github.com/fake/repo/compare/v1.2.3...v1.2.4) (1983-10-10)
+
+
+### Bug Fixes
+
+* **foolib:** bufix python foolib ([8df9117](https://www.github.com/fake/repo/commit/8df9117959264dc5b7b6c72ff36b8846))
+
+filename: python/setup.cfg
+version=1.2.4
+
+filename: python/setup.py
+version = "1.2.4"
+
+filename: python/src/foolib/version.py
+__version__ = "1.2.4"
+
+filename: .release-please-manifest.json
+{
+  "node/pkg1": "4.0.0",
+  "node/pkg2": "0.2.0",
+  "python": "1.2.4"
+}
+
+`
+
+exports['Manifest pullRequest boostraps from HEAD manifest if manifest was deleted in last release PR: options'] = `
+
+upstreamOwner: fake
+upstreamRepo: repo
+title: chore: release
+branch: release-please/branches/main
+description: :robot: I have created a release \\*beep\\* \\*boop\\*
+
+---
+@node/pkg1: 4.0.0
+## [4.0.0](https://www.github.com/fake/repo/compare/v3.2.1...v4.0.0) (1983-10-10)
+
+
+### ⚠ BREAKING CHANGES
+
+* **@node/pkg1:** major new feature
+
+### Features
+
+* **@node/pkg1:** major new feature ([e3ab0ab](https://www.github.com/fake/repo/commit/e3ab0abfd66e66324f685ceeececf35c))
+---
+
+
+---
+@node/pkg2: 0.2.0
+## [0.2.0](https://www.github.com/fake/repo/compare/v0.1.2...v0.2.0) (1983-10-10)
+
+
+### Features
+
+* **@node/pkg2:** new feature ([6cefc4f](https://www.github.com/fake/repo/commit/6cefc4f5b1f432a24f7c066c5dd95e68))
+---
+
+
+---
+foolib: 1.2.4
+### [1.2.4](https://www.github.com/fake/repo/compare/v1.2.3...v1.2.4) (1983-10-10)
+
+
+### Bug Fixes
+
+* **foolib:** bufix python foolib ([8df9117](https://www.github.com/fake/repo/commit/8df9117959264dc5b7b6c72ff36b8846))
+---
+
+
+This PR was generated with [Release Please](https://github.com/googleapis/release-please). See [documentation](https://github.com/googleapis/release-please#release-please).
+primary: main
+force: true
+fork: false
+message: chore: release
+`
+
 exports['Manifest pullRequest bootstraps a new package from curated manifest: changes'] = `
 
 filename: node/pkg1/CHANGELOG.md

--- a/src/github.ts
+++ b/src/github.ts
@@ -510,27 +510,28 @@ export class GitHub {
     const baseBranch = await this.getDefaultBranch();
     const response: Repository<PullRequests> = await this.graphqlRequest({
       query: `query lastMergedPRByHeadBranch($owner: String!, $repo: String!, $baseBranch: String!, $headBranch: String!) {
-        repository(owner: $owner, name: $repo) {
-          pullRequests(baseRefName: $baseBranch, states: MERGED, orderBy: {field: CREATED_AT, direction: DESC}, first: 1, headRefName: $headBranch) {
-          nodes {
-            title
-            body
-            number
-            mergeCommit {
-              oid
-            }
-            files(first: 100) {
-              nodes {
-                path
+          repository(owner: $owner, name: $repo) {
+            pullRequests(baseRefName: $baseBranch, states: MERGED, orderBy: {field: CREATED_AT, direction: DESC}, first: 1, headRefName: $headBranch) {
+            nodes {
+              title
+              body
+              number
+              mergeCommit {
+                oid
               }
-              pageInfo {
-                hasNextPage
-                endCursor
+              files(first: 100) {
+                nodes {
+                  path
+                }
+                pageInfo {
+                  hasNextPage
+                  endCursor
+                }
               }
-            }
-            labels(first: 10) {
-              nodes {
-                name
+              labels(first: 10) {
+                nodes {
+                  name
+                }
               }
             }
           }

--- a/src/release-pr.ts
+++ b/src/release-pr.ts
@@ -186,7 +186,7 @@ export class ReleasePR {
     }
   }
 
-  protected defaultInitialVersion(): string {
+  defaultInitialVersion(): string {
     return this.bumpMinorPreMajor ? '0.1.0' : '1.0.0';
   }
 

--- a/src/releasers/go-yoshi.ts
+++ b/src/releasers/go-yoshi.ts
@@ -151,7 +151,7 @@ export class GoYoshi extends ReleasePR {
     return repo === 'google-cloud-go' || repo === 'google-api-go-client';
   }
 
-  protected defaultInitialVersion(): string {
+  defaultInitialVersion(): string {
     return '0.1.0';
   }
 

--- a/src/releasers/java-bom.ts
+++ b/src/releasers/java-bom.ts
@@ -206,7 +206,7 @@ export class JavaBom extends ReleasePR {
     return true;
   }
 
-  protected defaultInitialVersion(): string {
+  defaultInitialVersion(): string {
     return '0.1.0';
   }
 

--- a/src/releasers/java-yoshi.ts
+++ b/src/releasers/java-yoshi.ts
@@ -266,7 +266,7 @@ export class JavaYoshi extends ReleasePR {
     return true;
   }
 
-  protected defaultInitialVersion(): string {
+  defaultInitialVersion(): string {
     return '0.1.0';
   }
 

--- a/src/releasers/python.ts
+++ b/src/releasers/python.ts
@@ -145,7 +145,7 @@ export class Python extends ReleasePR {
     return openPROptions ? await this.openPR(openPROptions) : undefined;
   }
 
-  protected defaultInitialVersion(): string {
+  defaultInitialVersion(): string {
     return '0.1.0';
   }
 }

--- a/src/releasers/rust.ts
+++ b/src/releasers/rust.ts
@@ -206,7 +206,7 @@ export class Rust extends ReleasePR {
     return commits;
   }
 
-  protected defaultInitialVersion(): string {
+  defaultInitialVersion(): string {
     return '0.1.0';
   }
 

--- a/src/releasers/terraform-module.ts
+++ b/src/releasers/terraform-module.ts
@@ -116,7 +116,7 @@ export class TerraformModule extends ReleasePR {
     });
   }
 
-  protected defaultInitialVersion(): string {
+  defaultInitialVersion(): string {
     return '0.1.0';
   }
 }


### PR DESCRIPTION
- stronger typing for manifest file: using VersionsMap type
- cleanup logic around manifest handling:
  1. retrieving manifest - use overload to distinguish between a call
     for the manifest at a specific sha vs at HEAD
  2. clearer logic to handle bootstrapping (i.e. falling back to HEAD
     manifest and then to defaultInitialVersion)
  3. more logging around version determination.
- switch to using a mock in tests
- typo fix in lastMergedPRByHeadBranch graphql query