### PR TITLE
fix: commit-split paths validation

### DIFF
--- a/test/commit-split.ts
+++ b/test/commit-split.ts
@@ -182,6 +182,21 @@ describe('CommitSplit', () => {
     });
   }
 
+  // Test valid CommitSplitOptions.packagePaths combinations.
+  // Intentionally inconsistent trailing slashes to test path normalization.
+  it('validates configured paths on / separator', () => {
+    const cs = new CommitSplit({
+      packagePaths: ['two-three', 'one-two', 'three/', 'one', 'one-two-three'],
+    });
+    expect(cs.packagePaths).to.be.eql([
+      'two-three',
+      'one-two',
+      'three',
+      'one',
+      'one-two-three',
+    ]);
+  });
+
   // Test invalid CommitSplitOptions.packagePaths combinations.
   // Intentionally inconsistent trailing slashes to test path normalization.
   const invalidPaths = [

--- a/test/commit-split.ts
+++ b/test/commit-split.ts
@@ -186,7 +186,15 @@ describe('CommitSplit', () => {
   // Intentionally inconsistent trailing slashes to test path normalization.
   it('validates configured paths on / separator', () => {
     const cs = new CommitSplit({
-      packagePaths: ['two-three', 'one-two', 'three/', 'one', 'one-two-three'],
+      packagePaths: [
+        '/two-three',
+        'one-two',
+        'three/',
+        'one',
+        'one-two-three',
+        'foo/bar',
+        'foo/bar-baz',
+      ],
     });
     expect(cs.packagePaths).to.be.eql([
       'two-three',
@@ -194,6 +202,8 @@ describe('CommitSplit', () => {
       'three',
       'one',
       'one-two-three',
+      'foo/bar',
+      'foo/bar-baz',
     ]);
   });
 


### PR DESCRIPTION
discovered this bug that prevented configuring with paths like:
- path/path1
- path/path1-extended

went a little heavy on making it clear to future editors why we're using
hardcoded `/` path separators

