### PR TITLE
refactor(manifest): bootstrap-sha and release-as

### DIFF
--- a/__snapshots__/manifest.js
+++ b/__snapshots__/manifest.js
@@ -234,6 +234,124 @@ fork: false
 message: chore: release
 `
 
+exports['Manifest pullRequest boostraps from HEAD manifest starting at bootstrap-sha if first PR: changes'] = `
+
+filename: node/pkg1/CHANGELOG.md
+# Changelog
+
+## [4.0.0](https://www.github.com/fake/repo/compare/pkg1-v3.2.1...pkg1-v4.0.0) (1983-10-10)
+
+
+### ⚠ BREAKING CHANGES
+
+* **@node/pkg1:** major new feature
+
+### Features
+
+* **@node/pkg1:** major new feature ([e3ab0ab](https://www.github.com/fake/repo/commit/e3ab0abfd66e66324f685ceeececf35c))
+
+filename: node/pkg1/package.json
+{
+  "name": "@node/pkg1",
+  "version": "4.0.0"
+}
+
+filename: node/pkg2/CHANGELOG.md
+# Changelog
+
+## [0.2.0](https://www.github.com/fake/repo/compare/pkg2-v0.1.2...pkg2-v0.2.0) (1983-10-10)
+
+
+### Features
+
+* **@node/pkg2:** new feature ([6cefc4f](https://www.github.com/fake/repo/commit/6cefc4f5b1f432a24f7c066c5dd95e68))
+
+filename: node/pkg2/package.json
+{
+  "name": "@node/pkg2",
+  "version": "0.2.0"
+}
+
+filename: python/CHANGELOG.md
+# Changelog
+
+### [1.2.4](https://www.github.com/fake/repo/compare/foolib-v1.2.3...foolib-v1.2.4) (1983-10-10)
+
+
+### Bug Fixes
+
+* **foolib:** bufix python foolib ([8df9117](https://www.github.com/fake/repo/commit/8df9117959264dc5b7b6c72ff36b8846))
+
+filename: python/setup.cfg
+version=1.2.4
+
+filename: python/setup.py
+version = "1.2.4"
+
+filename: python/src/foolib/version.py
+__version__ = "1.2.4"
+
+filename: .release-please-manifest.json
+{
+  "node/pkg1": "4.0.0",
+  "node/pkg2": "0.2.0",
+  "python": "1.2.4"
+}
+
+`
+
+exports['Manifest pullRequest boostraps from HEAD manifest starting at bootstrap-sha if first PR: options'] = `
+
+upstreamOwner: fake
+upstreamRepo: repo
+title: chore: release
+branch: release-please/branches/main
+description: :robot: I have created a release \\*beep\\* \\*boop\\*
+
+---
+@node/pkg1: 4.0.0
+## [4.0.0](https://www.github.com/fake/repo/compare/pkg1-v3.2.1...pkg1-v4.0.0) (1983-10-10)
+
+
+### ⚠ BREAKING CHANGES
+
+* **@node/pkg1:** major new feature
+
+### Features
+
+* **@node/pkg1:** major new feature ([e3ab0ab](https://www.github.com/fake/repo/commit/e3ab0abfd66e66324f685ceeececf35c))
+---
+
+
+---
+@node/pkg2: 0.2.0
+## [0.2.0](https://www.github.com/fake/repo/compare/pkg2-v0.1.2...pkg2-v0.2.0) (1983-10-10)
+
+
+### Features
+
+* **@node/pkg2:** new feature ([6cefc4f](https://www.github.com/fake/repo/commit/6cefc4f5b1f432a24f7c066c5dd95e68))
+---
+
+
+---
+foolib: 1.2.4
+### [1.2.4](https://www.github.com/fake/repo/compare/foolib-v1.2.3...foolib-v1.2.4) (1983-10-10)
+
+
+### Bug Fixes
+
+* **foolib:** bufix python foolib ([8df9117](https://www.github.com/fake/repo/commit/8df9117959264dc5b7b6c72ff36b8846))
+---
+
+
+This PR was generated with [Release Please](https://github.com/googleapis/release-please). See [documentation](https://github.com/googleapis/release-please#release-please).
+primary: main
+force: true
+fork: false
+message: chore: release
+`
+
 exports['Manifest pullRequest bootstraps a new package from curated manifest: changes'] = `
 
 filename: node/pkg1/CHANGELOG.md
@@ -618,7 +736,7 @@ exports['Manifest pullRequest respects python releaser specific config over defa
 filename: node/pkg1/HISTORY.md
 # Changelog
 
-## [0.2.0](https://www.github.com/fake/repo/compare/pkg1-v0.1.1...pkg1-v0.2.0) (1983-10-10)
+### [5.5.5](https://www.github.com/fake/repo/compare/pkg1-v0.1.1...pkg1-v5.5.5) (1983-10-10)
 
 
 ### ⚠ BREAKING CHANGES
@@ -632,7 +750,27 @@ filename: node/pkg1/HISTORY.md
 filename: node/pkg1/package.json
 {
   "name": "@node/pkg1",
-  "version": "0.2.0"
+  "version": "5.5.5"
+}
+
+filename: node/pkg2/CHANGELOG.md
+# Changelog
+
+## [0.3.0](https://www.github.com/fake/repo/compare/pkg2-v0.2.2...pkg2-v0.3.0) (1983-10-10)
+
+
+### ⚠ BREAKING CHANGES
+
+* **@node/pkg2:** node2 feature
+
+### Default Features Section
+
+* **@node/pkg2:** node2 feature ([f3373c7](https://www.github.com/fake/repo/commit/f3373c71ffaf1a67b19ce6a116e861ea))
+
+filename: node/pkg2/package.json
+{
+  "name": "@node/pkg2",
+  "version": "0.3.0"
 }
 
 filename: python/CHANGELOG.md
@@ -665,7 +803,8 @@ __version__ = "1.0.0"
 
 filename: .release-please-manifest.json
 {
-  "node/pkg1": "0.2.0",
+  "node/pkg1": "5.5.5",
+  "node/pkg2": "0.3.0",
   "python": "1.0.0"
 }
 
@@ -680,8 +819,8 @@ branch: release-please/branches/main
 description: :robot: I have created a release \\*beep\\* \\*boop\\*
 
 ---
-@node/pkg1: 0.2.0
-## [0.2.0](https://www.github.com/fake/repo/compare/pkg1-v0.1.1...pkg1-v0.2.0) (1983-10-10)
+@node/pkg1: 5.5.5
+### [5.5.5](https://www.github.com/fake/repo/compare/pkg1-v0.1.1...pkg1-v5.5.5) (1983-10-10)
 
 
 ### ⚠ BREAKING CHANGES
@@ -691,6 +830,21 @@ description: :robot: I have created a release \\*beep\\* \\*boop\\*
 ### Default Features Section
 
 * **@node/pkg1:** node feature ([8ef6b52](https://www.github.com/fake/repo/commit/8ef6b521e268395ded9b66bb1ff89696))
+---
+
+
+---
+@node/pkg2: 0.3.0
+## [0.3.0](https://www.github.com/fake/repo/compare/pkg2-v0.2.2...pkg2-v0.3.0) (1983-10-10)
+
+
+### ⚠ BREAKING CHANGES
+
+* **@node/pkg2:** node2 feature
+
+### Default Features Section
+
+* **@node/pkg2:** node2 feature ([f3373c7](https://www.github.com/fake/repo/commit/f3373c71ffaf1a67b19ce6a116e861ea))
 ---
 
 


### PR DESCRIPTION
Two new manifest config options:
1. bootstrap-sha: optional top-level only
  - The first time `manifest-pr` is run against a repo (or setup for
  the first time on a new `--default-branch`), it will not find a
  previously merged PR as the starting point to collect commits for
  determine the next release/changelog. The default behavior is to
  iteravily traverse back to the very first commit of the repo. This
  option provides an arbitrary place to start. Once at least one release
  PR has been merged in the history of the `--default-branch`, this
  option is ignored.
2. release-as: optional per package and top-level default
  - manually set the next release version for a package. This will not
  force a release (there still must be user facing commits since the
  last realease). Per-package release-as overrides any top level
  release-as setting. If there is a top-level release-as configured but
  you'd like some packages to auto-increment you can set their
  per-package release-as to an empty string to override the default
  value.