### PR TITLE
feat(manifest): factory/cli integration

### DIFF
--- a/src/bin/release-please.ts
+++ b/src/bin/release-please.ts
@@ -19,7 +19,11 @@ import {coerceOption} from '../util/coerce-option';
 import {factory} from '../factory';
 import {getReleaserTypes, ReleaseType} from '../releasers';
 import * as yargs from 'yargs';
-import {GitHubReleaseFactoryOptions, ReleasePRFactoryOptions} from '..';
+import {
+  GitHubReleaseFactoryOptions,
+  ReleasePRFactoryOptions,
+  ManifestFactoryOptions,
+} from '..';
 import {GH_API_URL} from '../constants';
 
 interface ErrorObject {
@@ -52,7 +56,38 @@ function releaseType(ya: YargsOptionsBuilder, defaultType?: string) {
   ya.option('release-type', relTypeOptions);
 }
 
+function manifestOptions(ya: YargsOptionsBuilder) {
+  ya.option('config-file', {
+    default: 'release-please-config.json',
+    describe: 'where can the config file be found in the project?',
+  });
+  ya.option('manifest-file', {
+    default: '.release-please-manifest.json',
+    describe: 'where can the manifest file be found in the project?',
+  });
+}
+
 export const parser = yargs
+  .command(
+    'manifest-pr',
+    'create a release-PR using a manifest file',
+    (yargs: YargsOptionsBuilder) => {
+      manifestOptions(yargs);
+    },
+    (argv: ManifestFactoryOptions) => {
+      factory.runCommand('manifest-pr', argv).catch(handleError);
+    }
+  )
+  .command(
+    'manifest-release',
+    'create releases/tags from last release-PR using a manifest file',
+    (yargs: YargsOptionsBuilder) => {
+      manifestOptions(yargs);
+    },
+    (argv: ManifestFactoryOptions) => {
+      factory.runCommand('manifest-release', argv).catch(handleError);
+    }
+  )
   .command(
     'release-pr',
     'create or update a PR representing the next release',

--- a/src/manifest.ts
+++ b/src/manifest.ts
@@ -82,6 +82,10 @@ interface PackageWithPRData {
 
 type ManifestJson = Record<string, string>;
 
+export type ManifestGitHubReleaseResult =
+  | Record<string, GitHubReleaseResponse | undefined>
+  | undefined;
+
 export class Manifest {
   gh: GitHub;
   configFileName: string;
@@ -545,9 +549,7 @@ export class Manifest {
     return pr;
   }
 
-  async githubRelease(): Promise<
-    Record<string, GitHubReleaseResponse | undefined> | undefined
-  > {
+  async githubRelease(): Promise<ManifestGitHubReleaseResult> {
     const valid = await this.validate();
     if (!valid) {
       return;

--- a/test/cli.ts
+++ b/test/cli.ts
@@ -87,17 +87,8 @@ describe('CLI', () => {
       ]);
     });
     it('needs yargs', () => {
-      let err: Error;
-      let caught = false;
       handleError.yargsArgs = undefined;
-      try {
-        handleError({message: '', stack: ''});
-      } catch (e) {
-        err = e;
-        caught = true;
-      }
-      expect(caught).to.be.true;
-      expect(err!.message).to.equal(
+      expect(() => handleError({message: '', stack: ''})).to.throw(
         'Set handleError.yargsArgs with a yargs.Arguments instance.'
       );
     });

--- a/test/cli.ts
+++ b/test/cli.ts
@@ -16,12 +16,14 @@ import * as assert from 'assert';
 import {expect} from 'chai';
 import {
   factory,
-  ReleasePRRunResult,
-  RunResult,
+  ReleasePRCallResult,
+  CallResult,
   ReleasePRMethod,
-  GitHubReleaseRunResult,
+  GitHubReleaseCallResult,
   Method,
   GitHubReleaseMethod,
+  ManifestMethod,
+  ManifestCallResult,
 } from '../src/factory';
 import {GitHubRelease} from '../src/github-release';
 import {ReleasePR} from '../src/release-pr';
@@ -31,24 +33,31 @@ import * as sinon from 'sinon';
 import {parser, handleError} from '../src/bin/release-please';
 import {ParseCallback} from 'yargs';
 import chalk = require('chalk');
+import {Manifest} from '../src/manifest';
 
 const sandbox = sinon.createSandbox();
 
-let instanceToRun: ReleasePR | GitHubRelease;
+let instanceToRun: Manifest | ReleasePR | GitHubRelease;
+let methodCalled: Method;
 
+function callStub(
+  instance: Manifest,
+  method: ManifestMethod
+): ManifestCallResult;
 function callStub(
   instance: ReleasePR,
   method: ReleasePRMethod
-): ReleasePRRunResult;
+): ReleasePRCallResult;
 function callStub(
   instance: GitHubRelease,
   method: GitHubReleaseMethod
-): GitHubReleaseRunResult;
+): GitHubReleaseCallResult;
 function callStub(
-  instance: ReleasePR | GitHubRelease,
-  _method: Method
-): RunResult {
+  instance: Manifest | ReleasePR | GitHubRelease,
+  method: Method
+): CallResult {
   instanceToRun = instance;
+  methodCalled = method;
   return Promise.resolve(undefined);
 }
 
@@ -93,6 +102,42 @@ describe('CLI', () => {
       );
     });
   });
+  describe('manifest', () => {
+    for (const [cmd, mtd] of [
+      ['manifest-pr', 'pullRequest'],
+      ['manifest-release', 'githubRelease'],
+    ]) {
+      it(`instantiates Manifest for ${cmd}/${mtd}`, () => {
+        sandbox.replace(factory, 'call', callStub);
+        parser.parse(`${cmd} --repo-url=googleapis/release-please-cli`);
+        assert.strictEqual(methodCalled, mtd);
+        assert.ok(instanceToRun! instanceof Manifest);
+        assert.strictEqual(instanceToRun.gh.owner, 'googleapis');
+        assert.strictEqual(instanceToRun.gh.repo, 'release-please-cli');
+        assert.strictEqual(
+          instanceToRun.configFileName,
+          'release-please-config.json'
+        );
+        assert.strictEqual(
+          instanceToRun.manifestFileName,
+          '.release-please-manifest.json'
+        );
+      });
+      it(`instantiates Manifest for ${cmd}/${mtd} config/manifest`, () => {
+        sandbox.replace(factory, 'call', callStub);
+        parser.parse(
+          `${cmd} --repo-url=googleapis/release-please-cli ` +
+            '--config-file=foo.json --manifest-file=.bar.json'
+        );
+        assert.strictEqual(methodCalled, mtd);
+        assert.ok(instanceToRun! instanceof Manifest);
+        assert.strictEqual(instanceToRun.gh.owner, 'googleapis');
+        assert.strictEqual(instanceToRun.gh.repo, 'release-please-cli');
+        assert.strictEqual(instanceToRun.configFileName, 'foo.json');
+        assert.strictEqual(instanceToRun.manifestFileName, '.bar.json');
+      });
+    }
+  });
   describe('release-pr', () => {
     it('instantiates release PR based on command line arguments', () => {
       sandbox.replace(factory, 'call', callStub);
@@ -102,6 +147,7 @@ describe('CLI', () => {
           '--package-name=cli-package ' +
           "--pull-request-title-pattern='chore${scope}: release${component} ${version}'"
       );
+      assert.strictEqual(methodCalled, 'run');
       assert.ok(instanceToRun! instanceof ReleasePR);
       assert.strictEqual(instanceToRun.gh.owner, 'googleapis');
       assert.strictEqual(instanceToRun.gh.repo, 'release-please-cli');
@@ -157,6 +203,7 @@ describe('CLI', () => {
       parser.parse(
         'latest-tag --repo-url=googleapis/release-please-cli --package-name=cli-package'
       );
+      assert.strictEqual(methodCalled, 'latestTag');
       assert.ok(instanceToRun! instanceof ReleasePR);
       assert.strictEqual(instanceToRun.gh.owner, 'googleapis');
       assert.strictEqual(instanceToRun.gh.repo, 'release-please-cli');
@@ -175,6 +222,7 @@ describe('CLI', () => {
         '--release-type=node ' +
         `--package-name=${pkgName}`;
       parser.parse(cmd);
+      assert.strictEqual(methodCalled, 'run');
       assert.ok(instanceToRun! instanceof GitHubRelease);
       assert.strictEqual(instanceToRun.gh.owner, 'googleapis');
       assert.strictEqual(instanceToRun.gh.repo, 'release-please-cli');
@@ -197,6 +245,7 @@ describe('CLI', () => {
       sandbox.replace(factory, 'call', callStub);
       const cmd = 'github-release --repo-url=googleapis/release-please-cli ';
       parser.parse(cmd);
+      assert.strictEqual(methodCalled, 'run');
       assert.ok(instanceToRun! instanceof GitHubRelease);
       assert.strictEqual(instanceToRun.releasePR.constructor.name, 'ReleasePR');
       assert.strictEqual(

--- a/test/commit-split.ts
+++ b/test/commit-split.ts
@@ -219,13 +219,7 @@ describe('CommitSplit', () => {
   ];
   for (const invalid of invalidPaths) {
     it(`validates configured paths: ${invalid}`, () => {
-      let caught = false;
-      try {
-        new CommitSplit({packagePaths: invalid});
-      } catch (e) {
-        caught = true;
-      }
-      expect(caught).to.be.true;
+      expect(() => new CommitSplit({packagePaths: invalid})).to.throw();
     });
   }
 });


### PR DESCRIPTION
This PR finally connects `Manifest` class commands to the cli:

1. `Manifest.pullRequest()` - `manifest-pr`
2. `Manifest.githubRelease()` - `manifest-release`

the only cli flags available are
a) the base set used for a `GitHub` instance (like `--repo-url`, `--default-branch` etc) and
b) `--config` and `--manifest` to override the respective default locations of `release-please-config.json` and `.release-please-manifest.json`
