### PR TITLE
refactor(github): get files from commits w/out PRs

### DIFF
--- a/src/github.ts
+++ b/src/github.ts
@@ -17,6 +17,7 @@ import {createPullRequest, Changes} from 'code-suggester';
 import {Octokit} from '@octokit/rest';
 import {request} from '@octokit/request';
 import {graphql} from '@octokit/graphql';
+import {Endpoints} from '@octokit/types';
 // The return types for responses have not yet been exposed in the
 // @octokit/* libraries, we explicitly define the types below to work
 // around this,. See: https://github.com/octokit/rest.js/issues/1624
@@ -45,6 +46,8 @@ type CreateIssueCommentResponse = PromiseValue<
 // see: PromiseValue<
 //  ReturnType<InstanceType<typeof Octokit>['repos']['createRelease']>
 // >['data'];
+type CommitsListResponse = Endpoints['GET /repos/{owner}/{repo}/commits']['response'];
+type CommitGetResponse = Endpoints['GET /repos/{owner}/{repo}/commits/{ref}']['response'];
 export type ReleaseCreateResponse = {
   name: string;
   tag_name: string;
@@ -279,6 +282,67 @@ export class GitHub {
         },
       });
     }
+  }
+
+  async commitsSinceShaRest(
+    sha?: string,
+    path?: string,
+    per_page = 100
+  ): Promise<Commit[]> {
+    let page = 1;
+    let found = false;
+    const baseBranch = await this.getDefaultBranch();
+    const commits = [];
+    while (!found) {
+      const response = await this.request(
+        'GET /repos/{owner}/{repo}/commits{?sha,page,per_page,path}',
+        {
+          owner: this.owner,
+          repo: this.repo,
+          sha: baseBranch,
+          page,
+          per_page,
+          path,
+        }
+      );
+      for (const commit of (response as CommitsListResponse).data) {
+        if (commit.sha === sha) {
+          found = true;
+          break;
+        }
+        // skip merge commits
+        if (commit.parents.length === 2) {
+          continue;
+        }
+        commits.push([commit.sha, commit.commit.message]);
+      }
+      page++;
+    }
+    const ret = [];
+    for (const [ref, message] of commits) {
+      const files = [];
+      let page = 1;
+      let moreFiles = true;
+      while (moreFiles) {
+        const response = (await this.request(
+          'GET /repos/{owner}/{repo}/commits/{ref}{?page}',
+          {owner: this.owner, repo: this.repo, ref, page}
+        )) as CommitGetResponse;
+        const commitFiles = response.data.files;
+        if (!commitFiles) {
+          moreFiles = false;
+          break;
+        }
+        files.push(...commitFiles.map(f => f.filename ?? ''));
+        if (commitFiles.length < 300) {
+          moreFiles = false;
+          break;
+        }
+        page++;
+      }
+      ret.push({sha: ref, message, files});
+    }
+    return ret;
   }
 
   // Commit.files only for commits from PRs.

--- a/src/manifest.ts
+++ b/src/manifest.ts
@@ -504,7 +504,7 @@ export class Manifest {
     if (fromSha === undefined) {
       fromSha = (await this.getConfigJson())['bootstrap-sha'];
     }
-    return this.gh.commitsSinceSha(fromSha);
+    return this.gh.commitsSinceShaRest(fromSha);
   }
 
   async pullRequest(): Promise<number | undefined> {

--- a/test/manifest.ts
+++ b/test/manifest.ts
@@ -101,12 +101,12 @@ describe('Manifest', () => {
     const {commits, lastReleaseSha} = params ?? {};
     if (commits) {
       mock
-        .expects('commitsSinceSha')
+        .expects('commitsSinceShaRest')
         .once()
         .withExactArgs(lastReleaseSha)
         .resolves(commits);
     } else {
-      mock.expects('commitsSinceSha').never();
+      mock.expects('commitsSinceShaRest').never();
     }
   }
 
@@ -761,8 +761,8 @@ describe('Manifest', () => {
       expectManifest(mock);
       expectPR(mock);
       // lastReleaseSha is undefined and no bootstrap-sha so we expect
-      // gh.commitsSinceSha to be called with undefined meaning go all the way
-      // back.
+      // gh.commitsSinceShaRest to be called with `undefined` meaning go all
+      // the way back to the first commit.
       expectCommitsSinceSha(mock, {commits});
       expectGetFiles(mock, {
         fixtureFiles: [


### PR DESCRIPTION
commitsSinceShaRest queries the REST API to get files associated directly
with a history of commits. This solves the problem that commitsWithFiles
has with processing a multi-commit PR: it ends up assigning all the
files for the PR to every commit in the PR.

I have not tested it but I think it could replace commitsWithFiles (
but not commitsWithLabels since there are no PRs as part of this query).
