### PR TITLE
feat(manifest): add support for releasing root module

### DIFF
--- a/__snapshots__/manifest.js
+++ b/__snapshots__/manifest.js
@@ -1,3 +1,134 @@
+exports['Manifest pullRequest allows root module to be published, via special "." path: changes'] = `
+
+filename: node/pkg1/CHANGELOG.md
+# Changelog
+
+## [4.0.0](https://www.github.com/fake/repo/compare/pkg1-v3.2.1...pkg1-v4.0.0) (1983-10-10)
+
+
+### ⚠ BREAKING CHANGES
+
+* **@node/pkg1:** major new feature
+
+### Features
+
+* **@node/pkg1:** major new feature ([e3ab0ab](https://www.github.com/fake/repo/commit/e3ab0abfd66e66324f685ceeececf35c))
+
+filename: node/pkg1/package.json
+{
+  "name": "@node/pkg1",
+  "version": "4.0.0"
+}
+
+filename: node/pkg2/CHANGELOG.md
+# Changelog
+
+## [2.0.0](https://www.github.com/fake/repo/compare/pkg2-v1.2.3...pkg2-v2.0.0) (1983-10-10)
+
+
+### ⚠ BREAKING CHANGES
+
+* **@node/pkg2:** major new feature
+
+### Features
+
+* **@node/pkg2:** major new feature ([72f962d](https://www.github.com/fake/repo/commit/72f962d44ba0bcee15594ea6bdc67d8b))
+
+filename: node/pkg2/package.json
+{
+  "name": "@node/pkg2",
+  "version": "2.0.0"
+}
+
+filename: CHANGELOG.md
+# Changelog
+
+## [3.0.0](https://www.github.com/fake/repo/compare/googleapis-v2.0.0...googleapis-v3.0.0) (1983-10-10)
+
+
+### ⚠ BREAKING CHANGES
+
+* **@node/pkg2:** major new feature
+
+### Features
+
+* **@node/pkg2:** major new feature ([72f962d](https://www.github.com/fake/repo/commit/72f962d44ba0bcee15594ea6bdc67d8b))
+
+filename: package.json
+{
+  "name": "googleapis",
+  "version": "3.0.0"
+}
+
+filename: .release-please-manifest.json
+{
+  ".": "3.0.0",
+  "node/pkg1": "4.0.0",
+  "node/pkg2": "2.0.0"
+}
+
+`
+
+exports['Manifest pullRequest allows root module to be published, via special "." path: options'] = `
+
+upstreamOwner: fake
+upstreamRepo: repo
+title: chore: release
+branch: release-please/branches/main
+description: :robot: I have created a release \\*beep\\* \\*boop\\*
+
+---
+@node/pkg1: 4.0.0
+## [4.0.0](https://www.github.com/fake/repo/compare/pkg1-v3.2.1...pkg1-v4.0.0) (1983-10-10)
+
+
+### ⚠ BREAKING CHANGES
+
+* **@node/pkg1:** major new feature
+
+### Features
+
+* **@node/pkg1:** major new feature ([e3ab0ab](https://www.github.com/fake/repo/commit/e3ab0abfd66e66324f685ceeececf35c))
+---
+
+
+---
+@node/pkg2: 2.0.0
+## [2.0.0](https://www.github.com/fake/repo/compare/pkg2-v1.2.3...pkg2-v2.0.0) (1983-10-10)
+
+
+### ⚠ BREAKING CHANGES
+
+* **@node/pkg2:** major new feature
+
+### Features
+
+* **@node/pkg2:** major new feature ([72f962d](https://www.github.com/fake/repo/commit/72f962d44ba0bcee15594ea6bdc67d8b))
+---
+
+
+---
+googleapis: 3.0.0
+## [3.0.0](https://www.github.com/fake/repo/compare/googleapis-v2.0.0...googleapis-v3.0.0) (1983-10-10)
+
+
+### ⚠ BREAKING CHANGES
+
+* **@node/pkg2:** major new feature
+
+### Features
+
+* **@node/pkg2:** major new feature ([72f962d](https://www.github.com/fake/repo/commit/72f962d44ba0bcee15594ea6bdc67d8b))
+---
+
+
+This PR was generated with [Release Please](https://github.com/googleapis/release-please). See [documentation](https://github.com/googleapis/release-please#release-please).
+primary: main
+force: true
+fork: false
+message: chore: release
+`
+
 exports['Manifest pullRequest boostraps from HEAD manifest if first PR: changes'] = `
 
 filename: node/pkg1/CHANGELOG.md

--- a/__snapshots__/manifest.js
+++ b/__snapshots__/manifest.js
@@ -48,10 +48,12 @@ filename: CHANGELOG.md
 
 ### ⚠ BREAKING CHANGES
 
+* **@node/pkg1:** major new feature
 * **@node/pkg2:** major new feature
 
 ### Features
 
+* **@node/pkg1:** major new feature ([e3ab0ab](https://www.github.com/fake/repo/commit/e3ab0abfd66e66324f685ceeececf35c))
 * **@node/pkg2:** major new feature ([72f962d](https://www.github.com/fake/repo/commit/72f962d44ba0bcee15594ea6bdc67d8b))
 
 filename: package.json
@@ -114,10 +116,12 @@ googleapis: 3.0.0
 
 ### ⚠ BREAKING CHANGES
 
+* **@node/pkg1:** major new feature
 * **@node/pkg2:** major new feature
 
 ### Features
 
+* **@node/pkg1:** major new feature ([e3ab0ab](https://www.github.com/fake/repo/commit/e3ab0abfd66e66324f685ceeececf35c))
 * **@node/pkg2:** major new feature ([72f962d](https://www.github.com/fake/repo/commit/72f962d44ba0bcee15594ea6bdc67d8b))
 ---
 

--- a/__snapshots__/manifest.js
+++ b/__snapshots__/manifest.js
@@ -56,6 +56,11 @@ filename: CHANGELOG.md
 * **@node/pkg1:** major new feature ([e3ab0ab](https://www.github.com/fake/repo/commit/e3ab0abfd66e66324f685ceeececf35c))
 * **@node/pkg2:** major new feature ([72f962d](https://www.github.com/fake/repo/commit/72f962d44ba0bcee15594ea6bdc67d8b))
 
+
+### Bug Fixes
+
+* **root:** root only change ([8b55db3](https://www.github.com/fake/repo/commit/8b55db3f6115306cc9c132bec0bb1447))
+
 filename: package.json
 {
   "name": "googleapis",
@@ -123,6 +128,11 @@ googleapis: 3.0.0
 
 * **@node/pkg1:** major new feature ([e3ab0ab](https://www.github.com/fake/repo/commit/e3ab0abfd66e66324f685ceeececf35c))
 * **@node/pkg2:** major new feature ([72f962d](https://www.github.com/fake/repo/commit/72f962d44ba0bcee15594ea6bdc67d8b))
+
+
+### Bug Fixes
+
+* **root:** root only change ([8b55db3](https://www.github.com/fake/repo/commit/8b55db3f6115306cc9c132bec0bb1447))
 ---
 
 

--- a/docs/manifest-releaser.md
+++ b/docs/manifest-releaser.md
@@ -233,3 +233,15 @@ PRs merge w/out running it). If successful it will remove the
 `"autorelease: pending"` label and adds the `"autorelease: tagged"` label.
 Creating all the releases is not transactional. If any fail to create the
 command can be re-run safely to finish creating releases.
+
+### Releasing Root Path of Library (".")
+
+One use-case that arose for [googleapis](https://github.com/googleapis/google-api-nodejs-client), was the need to publish individual libraries along
+with a combined version of the library, i.e.,
+
+* an individual library for `@googleapis/youtube`, `@googleapis/sheets`, etc.
+* a root library that combined all these API surfaces.
+
+This functionality can be achieved by using the special `"."` path.
+`"."` indicates a release should be created when any changes are made to the
+codebase.

--- a/src/manifest.ts
+++ b/src/manifest.ts
@@ -279,7 +279,7 @@ export class Manifest {
   }
 
   protected async getPackagesToRelease(
-    commits: Commit[],
+    allCommits: Commit[],
     sha?: string
   ): Promise<PackageReleaseData[]> {
     const packages = (await this.getConfigJson()).parsedPackages;
@@ -288,14 +288,14 @@ export class Manifest {
       includeEmpty: true,
       packagePaths: packages.map(p => p.path),
     });
-    const commitsPerPath = cs.split(commits);
+    const commitsPerPath = cs.split(allCommits);
     const packagesToRelease: Record<string, PackageReleaseData> = {};
     const missingVersionPaths = [];
     const defaultBranch = await this.gh.getDefaultBranch();
     for (const pkg of packages) {
       // The special path of '.' indicates the root module is being released
       // in this case, use the entire list of commits:
-      commits = pkg.path === '.' ? commits : commitsPerPath[pkg.path];
+      const commits = pkg.path === '.' ? allCommits : commitsPerPath[pkg.path];
       if (!commits || commits.length === 0) {
         continue;
       }

--- a/src/manifest.ts
+++ b/src/manifest.ts
@@ -293,7 +293,9 @@ export class Manifest {
     const missingVersionPaths = [];
     const defaultBranch = await this.gh.getDefaultBranch();
     for (const pkg of packages) {
-      const commits = commitsPerPath[pkg.path];
+      // The special path of '.' indicates the root module is being released
+      // in this case, use the entire list of commits:
+      commits = pkg.path === '.' ? commits : commitsPerPath[pkg.path];
       if (!commits || commits.length === 0) {
         continue;
       }

--- a/src/release-pr.ts
+++ b/src/release-pr.ts
@@ -87,7 +87,9 @@ export class ReleasePR {
   constructor(options: ReleasePRConstructorOptions) {
     this.bumpMinorPreMajor = options.bumpMinorPreMajor || false;
     this.labels = options.labels ?? DEFAULT_LABELS;
-    this.path = options.path;
+    // undefined represents the root path of the library, if the special
+    // '.' path is provided, simply ignore it:
+    this.path = options.path !== '.' ? options.path : undefined;
     this.packageName = options.packageName || '';
     this.monorepoTags = options.monorepoTags || false;
     this.releaseAs = options.releaseAs;

--- a/test/fixtures/manifest/repo/package.json
+++ b/test/fixtures/manifest/repo/package.json
@@ -1,0 +1,4 @@
+{
+  "name": "googleapis",
+  "version": "3.3.3"
+}

--- a/test/manifest.ts
+++ b/test/manifest.ts
@@ -1898,7 +1898,7 @@ describe('Manifest', () => {
           draft: false,
           body: '',
           sha: 'abc123',
-          html_url: 'https://pkg1@3.2.1:html',
+          html_url: 'https://googleapis@3.2.1:html',
           tag_name: 'googleapis-v3.2.1',
           name: 'googleapis googleapis-v3.2.1',
           upload_url: 'https://googleapis@3.2.1:upload',

--- a/test/manifest.ts
+++ b/test/manifest.ts
@@ -306,6 +306,7 @@ describe('Manifest', () => {
         buildMockCommit('feat(@node/pkg2)!: major new feature', [
           'node/pkg2/src/bar.ts',
         ]),
+        buildMockCommit('fix(root): root only change', ['src/foo.ts']),
       ];
 
       const github = new GitHub({

--- a/test/manifest.ts
+++ b/test/manifest.ts
@@ -1882,8 +1882,8 @@ describe('Manifest', () => {
           tag_name: 'googleapis-v3.2.1',
           draft: false,
           body: '',
-          html_url: 'https://pkg1@3.2.1:html',
-          upload_url: 'https://pkg1@3.2.1:upload',
+          html_url: 'https://googleapis@3.2.1:html',
+          upload_url: 'https://googleapis@3.2.1:upload',
         });
 
       const releases = await new Manifest({github}).githubRelease();

--- a/test/manifest.ts
+++ b/test/manifest.ts
@@ -1901,7 +1901,7 @@ describe('Manifest', () => {
           html_url: 'https://pkg1@3.2.1:html',
           tag_name: 'googleapis-v3.2.1',
           name: 'googleapis googleapis-v3.2.1',
-          upload_url: 'https://pkg1@3.2.1:upload',
+          upload_url: 'https://googleapis@3.2.1:upload',
         },
       });
     });

--- a/test/manifest.ts
+++ b/test/manifest.ts
@@ -1864,7 +1864,7 @@ describe('Manifest', () => {
         addLabel: 'autorelease: tagged',
         removeLabel: 'autorelease: pending',
         prComments: [
-          ':robot: Release for googleapis is at https://pkg1@3.2.1:html :sunflower:',
+          ':robot: Release for googleapis is at https://googleapis@3.2.1:html :sunflower:',
         ],
       });
       mock


### PR DESCRIPTION
Add support for a special "." path which indicates that a root module should be released.

This is for the [googleapis use-case](https://github.com/googleapis/google-api-nodejs-client/pull/2559).

CC: @joeldodge79 