### PR TITLE
refactor(manifest): typing cleanup

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -30,12 +30,12 @@ interface GitHubOptions {
 }
 
 // Used by GitHubRelease: Factory and Constructor
-interface GitHubReleaseOptions {
+export interface GitHubReleaseOptions {
   draft?: boolean;
 }
 
 // Used by ReleasePR: Factory and Constructor
-interface ReleasePROptions {
+export interface ReleasePROptions {
   path?: string;
   packageName?: string;
   bumpMinorPreMajor?: boolean;

--- a/test/manifest.ts
+++ b/test/manifest.ts
@@ -1085,7 +1085,7 @@ describe('Manifest', () => {
           python: {
             'release-type': 'python',
             'package-name': 'foolib',
-            'release-draft': true,
+            draft: true,
           },
         },
       });


### PR DESCRIPTION
- `Package` type is really a limited collection of ReleasePROptions and
  GitHubReleaseOptions.
- Renamed some internal interfaces used to join package config to
  commit/last-version data for ReleasePR instances (`PackageForReleaser`)
  and to data for opening a pr (`PackageWithPRData`)
- DRYed out code to instantiate a ReleasePR instance
- reverted `"release-draft"` config option to the original
  GitHubReleaseFactoryOptions.draft to remove option parsing complexity:
  if we ever need to support a "draft PR" then we'll make sure to
  namespace that config option appropriately (e.g. `"draft-pr"`)