### PR TITLE
fix(manifest): split commits on exact package path prefix

### DIFF
--- a/src/commit-split.ts
+++ b/src/commit-split.ts
@@ -49,6 +49,11 @@ export class CommitSplit {
     if (opts.packagePaths) {
       const paths: string[] = [];
       for (let newPath of opts.packagePaths) {
+        // The special "." path, representing the root of the module, should be
+        // ignored by commit-split as it is assigned all commits in manifest.ts
+        if (newPath === '.') {
+          continue;
+        }
         // normalize so that all paths have leading and trailing slashes for
         // non-overlap validation.
         // NOTE: GitHub API always returns paths using the `/` separator,
@@ -91,11 +96,7 @@ export class CommitSplit {
         let pkgName;
         if (this.packagePaths) {
           // only track paths under this.packagePaths
-          pkgName = this.packagePaths.find(p => {
-            // The special "." path, representing the root of the module
-            // should be ignored by commit-split:
-            return file.indexOf(p) >= 0 && p !== '.';
-          });
+          pkgName = this.packagePaths.find(p => file.indexOf(p) === 0);
         } else {
           // track paths by top level folder
           pkgName = splitPath[0];

--- a/test/commit-split.ts
+++ b/test/commit-split.ts
@@ -196,7 +196,7 @@ describe('CommitSplit', () => {
         'foo/bar-baz',
       ],
     });
-    expect(cs.packagePaths).to.be.eql([
+    expect(cs.packagePaths).to.eql([
       'two-three',
       'one-two',
       'three',
@@ -205,6 +205,31 @@ describe('CommitSplit', () => {
       'foo/bar',
       'foo/bar-baz',
     ]);
+  });
+
+  it('ignore the "." package', () => {
+    const foo = buildMockCommit('fix(foo): fix foo', ['foo/foo.ts']);
+    const topLevel = buildMockCommit('fix: fix top level', ['bar.ts']);
+    const topAndFoo = buildMockCommit('fix: foo and top level', [
+      'foo/foo.ts',
+      'bar.ts',
+    ]);
+    const commits = [foo, topLevel, topAndFoo];
+    const cs = new CommitSplit({packagePaths: ['foo', '.']});
+    expect(cs.packagePaths).to.eql(['foo']);
+    const actualSplitCommits = cs.split(commits);
+    expect(actualSplitCommits).to.eql({foo: [foo, topAndFoo]});
+  });
+
+  it('package path exact start match', () => {
+    const foo = buildMockCommit('fix(foo): fix foo', ['foo/foo.ts']);
+    const notFoo = buildMockCommit('fix(not-foo): fix not foo', [
+      'not/foo/bar.ts',
+    ]);
+    const commits = [foo, notFoo];
+    const cs = new CommitSplit({packagePaths: ['foo']});
+    const actualSplitCommits = cs.split(commits);
+    expect(actualSplitCommits).to.eql({foo: [foo]});
   });
 
   // Test invalid CommitSplitOptions.packagePaths combinations.


### PR DESCRIPTION
prior to this change commits touching both the following files would be
attributed to the "foo" package:
- foo/bar.ts
- some/sub/dir/foo/another.ts

also moved the '.' package path skipping into the constructor