### PR TITLE
feat: allow "standard" pre-1.0.0 patch bumps

### DIFF
--- a/__snapshots__/cli.js
+++ b/__snapshots__/cli.js
@@ -4,45 +4,51 @@ cli.js github-release
 create a GitHub release from a release PR
 
 Options:
-  --help                        Show help                              [boolean]
-  --version                     Show version number                    [boolean]
-  --debug                       print verbose errors (use only for local
-                                debugging).           [boolean] [default: false]
-  --token                       GitHub token with repo write permissions
-  --api-url                     URL to use when making API requests
+  --help                            Show help                          [boolean]
+  --version                         Show version number                [boolean]
+  --debug                           print verbose errors (use only for local
+                                    debugging).       [boolean] [default: false]
+  --token                           GitHub token with repo write permissions
+  --api-url                         URL to use when making API requests
                                     [string] [default: "https://api.github.com"]
-  --default-branch              The branch to open release PRs against and tag
-                                releases on                             [string]
-  --fork                        should the PR be created from a fork
+  --default-branch                  The branch to open release PRs against and
+                                    tag releases on                     [string]
+  --fork                            should the PR be created from a fork
                                                       [boolean] [default: false]
-  --repo-url                    GitHub URL to generate release for    [required]
-  --release-type                what type of repo is a release being created
-                                for?
+  --repo-url                        GitHub URL to generate release for[required]
+  --release-type                    what type of repo is a release being created
+                                    for?
        [choices: "go", "go-yoshi", "java-bom", "java-lts", "java-yoshi", "node",
          "ocaml", "php-yoshi", "python", "ruby", "ruby-yoshi", "rust", "simple",
                                                      "terraform-module", "helm"]
-  --label                       label to remove from release PR
+  --label                           label to remove from release PR
                                                [default: "autorelease: pending"]
-  --release-as                  override the semantically determined release
-                                version                                 [string]
-  --bump-minor-pre-major        should we bump the semver minor prior to the
-                                first major release   [boolean] [default: false]
-  --path                        release from path other than root directory
+  --release-as                      override the semantically determined release
+                                    version                             [string]
+  --bump-minor-pre-major            should we bump the semver minor prior to the
+                                    first major release
+                                                      [boolean] [default: false]
+  --bump-minor-for-patch-pre-major  should we bump the semver patch instead of
+                                    the minor for non-breaking changes prior to
+                                    the first major release
+                                                      [boolean] [default: false]
+  --path                            release from path other than root directory
                                                                         [string]
-  --package-name                name of package release is being minted for
-  --monorepo-tags               include library name in tags and release
-                                branches              [boolean] [default: false]
-  --version-file                path to version file to update, e.g., version.rb
-  --last-package-version        last version # that package was released as
-  --snapshot                    is it a snapshot (or pre-release) being
-                                generated?            [boolean] [default: false]
-  --pull-request-title-pattern  Title pattern to make release PR        [string]
-  --changelog-path              where can the CHANGELOG be found in the project?
-                                                       [default: "CHANGELOG.md"]
-  --draft                       mark release as a draft. no tag is created but
-                                tag_name and target_commitish are associated
-                                with the release for future tag creation upon
-                                "un-drafting" the release.
+  --package-name                    name of package release is being minted for
+  --monorepo-tags                   include library name in tags and release
+                                    branches          [boolean] [default: false]
+  --version-file                    path to version file to update, e.g.,
+                                    version.rb
+  --last-package-version            last version # that package was released as
+  --snapshot                        is it a snapshot (or pre-release) being
+                                    generated?        [boolean] [default: false]
+  --pull-request-title-pattern      Title pattern to make release PR    [string]
+  --changelog-path                  where can the CHANGELOG be found in the
+                                    project?           [default: "CHANGELOG.md"]
+  --draft                           mark release as a draft. no tag is created
+                                    but tag_name and target_commitish are
+                                    associated with the release for future tag
+                                    creation upon "un-drafting" the release.
                                                       [boolean] [default: false]
 `
 
@@ -52,41 +58,47 @@ cli.js latest-tag
 find the sha of the latest release
 
 Options:
-  --help                        Show help                              [boolean]
-  --version                     Show version number                    [boolean]
-  --debug                       print verbose errors (use only for local
-                                debugging).           [boolean] [default: false]
-  --token                       GitHub token with repo write permissions
-  --api-url                     URL to use when making API requests
+  --help                            Show help                          [boolean]
+  --version                         Show version number                [boolean]
+  --debug                           print verbose errors (use only for local
+                                    debugging).       [boolean] [default: false]
+  --token                           GitHub token with repo write permissions
+  --api-url                         URL to use when making API requests
                                     [string] [default: "https://api.github.com"]
-  --default-branch              The branch to open release PRs against and tag
-                                releases on                             [string]
-  --fork                        should the PR be created from a fork
+  --default-branch                  The branch to open release PRs against and
+                                    tag releases on                     [string]
+  --fork                            should the PR be created from a fork
                                                       [boolean] [default: false]
-  --repo-url                    GitHub URL to generate release for    [required]
-  --release-type                what type of repo is a release being created
-                                for?
+  --repo-url                        GitHub URL to generate release for[required]
+  --release-type                    what type of repo is a release being created
+                                    for?
        [choices: "go", "go-yoshi", "java-bom", "java-lts", "java-yoshi", "node",
          "ocaml", "php-yoshi", "python", "ruby", "ruby-yoshi", "rust", "simple",
                                    "terraform-module", "helm"] [default: "node"]
-  --label                       label to remove from release PR
+  --label                           label to remove from release PR
                                                [default: "autorelease: pending"]
-  --release-as                  override the semantically determined release
-                                version                                 [string]
-  --bump-minor-pre-major        should we bump the semver minor prior to the
-                                first major release   [boolean] [default: false]
-  --path                        release from path other than root directory
+  --release-as                      override the semantically determined release
+                                    version                             [string]
+  --bump-minor-pre-major            should we bump the semver minor prior to the
+                                    first major release
+                                                      [boolean] [default: false]
+  --bump-minor-for-patch-pre-major  should we bump the semver patch instead of
+                                    the minor for non-breaking changes prior to
+                                    the first major release
+                                                      [boolean] [default: false]
+  --path                            release from path other than root directory
                                                                         [string]
-  --package-name                name of package release is being minted for
-  --monorepo-tags               include library name in tags and release
-                                branches              [boolean] [default: false]
-  --version-file                path to version file to update, e.g., version.rb
-  --last-package-version        last version # that package was released as
-  --snapshot                    is it a snapshot (or pre-release) being
-                                generated?            [boolean] [default: false]
-  --pull-request-title-pattern  Title pattern to make release PR        [string]
-  --changelog-path              where can the CHANGELOG be found in the project?
-                                                       [default: "CHANGELOG.md"]
+  --package-name                    name of package release is being minted for
+  --monorepo-tags                   include library name in tags and release
+                                    branches          [boolean] [default: false]
+  --version-file                    path to version file to update, e.g.,
+                                    version.rb
+  --last-package-version            last version # that package was released as
+  --snapshot                        is it a snapshot (or pre-release) being
+                                    generated?        [boolean] [default: false]
+  --pull-request-title-pattern      Title pattern to make release PR    [string]
+  --changelog-path                  where can the CHANGELOG be found in the
+                                    project?           [default: "CHANGELOG.md"]
 `
 
 exports['CLI flags manifest-pr flags 1'] = `
@@ -143,39 +155,45 @@ cli.js release-pr
 create or update a PR representing the next release
 
 Options:
-  --help                        Show help                              [boolean]
-  --version                     Show version number                    [boolean]
-  --debug                       print verbose errors (use only for local
-                                debugging).           [boolean] [default: false]
-  --token                       GitHub token with repo write permissions
-  --api-url                     URL to use when making API requests
+  --help                            Show help                          [boolean]
+  --version                         Show version number                [boolean]
+  --debug                           print verbose errors (use only for local
+                                    debugging).       [boolean] [default: false]
+  --token                           GitHub token with repo write permissions
+  --api-url                         URL to use when making API requests
                                     [string] [default: "https://api.github.com"]
-  --default-branch              The branch to open release PRs against and tag
-                                releases on                             [string]
-  --fork                        should the PR be created from a fork
+  --default-branch                  The branch to open release PRs against and
+                                    tag releases on                     [string]
+  --fork                            should the PR be created from a fork
                                                       [boolean] [default: false]
-  --repo-url                    GitHub URL to generate release for    [required]
-  --release-type                what type of repo is a release being created
-                                for?
+  --repo-url                        GitHub URL to generate release for[required]
+  --release-type                    what type of repo is a release being created
+                                    for?
        [choices: "go", "go-yoshi", "java-bom", "java-lts", "java-yoshi", "node",
          "ocaml", "php-yoshi", "python", "ruby", "ruby-yoshi", "rust", "simple",
                                    "terraform-module", "helm"] [default: "node"]
-  --label                       label to remove from release PR
+  --label                           label to remove from release PR
                                                [default: "autorelease: pending"]
-  --release-as                  override the semantically determined release
-                                version                                 [string]
-  --bump-minor-pre-major        should we bump the semver minor prior to the
-                                first major release   [boolean] [default: false]
-  --path                        release from path other than root directory
+  --release-as                      override the semantically determined release
+                                    version                             [string]
+  --bump-minor-pre-major            should we bump the semver minor prior to the
+                                    first major release
+                                                      [boolean] [default: false]
+  --bump-minor-for-patch-pre-major  should we bump the semver patch instead of
+                                    the minor for non-breaking changes prior to
+                                    the first major release
+                                                      [boolean] [default: false]
+  --path                            release from path other than root directory
                                                                         [string]
-  --package-name                name of package release is being minted for
-  --monorepo-tags               include library name in tags and release
-                                branches              [boolean] [default: false]
-  --version-file                path to version file to update, e.g., version.rb
-  --last-package-version        last version # that package was released as
-  --snapshot                    is it a snapshot (or pre-release) being
-                                generated?            [boolean] [default: false]
-  --pull-request-title-pattern  Title pattern to make release PR        [string]
-  --changelog-path              where can the CHANGELOG be found in the project?
-                                                       [default: "CHANGELOG.md"]
+  --package-name                    name of package release is being minted for
+  --monorepo-tags                   include library name in tags and release
+                                    branches          [boolean] [default: false]
+  --version-file                    path to version file to update, e.g.,
+                                    version.rb
+  --last-package-version            last version # that package was released as
+  --snapshot                        is it a snapshot (or pre-release) being
+                                    generated?        [boolean] [default: false]
+  --pull-request-title-pattern      Title pattern to make release PR    [string]
+  --changelog-path                  where can the CHANGELOG be found in the
+                                    project?           [default: "CHANGELOG.md"]
 `

--- a/docs/manifest-releaser.md
+++ b/docs/manifest-releaser.md
@@ -119,6 +119,10 @@ documented in comments)
   // absence defaults to false
   "bump-minor-pre-major": true,
 
+  // feat commits bump semver patch instead of minor if version < 1.0.0
+  // absence defaults to false
+  "bump-patch-for-minor-pre-major": true,
+
   // set default conventional commit => changelog sections mapping/appearance.
   // absence defaults to https://git.io/JqCZL
   "changelog-sections": [...]

--- a/src/bin/release-please.ts
+++ b/src/bin/release-please.ts
@@ -61,6 +61,13 @@ function releaserCommon(ya: YargsOptionsBuilder) {
     default: false,
     type: 'boolean',
   });
+  ya.option('bump-minor-for-patch-pre-major', {
+    describe:
+      'should we bump the semver patch instead of the minor for non-breaking' +
+      ' changes prior to the first major release',
+    default: false,
+    type: 'boolean',
+  });
   ya.option('path', {
     describe: 'release from path other than root directory',
     type: 'string',

--- a/src/conventional-commits.ts
+++ b/src/conventional-commits.ts
@@ -40,6 +40,7 @@ interface ConventionalCommitsOptions {
   repository: string;
   host?: string;
   bumpMinorPreMajor?: boolean;
+  bumpPatchForMinorPreMajor?: boolean;
   // allow for customized commit template.
   commitPartial?: string;
   headerPartial?: string;
@@ -146,6 +147,7 @@ export class ConventionalCommits {
   owner: string;
   repository: string;
   bumpMinorPreMajor?: boolean;
+  bumpPatchForMinorPreMajor?: boolean;
 
   // allow for customized commit template.
   commitPartial?: string;
@@ -157,6 +159,7 @@ export class ConventionalCommits {
   constructor(options: ConventionalCommitsOptions) {
     this.commits = options.commits;
     this.bumpMinorPreMajor = options.bumpMinorPreMajor || false;
+    this.bumpPatchForMinorPreMajor = options.bumpPatchForMinorPreMajor || false;
     this.host = options.host || 'https://www.github.com';
     this.owner = options.owner;
     this.repository = options.repository;
@@ -237,9 +240,11 @@ export class ConventionalCommits {
 
     // we have slightly different logic than the default of conventional commits,
     // the minor should be bumped when features are introduced for pre 1.x.x libs:
+    // turn off custom logic here by setting bumpPatchForMinorPreMajor = true
     if (
       result.reason.indexOf(' 0 features') === -1 &&
-      result.releaseType === 'patch'
+      result.releaseType === 'patch' &&
+      !this.bumpPatchForMinorPreMajor
     ) {
       result.releaseType = 'minor';
     }

--- a/src/index.ts
+++ b/src/index.ts
@@ -39,6 +39,7 @@ export interface ReleasePROptions {
   path?: string;
   packageName?: string;
   bumpMinorPreMajor?: boolean;
+  bumpPatchForMinorPreMajor?: boolean;
   releaseAs?: string;
   snapshot?: boolean;
   monorepoTags?: boolean;

--- a/src/manifest.ts
+++ b/src/manifest.ts
@@ -44,6 +44,7 @@ import {ReleasePR} from './release-pr';
 interface ReleaserConfigJson {
   'release-type'?: ReleaseType;
   'bump-minor-pre-major'?: boolean;
+  'bump-patch-for-minor-pre-major'?: boolean;
   'changelog-sections'?: ChangelogSection[];
   'release-as'?: string;
   draft?: boolean;
@@ -74,6 +75,7 @@ type Package = Pick<
   | 'draft'
   | 'packageName'
   | 'bumpMinorPreMajor'
+  | 'bumpPatchForMinorPreMajor'
   | 'releaseAs'
   | 'changelogSections'
   | 'changelogPath'
@@ -252,6 +254,9 @@ export class Manifest {
           packageName: pkgCfg['package-name'],
           bumpMinorPreMajor:
             pkgCfg['bump-minor-pre-major'] ?? config['bump-minor-pre-major'],
+          bumpPatchForMinorPreMajor:
+            pkgCfg['bump-patch-for-minor-pre-major'] ??
+            config['bump-patch-for-minor-pre-major'],
           changelogSections:
             pkgCfg['changelog-sections'] ?? config['changelog-sections'],
           changelogPath: pkgCfg['changelog-path'],

--- a/src/release-pr.ts
+++ b/src/release-pr.ts
@@ -74,6 +74,7 @@ export class ReleasePR {
   labels: string[];
   gh: GitHub;
   bumpMinorPreMajor?: boolean;
+  bumpPatchForMinorPreMajor?: boolean;
   path?: string;
   packageName: string;
   monorepoTags: boolean;
@@ -86,6 +87,7 @@ export class ReleasePR {
 
   constructor(options: ReleasePRConstructorOptions) {
     this.bumpMinorPreMajor = options.bumpMinorPreMajor || false;
+    this.bumpPatchForMinorPreMajor = options.bumpPatchForMinorPreMajor || false;
     this.labels = options.labels ?? DEFAULT_LABELS;
     // undefined represents the root path of the library, if the special
     // '.' path is provided, simply ignore it:

--- a/src/releasers/node.ts
+++ b/src/releasers/node.ts
@@ -44,6 +44,7 @@ export class Node extends ReleasePR {
       owner: this.gh.owner,
       repository: this.gh.repo,
       bumpMinorPreMajor: this.bumpMinorPreMajor,
+      bumpPatchForMinorPreMajor: this.bumpPatchForMinorPreMajor,
       changelogSections: this.changelogSections,
     });
     const candidate: ReleaseCandidate = await this.coerceReleaseCandidate(

--- a/src/releasers/python.ts
+++ b/src/releasers/python.ts
@@ -52,6 +52,7 @@ export class Python extends ReleasePR {
       owner: this.gh.owner,
       repository: this.gh.repo,
       bumpMinorPreMajor: this.bumpMinorPreMajor,
+      bumpPatchForMinorPreMajor: this.bumpPatchForMinorPreMajor,
       changelogSections: this.changelogSections || CHANGELOG_SECTIONS,
     });
     const candidate: ReleaseCandidate = await this.coerceReleaseCandidate(

--- a/test/conventional-commits.ts
+++ b/test/conventional-commits.ts
@@ -44,6 +44,28 @@ describe('ConventionalCommits', () => {
       expect(bump.releaseType).to.equal('minor');
       expect(bump.reason).to.equal('There is 1 BREAKING CHANGE and 1 features');
     });
+
+    it('follows standard patch for minor bump behavior pre 1.0', async () => {
+      const cc = new ConventionalCommits({
+        commits: [
+          {
+            message: 'fix: addressed issues with foo',
+            sha: 'abc123',
+            files: [],
+          },
+          {message: 'feat: awesome feature', sha: 'abc678', files: []},
+        ],
+        owner: 'bcoe',
+        repository: 'release-please',
+        bumpMinorPreMajor: true,
+        bumpPatchForMinorPreMajor: true,
+      });
+      const bump = await cc.suggestBump('0.3.0');
+      expect(bump.releaseType).to.equal('patch');
+      expect(bump.reason).to.equal(
+        'There are 0 BREAKING CHANGES and 1 features'
+      );
+    });
   });
 
   describe('generateChangelogEntry', () => {


### PR DESCRIPTION
opt-in behavior for pre-1.0.0 packages that want to follow the standard
conventional commits behavior of bumping the patch instead of the minor

the motivation for this change is compatibility for node package dependencies with versions < 1.0.0 using [Caret Ranges](https://github.com/npm/node-semver#caret-ranges-123-025-004)