### PR TITLE
fix: adjust patch rule for Java LTS strategy

### DIFF
--- a/__snapshots__/java-lts.js
+++ b/__snapshots__/java-lts.js
@@ -1574,11 +1574,11 @@ filename: versions.txt
 # Format:
 # module:released-version:current-version
 
-google-cloud-trace:0.108.0-beta-sp.1:0.108.0-beta-sp.2-SNAPSHOT
-grpc-google-cloud-trace-v1:0.73.0-sp.1:0.73.0-sp.2-SNAPSHOT
-grpc-google-cloud-trace-v2:0.73.0-sp.1:0.73.0-sp.2-SNAPSHOT
-proto-google-cloud-trace-v1:0.73.0-sp.1:0.73.0-sp.2-SNAPSHOT
-proto-google-cloud-trace-v2:0.73.0-sp.1:0.73.0-sp.2-SNAPSHOT
+google-cloud-trace:0.108.0-beta:0.108.0-beta-sp.1-SNAPSHOT
+grpc-google-cloud-trace-v1:0.73.0:0.73.0-sp.1-SNAPSHOT
+grpc-google-cloud-trace-v2:0.73.0:0.73.0-sp.1-SNAPSHOT
+proto-google-cloud-trace-v1:0.73.0:0.73.0-sp.1-SNAPSHOT
+proto-google-cloud-trace-v2:0.73.0:0.73.0-sp.1-SNAPSHOT
 filename: pom.xml
 <?xml version='1.0' encoding='UTF-8'?>
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
@@ -1586,7 +1586,7 @@ filename: pom.xml
   <groupId>com.google.cloud</groupId>
   <artifactId>google-cloud-trace-parent</artifactId>
   <packaging>pom</packaging>
-  <version>0.108.0-beta-sp.2-SNAPSHOT</version><!-- {x-version-update:google-cloud-trace:current} -->
+  <version>0.108.0-beta-sp.1-SNAPSHOT</version><!-- {x-version-update:google-cloud-trace:current} -->
   <name>Google Cloud Trace Parent</name>
   <url>https://github.com/googleapis/java-core</url>
   <description>
@@ -1750,22 +1750,22 @@ filename: pom.xml
       <dependency>
         <groupId>com.google.api.grpc</groupId>
         <artifactId>proto-google-cloud-trace-v1</artifactId>
-        <version>0.73.0-sp.2-SNAPSHOT</version><!-- {x-version-update:proto-google-cloud-trace-v1:current} -->
+        <version>0.73.0-sp.1-SNAPSHOT</version><!-- {x-version-update:proto-google-cloud-trace-v1:current} -->
       </dependency>
       <dependency>
         <groupId>com.google.api.grpc</groupId>
         <artifactId>proto-google-cloud-trace-v2</artifactId>
-        <version>0.73.0-sp.2-SNAPSHOT</version><!-- {x-version-update:proto-google-cloud-trace-v2:current} -->
+        <version>0.73.0-sp.1-SNAPSHOT</version><!-- {x-version-update:proto-google-cloud-trace-v2:current} -->
       </dependency>
       <dependency>
         <groupId>com.google.api.grpc</groupId>
         <artifactId>grpc-google-cloud-trace-v1</artifactId>
-        <version>0.73.0-sp.2-SNAPSHOT</version><!-- {x-version-update:grpc-google-cloud-trace-v1:current} -->
+        <version>0.73.0-sp.1-SNAPSHOT</version><!-- {x-version-update:grpc-google-cloud-trace-v1:current} -->
       </dependency>
       <dependency>
         <groupId>com.google.api.grpc</groupId>
         <artifactId>grpc-google-cloud-trace-v2</artifactId>
-        <version>0.73.0-sp.2-SNAPSHOT</version><!-- {x-version-update:grpc-google-cloud-trace-v2:current} -->
+        <version>0.73.0-sp.1-SNAPSHOT</version><!-- {x-version-update:grpc-google-cloud-trace-v2:current} -->
       </dependency>
 
       <dependency>

--- a/__snapshots__/java-lts.js
+++ b/__snapshots__/java-lts.js
@@ -3,7 +3,7 @@ exports['JavaLTS creates a release PR against a feature branch: changes'] = `
 filename: CHANGELOG.md
 # Changelog
 
-### [0.20.3-sp.1-SNAPSHOT](https://www.github.com/googleapis/java-trace/compare/0.20.3...v0.20.3-sp.1-SNAPSHOT) (1983-10-10)
+### [0.20.3-sp.1](https://www.github.com/googleapis/java-trace/compare/0.20.3...v0.20.3-sp.1) (1983-10-10)
 
 
 ### Bug Fixes
@@ -149,7 +149,7 @@ public final class GoogleUtils {
   // NOTE: toString() so compiler thinks it isn't a constant, so it won't inline it
   // {x-version-update-start:google-api-client:current}
   /** Current release version. */
-  public static final String VERSION = "0.20.3-sp.1-SNAPSHOT".toString();
+  public static final String VERSION = "0.20.3-sp.1".toString();
   // {x-version-update-end:google-api-client:current}
 
   // NOTE: Integer instead of int so compiler thinks it isn't a constant, so it won't inline it
@@ -211,11 +211,11 @@ filename: versions.txt
 # Format:
 # module:released-version:current-version
 
-google-cloud-trace:0.108.0-beta-sp.1:0.108.0-beta-sp.1
-grpc-google-cloud-trace-v1:0.73.0-sp.1:0.73.0-sp.1
-grpc-google-cloud-trace-v2:0.73.0-sp.1:0.73.0-sp.1
-proto-google-cloud-trace-v1:0.73.0-sp.1:0.73.0-sp.1
-proto-google-cloud-trace-v2:0.73.0-sp.1:0.73.0-sp.1
+google-cloud-trace:0.108.0-beta-sp.1:0.108.0-beta-sp.1-sp.1-SNAPSHOT
+grpc-google-cloud-trace-v1:0.73.0-sp.1:0.73.0-sp.1.1-SNAPSHOT
+grpc-google-cloud-trace-v2:0.73.0-sp.1:0.73.0-sp.1.1-SNAPSHOT
+proto-google-cloud-trace-v1:0.73.0-sp.1:0.73.0-sp.1.1-SNAPSHOT
+proto-google-cloud-trace-v2:0.73.0-sp.1:0.73.0-sp.1.1-SNAPSHOT
 filename: pom.xml
 <?xml version='1.0' encoding='UTF-8'?>
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
@@ -572,11 +572,11 @@ exports['JavaLTS creates a release PR against a feature branch: options'] = `
 
 upstreamOwner: googleapis
 upstreamRepo: java-trace
-title: chore(1.x): release 0.20.3-sp.1-SNAPSHOT
+title: chore(1.x): release 0.20.3-sp.1
 branch: release-please/branches/1.x
 description: :robot: I have created a release \\*beep\\* \\*boop\\*
 ---
-### [0.20.3-sp.1-SNAPSHOT](https://www.github.com/googleapis/java-trace/compare/0.20.3...v0.20.3-sp.1-SNAPSHOT) (1983-10-10)
+### [0.20.3-sp.1](https://www.github.com/googleapis/java-trace/compare/0.20.3...v0.20.3-sp.1) (1983-10-10)
 
 
 ### Bug Fixes
@@ -589,7 +589,7 @@ This PR was generated with [Release Please](https://github.com/googleapis/releas
 primary: 1.x
 force: true
 fork: false
-message: chore(1.x): release 0.20.3-sp.1-SNAPSHOT
+message: chore(1.x): release 0.20.3-sp.1
 `
 
 exports['JavaLTS creates a release PR: changes'] = `
@@ -597,7 +597,7 @@ exports['JavaLTS creates a release PR: changes'] = `
 filename: CHANGELOG.md
 # Changelog
 
-### [0.20.3-sp.1-SNAPSHOT](https://www.github.com/googleapis/java-trace/compare/0.20.3...v0.20.3-sp.1-SNAPSHOT) (1983-10-10)
+### [0.20.3-sp.1](https://www.github.com/googleapis/java-trace/compare/0.20.3...v0.20.3-sp.1) (1983-10-10)
 
 
 ### Bug Fixes
@@ -743,7 +743,7 @@ public final class GoogleUtils {
   // NOTE: toString() so compiler thinks it isn't a constant, so it won't inline it
   // {x-version-update-start:google-api-client:current}
   /** Current release version. */
-  public static final String VERSION = "0.20.3-sp.1-SNAPSHOT".toString();
+  public static final String VERSION = "0.20.3-sp.1".toString();
   // {x-version-update-end:google-api-client:current}
 
   // NOTE: Integer instead of int so compiler thinks it isn't a constant, so it won't inline it
@@ -805,11 +805,11 @@ filename: versions.txt
 # Format:
 # module:released-version:current-version
 
-google-cloud-trace:0.108.0-beta-sp.1:0.108.0-beta-sp.1
-grpc-google-cloud-trace-v1:0.73.0-sp.1:0.73.0-sp.1
-grpc-google-cloud-trace-v2:0.73.0-sp.1:0.73.0-sp.1
-proto-google-cloud-trace-v1:0.73.0-sp.1:0.73.0-sp.1
-proto-google-cloud-trace-v2:0.73.0-sp.1:0.73.0-sp.1
+google-cloud-trace:0.108.0-beta-sp.1:0.108.0-beta-sp.1-sp.1-SNAPSHOT
+grpc-google-cloud-trace-v1:0.73.0-sp.1:0.73.0-sp.1.1-SNAPSHOT
+grpc-google-cloud-trace-v2:0.73.0-sp.1:0.73.0-sp.1.1-SNAPSHOT
+proto-google-cloud-trace-v1:0.73.0-sp.1:0.73.0-sp.1.1-SNAPSHOT
+proto-google-cloud-trace-v2:0.73.0-sp.1:0.73.0-sp.1.1-SNAPSHOT
 filename: pom.xml
 <?xml version='1.0' encoding='UTF-8'?>
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
@@ -1166,11 +1166,11 @@ exports['JavaLTS creates a release PR: options'] = `
 
 upstreamOwner: googleapis
 upstreamRepo: java-trace
-title: chore: release 0.20.3-sp.1-SNAPSHOT
+title: chore: release 0.20.3-sp.1
 branch: release-please/branches/master
 description: :robot: I have created a release \\*beep\\* \\*boop\\*
 ---
-### [0.20.3-sp.1-SNAPSHOT](https://www.github.com/googleapis/java-trace/compare/0.20.3...v0.20.3-sp.1-SNAPSHOT) (1983-10-10)
+### [0.20.3-sp.1](https://www.github.com/googleapis/java-trace/compare/0.20.3...v0.20.3-sp.1) (1983-10-10)
 
 
 ### Bug Fixes
@@ -1183,7 +1183,7 @@ This PR was generated with [Release Please](https://github.com/googleapis/releas
 primary: master
 force: true
 fork: false
-message: chore: release 0.20.3-sp.1-SNAPSHOT
+message: chore: release 0.20.3-sp.1
 `
 
 exports['JavaLTS creates a snapshot PR if an explicit release is requested, but a snapshot is needed: changes'] = `
@@ -1192,11 +1192,11 @@ filename: versions.txt
 # Format:
 # module:released-version:current-version
 
-google-cloud-trace:0.108.0-beta:0.108.1-beta-SNAPSHOT
-grpc-google-cloud-trace-v1:0.73.0:0.73.1-SNAPSHOT
-grpc-google-cloud-trace-v2:0.73.0:0.73.1-SNAPSHOT
-proto-google-cloud-trace-v1:0.73.0:0.73.1-SNAPSHOT
-proto-google-cloud-trace-v2:0.73.0:0.73.1-SNAPSHOT
+google-cloud-trace:0.108.0-beta-sp.1:0.108.0-beta-sp.2-SNAPSHOT-sp.1
+grpc-google-cloud-trace-v1:0.73.0-sp.1:0.73.0-sp.2-SNAPSHOT.1
+grpc-google-cloud-trace-v2:0.73.0-sp.1:0.73.0-sp.2-SNAPSHOT.1
+proto-google-cloud-trace-v1:0.73.0-sp.1:0.73.0-sp.2-SNAPSHOT.1
+proto-google-cloud-trace-v2:0.73.0-sp.1:0.73.0-sp.2-SNAPSHOT.1
 filename: pom.xml
 <?xml version='1.0' encoding='UTF-8'?>
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
@@ -1204,7 +1204,7 @@ filename: pom.xml
   <groupId>com.google.cloud</groupId>
   <artifactId>google-cloud-trace-parent</artifactId>
   <packaging>pom</packaging>
-  <version>0.108.1-beta-SNAPSHOT</version><!-- {x-version-update:google-cloud-trace:current} -->
+  <version>0.108.0-beta-sp.2-SNAPSHOT</version><!-- {x-version-update:google-cloud-trace:current} -->
   <name>Google Cloud Trace Parent</name>
   <url>https://github.com/googleapis/java-core</url>
   <description>
@@ -1368,22 +1368,22 @@ filename: pom.xml
       <dependency>
         <groupId>com.google.api.grpc</groupId>
         <artifactId>proto-google-cloud-trace-v1</artifactId>
-        <version>0.73.1-SNAPSHOT</version><!-- {x-version-update:proto-google-cloud-trace-v1:current} -->
+        <version>0.73.0-sp.2-SNAPSHOT</version><!-- {x-version-update:proto-google-cloud-trace-v1:current} -->
       </dependency>
       <dependency>
         <groupId>com.google.api.grpc</groupId>
         <artifactId>proto-google-cloud-trace-v2</artifactId>
-        <version>0.73.1-SNAPSHOT</version><!-- {x-version-update:proto-google-cloud-trace-v2:current} -->
+        <version>0.73.0-sp.2-SNAPSHOT</version><!-- {x-version-update:proto-google-cloud-trace-v2:current} -->
       </dependency>
       <dependency>
         <groupId>com.google.api.grpc</groupId>
         <artifactId>grpc-google-cloud-trace-v1</artifactId>
-        <version>0.73.1-SNAPSHOT</version><!-- {x-version-update:grpc-google-cloud-trace-v1:current} -->
+        <version>0.73.0-sp.2-SNAPSHOT</version><!-- {x-version-update:grpc-google-cloud-trace-v1:current} -->
       </dependency>
       <dependency>
         <groupId>com.google.api.grpc</groupId>
         <artifactId>grpc-google-cloud-trace-v2</artifactId>
-        <version>0.73.1-SNAPSHOT</version><!-- {x-version-update:grpc-google-cloud-trace-v2:current} -->
+        <version>0.73.0-sp.2-SNAPSHOT</version><!-- {x-version-update:grpc-google-cloud-trace-v2:current} -->
       </dependency>
 
       <dependency>
@@ -1553,7 +1553,7 @@ exports['JavaLTS creates a snapshot PR if an explicit release is requested, but 
 
 upstreamOwner: googleapis
 upstreamRepo: java-trace
-title: chore: release 0.20.4-SNAPSHOT
+title: chore: release 0.20.3-sp.1-SNAPSHOT
 branch: release-please/branches/master
 description: :robot: I have created a release \\*beep\\* \\*boop\\*
 ---
@@ -1565,7 +1565,7 @@ This PR was generated with [Release Please](https://github.com/googleapis/releas
 primary: master
 force: true
 fork: false
-message: chore: release 0.20.4-SNAPSHOT
+message: chore: release 0.20.3-sp.1-SNAPSHOT
 `
 
 exports['JavaLTS creates a snapshot PR, when latest release sha is head: changes'] = `
@@ -1574,11 +1574,11 @@ filename: versions.txt
 # Format:
 # module:released-version:current-version
 
-google-cloud-trace:0.108.0-beta:0.108.1-beta-SNAPSHOT
-grpc-google-cloud-trace-v1:0.73.0:0.73.1-SNAPSHOT
-grpc-google-cloud-trace-v2:0.73.0:0.73.1-SNAPSHOT
-proto-google-cloud-trace-v1:0.73.0:0.73.1-SNAPSHOT
-proto-google-cloud-trace-v2:0.73.0:0.73.1-SNAPSHOT
+google-cloud-trace:0.108.0-beta-sp.1:0.108.0-beta-sp.2-SNAPSHOT-sp.1
+grpc-google-cloud-trace-v1:0.73.0-sp.1:0.73.0-sp.2-SNAPSHOT.1
+grpc-google-cloud-trace-v2:0.73.0-sp.1:0.73.0-sp.2-SNAPSHOT.1
+proto-google-cloud-trace-v1:0.73.0-sp.1:0.73.0-sp.2-SNAPSHOT.1
+proto-google-cloud-trace-v2:0.73.0-sp.1:0.73.0-sp.2-SNAPSHOT.1
 filename: pom.xml
 <?xml version='1.0' encoding='UTF-8'?>
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
@@ -1586,7 +1586,7 @@ filename: pom.xml
   <groupId>com.google.cloud</groupId>
   <artifactId>google-cloud-trace-parent</artifactId>
   <packaging>pom</packaging>
-  <version>0.108.1-beta-SNAPSHOT</version><!-- {x-version-update:google-cloud-trace:current} -->
+  <version>0.108.0-beta-sp.2-SNAPSHOT</version><!-- {x-version-update:google-cloud-trace:current} -->
   <name>Google Cloud Trace Parent</name>
   <url>https://github.com/googleapis/java-core</url>
   <description>
@@ -1750,22 +1750,22 @@ filename: pom.xml
       <dependency>
         <groupId>com.google.api.grpc</groupId>
         <artifactId>proto-google-cloud-trace-v1</artifactId>
-        <version>0.73.1-SNAPSHOT</version><!-- {x-version-update:proto-google-cloud-trace-v1:current} -->
+        <version>0.73.0-sp.2-SNAPSHOT</version><!-- {x-version-update:proto-google-cloud-trace-v1:current} -->
       </dependency>
       <dependency>
         <groupId>com.google.api.grpc</groupId>
         <artifactId>proto-google-cloud-trace-v2</artifactId>
-        <version>0.73.1-SNAPSHOT</version><!-- {x-version-update:proto-google-cloud-trace-v2:current} -->
+        <version>0.73.0-sp.2-SNAPSHOT</version><!-- {x-version-update:proto-google-cloud-trace-v2:current} -->
       </dependency>
       <dependency>
         <groupId>com.google.api.grpc</groupId>
         <artifactId>grpc-google-cloud-trace-v1</artifactId>
-        <version>0.73.1-SNAPSHOT</version><!-- {x-version-update:grpc-google-cloud-trace-v1:current} -->
+        <version>0.73.0-sp.2-SNAPSHOT</version><!-- {x-version-update:grpc-google-cloud-trace-v1:current} -->
       </dependency>
       <dependency>
         <groupId>com.google.api.grpc</groupId>
         <artifactId>grpc-google-cloud-trace-v2</artifactId>
-        <version>0.73.1-SNAPSHOT</version><!-- {x-version-update:grpc-google-cloud-trace-v2:current} -->
+        <version>0.73.0-sp.2-SNAPSHOT</version><!-- {x-version-update:grpc-google-cloud-trace-v2:current} -->
       </dependency>
 
       <dependency>
@@ -1935,7 +1935,7 @@ exports['JavaLTS creates a snapshot PR, when latest release sha is head: options
 
 upstreamOwner: googleapis
 upstreamRepo: java-trace
-title: chore: release 0.20.4-SNAPSHOT
+title: chore: release 0.20.3-sp.1-SNAPSHOT
 branch: release-please/branches/master
 description: :robot: I have created a release \\*beep\\* \\*boop\\*
 ---
@@ -1947,7 +1947,7 @@ This PR was generated with [Release Please](https://github.com/googleapis/releas
 primary: master
 force: true
 fork: false
-message: chore: release 0.20.4-SNAPSHOT
+message: chore: release 0.20.3-sp.1-SNAPSHOT
 `
 
 exports['JavaLTS creates a snapshot PR: changes'] = `
@@ -1956,11 +1956,11 @@ filename: versions.txt
 # Format:
 # module:released-version:current-version
 
-google-cloud-trace:0.108.0-beta:0.108.1-beta-SNAPSHOT
-grpc-google-cloud-trace-v1:0.73.0:0.73.1-SNAPSHOT
-grpc-google-cloud-trace-v2:0.73.0:0.73.1-SNAPSHOT
-proto-google-cloud-trace-v1:0.73.0:0.73.1-SNAPSHOT
-proto-google-cloud-trace-v2:0.73.0:0.73.1-SNAPSHOT
+google-cloud-trace:0.108.0-beta-sp.1:0.108.0-beta-sp.2-SNAPSHOT-sp.1
+grpc-google-cloud-trace-v1:0.73.0-sp.1:0.73.0-sp.2-SNAPSHOT.1
+grpc-google-cloud-trace-v2:0.73.0-sp.1:0.73.0-sp.2-SNAPSHOT.1
+proto-google-cloud-trace-v1:0.73.0-sp.1:0.73.0-sp.2-SNAPSHOT.1
+proto-google-cloud-trace-v2:0.73.0-sp.1:0.73.0-sp.2-SNAPSHOT.1
 filename: pom.xml
 <?xml version='1.0' encoding='UTF-8'?>
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
@@ -1968,7 +1968,7 @@ filename: pom.xml
   <groupId>com.google.cloud</groupId>
   <artifactId>google-cloud-trace-parent</artifactId>
   <packaging>pom</packaging>
-  <version>0.108.1-beta-SNAPSHOT</version><!-- {x-version-update:google-cloud-trace:current} -->
+  <version>0.108.0-beta-sp.2-SNAPSHOT</version><!-- {x-version-update:google-cloud-trace:current} -->
   <name>Google Cloud Trace Parent</name>
   <url>https://github.com/googleapis/java-core</url>
   <description>
@@ -2132,22 +2132,22 @@ filename: pom.xml
       <dependency>
         <groupId>com.google.api.grpc</groupId>
         <artifactId>proto-google-cloud-trace-v1</artifactId>
-        <version>0.73.1-SNAPSHOT</version><!-- {x-version-update:proto-google-cloud-trace-v1:current} -->
+        <version>0.73.0-sp.2-SNAPSHOT</version><!-- {x-version-update:proto-google-cloud-trace-v1:current} -->
       </dependency>
       <dependency>
         <groupId>com.google.api.grpc</groupId>
         <artifactId>proto-google-cloud-trace-v2</artifactId>
-        <version>0.73.1-SNAPSHOT</version><!-- {x-version-update:proto-google-cloud-trace-v2:current} -->
+        <version>0.73.0-sp.2-SNAPSHOT</version><!-- {x-version-update:proto-google-cloud-trace-v2:current} -->
       </dependency>
       <dependency>
         <groupId>com.google.api.grpc</groupId>
         <artifactId>grpc-google-cloud-trace-v1</artifactId>
-        <version>0.73.1-SNAPSHOT</version><!-- {x-version-update:grpc-google-cloud-trace-v1:current} -->
+        <version>0.73.0-sp.2-SNAPSHOT</version><!-- {x-version-update:grpc-google-cloud-trace-v1:current} -->
       </dependency>
       <dependency>
         <groupId>com.google.api.grpc</groupId>
         <artifactId>grpc-google-cloud-trace-v2</artifactId>
-        <version>0.73.1-SNAPSHOT</version><!-- {x-version-update:grpc-google-cloud-trace-v2:current} -->
+        <version>0.73.0-sp.2-SNAPSHOT</version><!-- {x-version-update:grpc-google-cloud-trace-v2:current} -->
       </dependency>
 
       <dependency>
@@ -2317,7 +2317,7 @@ exports['JavaLTS creates a snapshot PR: options'] = `
 
 upstreamOwner: googleapis
 upstreamRepo: java-trace
-title: chore: release 0.20.4-SNAPSHOT
+title: chore: release 0.20.3-sp.1-SNAPSHOT
 branch: release-please/branches/master
 description: :robot: I have created a release \\*beep\\* \\*boop\\*
 ---
@@ -2329,5 +2329,5 @@ This PR was generated with [Release Please](https://github.com/googleapis/releas
 primary: master
 force: true
 fork: false
-message: chore: release 0.20.4-SNAPSHOT
+message: chore: release 0.20.3-sp.1-SNAPSHOT
 `

--- a/__snapshots__/java-lts.js
+++ b/__snapshots__/java-lts.js
@@ -211,11 +211,11 @@ filename: versions.txt
 # Format:
 # module:released-version:current-version
 
-google-cloud-trace:0.108.0-beta-sp.1:0.108.0-beta-sp.1-sp.1-SNAPSHOT
-grpc-google-cloud-trace-v1:0.73.0-sp.1:0.73.0-sp.1.1-SNAPSHOT
-grpc-google-cloud-trace-v2:0.73.0-sp.1:0.73.0-sp.1.1-SNAPSHOT
-proto-google-cloud-trace-v1:0.73.0-sp.1:0.73.0-sp.1.1-SNAPSHOT
-proto-google-cloud-trace-v2:0.73.0-sp.1:0.73.0-sp.1.1-SNAPSHOT
+google-cloud-trace:0.108.0-beta-sp.1:0.108.0-beta-sp.1
+grpc-google-cloud-trace-v1:0.73.0-sp.1:0.73.0-sp.1
+grpc-google-cloud-trace-v2:0.73.0-sp.1:0.73.0-sp.1
+proto-google-cloud-trace-v1:0.73.0-sp.1:0.73.0-sp.1
+proto-google-cloud-trace-v2:0.73.0-sp.1:0.73.0-sp.1
 filename: pom.xml
 <?xml version='1.0' encoding='UTF-8'?>
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
@@ -805,11 +805,11 @@ filename: versions.txt
 # Format:
 # module:released-version:current-version
 
-google-cloud-trace:0.108.0-beta-sp.1:0.108.0-beta-sp.1-sp.1-SNAPSHOT
-grpc-google-cloud-trace-v1:0.73.0-sp.1:0.73.0-sp.1.1-SNAPSHOT
-grpc-google-cloud-trace-v2:0.73.0-sp.1:0.73.0-sp.1.1-SNAPSHOT
-proto-google-cloud-trace-v1:0.73.0-sp.1:0.73.0-sp.1.1-SNAPSHOT
-proto-google-cloud-trace-v2:0.73.0-sp.1:0.73.0-sp.1.1-SNAPSHOT
+google-cloud-trace:0.108.0-beta-sp.1:0.108.0-beta-sp.1
+grpc-google-cloud-trace-v1:0.73.0-sp.1:0.73.0-sp.1
+grpc-google-cloud-trace-v2:0.73.0-sp.1:0.73.0-sp.1
+proto-google-cloud-trace-v1:0.73.0-sp.1:0.73.0-sp.1
+proto-google-cloud-trace-v2:0.73.0-sp.1:0.73.0-sp.1
 filename: pom.xml
 <?xml version='1.0' encoding='UTF-8'?>
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
@@ -1192,11 +1192,11 @@ filename: versions.txt
 # Format:
 # module:released-version:current-version
 
-google-cloud-trace:0.108.0-beta-sp.1:0.108.0-beta-sp.2-SNAPSHOT-sp.1
-grpc-google-cloud-trace-v1:0.73.0-sp.1:0.73.0-sp.2-SNAPSHOT.1
-grpc-google-cloud-trace-v2:0.73.0-sp.1:0.73.0-sp.2-SNAPSHOT.1
-proto-google-cloud-trace-v1:0.73.0-sp.1:0.73.0-sp.2-SNAPSHOT.1
-proto-google-cloud-trace-v2:0.73.0-sp.1:0.73.0-sp.2-SNAPSHOT.1
+google-cloud-trace:0.108.0-beta-sp.1:0.108.0-beta-sp.2-SNAPSHOT
+grpc-google-cloud-trace-v1:0.73.0-sp.1:0.73.0-sp.2-SNAPSHOT
+grpc-google-cloud-trace-v2:0.73.0-sp.1:0.73.0-sp.2-SNAPSHOT
+proto-google-cloud-trace-v1:0.73.0-sp.1:0.73.0-sp.2-SNAPSHOT
+proto-google-cloud-trace-v2:0.73.0-sp.1:0.73.0-sp.2-SNAPSHOT
 filename: pom.xml
 <?xml version='1.0' encoding='UTF-8'?>
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
@@ -1574,11 +1574,11 @@ filename: versions.txt
 # Format:
 # module:released-version:current-version
 
-google-cloud-trace:0.108.0-beta-sp.1:0.108.0-beta-sp.2-SNAPSHOT-sp.1
-grpc-google-cloud-trace-v1:0.73.0-sp.1:0.73.0-sp.2-SNAPSHOT.1
-grpc-google-cloud-trace-v2:0.73.0-sp.1:0.73.0-sp.2-SNAPSHOT.1
-proto-google-cloud-trace-v1:0.73.0-sp.1:0.73.0-sp.2-SNAPSHOT.1
-proto-google-cloud-trace-v2:0.73.0-sp.1:0.73.0-sp.2-SNAPSHOT.1
+google-cloud-trace:0.108.0-beta-sp.1:0.108.0-beta-sp.2-SNAPSHOT
+grpc-google-cloud-trace-v1:0.73.0-sp.1:0.73.0-sp.2-SNAPSHOT
+grpc-google-cloud-trace-v2:0.73.0-sp.1:0.73.0-sp.2-SNAPSHOT
+proto-google-cloud-trace-v1:0.73.0-sp.1:0.73.0-sp.2-SNAPSHOT
+proto-google-cloud-trace-v2:0.73.0-sp.1:0.73.0-sp.2-SNAPSHOT
 filename: pom.xml
 <?xml version='1.0' encoding='UTF-8'?>
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
@@ -1956,11 +1956,11 @@ filename: versions.txt
 # Format:
 # module:released-version:current-version
 
-google-cloud-trace:0.108.0-beta-sp.1:0.108.0-beta-sp.2-SNAPSHOT-sp.1
-grpc-google-cloud-trace-v1:0.73.0-sp.1:0.73.0-sp.2-SNAPSHOT.1
-grpc-google-cloud-trace-v2:0.73.0-sp.1:0.73.0-sp.2-SNAPSHOT.1
-proto-google-cloud-trace-v1:0.73.0-sp.1:0.73.0-sp.2-SNAPSHOT.1
-proto-google-cloud-trace-v2:0.73.0-sp.1:0.73.0-sp.2-SNAPSHOT.1
+google-cloud-trace:0.108.0-beta-sp.1:0.108.0-beta-sp.2-SNAPSHOT
+grpc-google-cloud-trace-v1:0.73.0-sp.1:0.73.0-sp.2-SNAPSHOT
+grpc-google-cloud-trace-v2:0.73.0-sp.1:0.73.0-sp.2-SNAPSHOT
+proto-google-cloud-trace-v1:0.73.0-sp.1:0.73.0-sp.2-SNAPSHOT
+proto-google-cloud-trace-v2:0.73.0-sp.1:0.73.0-sp.2-SNAPSHOT
 filename: pom.xml
 <?xml version='1.0' encoding='UTF-8'?>
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">

--- a/__snapshots__/java-lts.js
+++ b/__snapshots__/java-lts.js
@@ -3,7 +3,7 @@ exports['JavaLTS creates a release PR against a feature branch: changes'] = `
 filename: CHANGELOG.md
 # Changelog
 
-### [0.20.4-sp.1](https://www.github.com/googleapis/java-trace/compare/0.20.3...v0.20.4-sp.1) (1983-10-10)
+### [0.20.3-sp.1-SNAPSHOT](https://www.github.com/googleapis/java-trace/compare/0.20.3...v0.20.3-sp.1-SNAPSHOT) (1983-10-10)
 
 
 ### Bug Fixes
@@ -31,16 +31,16 @@ If you are using Maven, add this to your pom.xml file
 <dependency>
   <groupId>com.google.cloud</groupId>
   <artifactId>google-cloud-trace</artifactId>
-  <version>0.108.1-beta-sp.1</version>
+  <version>0.108.0-beta-sp.1</version>
 </dependency>
 \`\`\`
 If you are using Gradle, add this to your dependencies
 \`\`\`Groovy
-compile 'com.google.cloud:google-cloud-trace:0.108.1-beta-sp.1'
+compile 'com.google.cloud:google-cloud-trace:0.108.0-beta-sp.1'
 \`\`\`
 If you are using SBT, add this to your dependencies
 \`\`\`Scala
-libraryDependencies += "com.google.cloud" % "google-cloud-trace" % "0.108.1-beta-sp.1"
+libraryDependencies += "com.google.cloud" % "google-cloud-trace" % "0.108.0-beta-sp.1"
 \`\`\`
 [//]: # ({x-version-update-end})
 
@@ -149,7 +149,7 @@ public final class GoogleUtils {
   // NOTE: toString() so compiler thinks it isn't a constant, so it won't inline it
   // {x-version-update-start:google-api-client:current}
   /** Current release version. */
-  public static final String VERSION = "0.20.4-sp.1".toString();
+  public static final String VERSION = "0.20.3-sp.1-SNAPSHOT".toString();
   // {x-version-update-end:google-api-client:current}
 
   // NOTE: Integer instead of int so compiler thinks it isn't a constant, so it won't inline it
@@ -211,11 +211,11 @@ filename: versions.txt
 # Format:
 # module:released-version:current-version
 
-google-cloud-trace:0.108.1-beta-sp.1:0.108.1-beta-sp.1
-grpc-google-cloud-trace-v1:0.73.1-sp.1:0.73.1-sp.1
-grpc-google-cloud-trace-v2:0.73.1-sp.1:0.73.1-sp.1
-proto-google-cloud-trace-v1:0.73.1-sp.1:0.73.1-sp.1
-proto-google-cloud-trace-v2:0.73.1-sp.1:0.73.1-sp.1
+google-cloud-trace:0.108.0-beta-sp.1:0.108.0-beta-sp.1
+grpc-google-cloud-trace-v1:0.73.0-sp.1:0.73.0-sp.1
+grpc-google-cloud-trace-v2:0.73.0-sp.1:0.73.0-sp.1
+proto-google-cloud-trace-v1:0.73.0-sp.1:0.73.0-sp.1
+proto-google-cloud-trace-v2:0.73.0-sp.1:0.73.0-sp.1
 filename: pom.xml
 <?xml version='1.0' encoding='UTF-8'?>
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
@@ -223,7 +223,7 @@ filename: pom.xml
   <groupId>com.google.cloud</groupId>
   <artifactId>google-cloud-trace-parent</artifactId>
   <packaging>pom</packaging>
-  <version>0.108.1-beta-sp.1</version><!-- {x-version-update:google-cloud-trace:current} -->
+  <version>0.108.0-beta-sp.1</version><!-- {x-version-update:google-cloud-trace:current} -->
   <name>Google Cloud Trace Parent</name>
   <url>https://github.com/googleapis/java-core</url>
   <description>
@@ -387,22 +387,22 @@ filename: pom.xml
       <dependency>
         <groupId>com.google.api.grpc</groupId>
         <artifactId>proto-google-cloud-trace-v1</artifactId>
-        <version>0.73.1-sp.1</version><!-- {x-version-update:proto-google-cloud-trace-v1:current} -->
+        <version>0.73.0-sp.1</version><!-- {x-version-update:proto-google-cloud-trace-v1:current} -->
       </dependency>
       <dependency>
         <groupId>com.google.api.grpc</groupId>
         <artifactId>proto-google-cloud-trace-v2</artifactId>
-        <version>0.73.1-sp.1</version><!-- {x-version-update:proto-google-cloud-trace-v2:current} -->
+        <version>0.73.0-sp.1</version><!-- {x-version-update:proto-google-cloud-trace-v2:current} -->
       </dependency>
       <dependency>
         <groupId>com.google.api.grpc</groupId>
         <artifactId>grpc-google-cloud-trace-v1</artifactId>
-        <version>0.73.1-sp.1</version><!-- {x-version-update:grpc-google-cloud-trace-v1:current} -->
+        <version>0.73.0-sp.1</version><!-- {x-version-update:grpc-google-cloud-trace-v1:current} -->
       </dependency>
       <dependency>
         <groupId>com.google.api.grpc</groupId>
         <artifactId>grpc-google-cloud-trace-v2</artifactId>
-        <version>0.73.1-sp.1</version><!-- {x-version-update:grpc-google-cloud-trace-v2:current} -->
+        <version>0.73.0-sp.1</version><!-- {x-version-update:grpc-google-cloud-trace-v2:current} -->
       </dependency>
 
       <dependency>
@@ -572,11 +572,11 @@ exports['JavaLTS creates a release PR against a feature branch: options'] = `
 
 upstreamOwner: googleapis
 upstreamRepo: java-trace
-title: chore(1.x): release 0.20.4-sp.1
+title: chore(1.x): release 0.20.3-sp.1-SNAPSHOT
 branch: release-please/branches/1.x
 description: :robot: I have created a release \\*beep\\* \\*boop\\*
 ---
-### [0.20.4-sp.1](https://www.github.com/googleapis/java-trace/compare/0.20.3...v0.20.4-sp.1) (1983-10-10)
+### [0.20.3-sp.1-SNAPSHOT](https://www.github.com/googleapis/java-trace/compare/0.20.3...v0.20.3-sp.1-SNAPSHOT) (1983-10-10)
 
 
 ### Bug Fixes
@@ -589,7 +589,7 @@ This PR was generated with [Release Please](https://github.com/googleapis/releas
 primary: 1.x
 force: true
 fork: false
-message: chore(1.x): release 0.20.4-sp.1
+message: chore(1.x): release 0.20.3-sp.1-SNAPSHOT
 `
 
 exports['JavaLTS creates a release PR: changes'] = `
@@ -597,7 +597,7 @@ exports['JavaLTS creates a release PR: changes'] = `
 filename: CHANGELOG.md
 # Changelog
 
-### [0.20.4-sp.1](https://www.github.com/googleapis/java-trace/compare/0.20.3...v0.20.4-sp.1) (1983-10-10)
+### [0.20.3-sp.1-SNAPSHOT](https://www.github.com/googleapis/java-trace/compare/0.20.3...v0.20.3-sp.1-SNAPSHOT) (1983-10-10)
 
 
 ### Bug Fixes
@@ -625,16 +625,16 @@ If you are using Maven, add this to your pom.xml file
 <dependency>
   <groupId>com.google.cloud</groupId>
   <artifactId>google-cloud-trace</artifactId>
-  <version>0.108.1-beta-sp.1</version>
+  <version>0.108.0-beta-sp.1</version>
 </dependency>
 \`\`\`
 If you are using Gradle, add this to your dependencies
 \`\`\`Groovy
-compile 'com.google.cloud:google-cloud-trace:0.108.1-beta-sp.1'
+compile 'com.google.cloud:google-cloud-trace:0.108.0-beta-sp.1'
 \`\`\`
 If you are using SBT, add this to your dependencies
 \`\`\`Scala
-libraryDependencies += "com.google.cloud" % "google-cloud-trace" % "0.108.1-beta-sp.1"
+libraryDependencies += "com.google.cloud" % "google-cloud-trace" % "0.108.0-beta-sp.1"
 \`\`\`
 [//]: # ({x-version-update-end})
 
@@ -743,7 +743,7 @@ public final class GoogleUtils {
   // NOTE: toString() so compiler thinks it isn't a constant, so it won't inline it
   // {x-version-update-start:google-api-client:current}
   /** Current release version. */
-  public static final String VERSION = "0.20.4-sp.1".toString();
+  public static final String VERSION = "0.20.3-sp.1-SNAPSHOT".toString();
   // {x-version-update-end:google-api-client:current}
 
   // NOTE: Integer instead of int so compiler thinks it isn't a constant, so it won't inline it
@@ -805,11 +805,11 @@ filename: versions.txt
 # Format:
 # module:released-version:current-version
 
-google-cloud-trace:0.108.1-beta-sp.1:0.108.1-beta-sp.1
-grpc-google-cloud-trace-v1:0.73.1-sp.1:0.73.1-sp.1
-grpc-google-cloud-trace-v2:0.73.1-sp.1:0.73.1-sp.1
-proto-google-cloud-trace-v1:0.73.1-sp.1:0.73.1-sp.1
-proto-google-cloud-trace-v2:0.73.1-sp.1:0.73.1-sp.1
+google-cloud-trace:0.108.0-beta-sp.1:0.108.0-beta-sp.1
+grpc-google-cloud-trace-v1:0.73.0-sp.1:0.73.0-sp.1
+grpc-google-cloud-trace-v2:0.73.0-sp.1:0.73.0-sp.1
+proto-google-cloud-trace-v1:0.73.0-sp.1:0.73.0-sp.1
+proto-google-cloud-trace-v2:0.73.0-sp.1:0.73.0-sp.1
 filename: pom.xml
 <?xml version='1.0' encoding='UTF-8'?>
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
@@ -817,7 +817,7 @@ filename: pom.xml
   <groupId>com.google.cloud</groupId>
   <artifactId>google-cloud-trace-parent</artifactId>
   <packaging>pom</packaging>
-  <version>0.108.1-beta-sp.1</version><!-- {x-version-update:google-cloud-trace:current} -->
+  <version>0.108.0-beta-sp.1</version><!-- {x-version-update:google-cloud-trace:current} -->
   <name>Google Cloud Trace Parent</name>
   <url>https://github.com/googleapis/java-core</url>
   <description>
@@ -981,22 +981,22 @@ filename: pom.xml
       <dependency>
         <groupId>com.google.api.grpc</groupId>
         <artifactId>proto-google-cloud-trace-v1</artifactId>
-        <version>0.73.1-sp.1</version><!-- {x-version-update:proto-google-cloud-trace-v1:current} -->
+        <version>0.73.0-sp.1</version><!-- {x-version-update:proto-google-cloud-trace-v1:current} -->
       </dependency>
       <dependency>
         <groupId>com.google.api.grpc</groupId>
         <artifactId>proto-google-cloud-trace-v2</artifactId>
-        <version>0.73.1-sp.1</version><!-- {x-version-update:proto-google-cloud-trace-v2:current} -->
+        <version>0.73.0-sp.1</version><!-- {x-version-update:proto-google-cloud-trace-v2:current} -->
       </dependency>
       <dependency>
         <groupId>com.google.api.grpc</groupId>
         <artifactId>grpc-google-cloud-trace-v1</artifactId>
-        <version>0.73.1-sp.1</version><!-- {x-version-update:grpc-google-cloud-trace-v1:current} -->
+        <version>0.73.0-sp.1</version><!-- {x-version-update:grpc-google-cloud-trace-v1:current} -->
       </dependency>
       <dependency>
         <groupId>com.google.api.grpc</groupId>
         <artifactId>grpc-google-cloud-trace-v2</artifactId>
-        <version>0.73.1-sp.1</version><!-- {x-version-update:grpc-google-cloud-trace-v2:current} -->
+        <version>0.73.0-sp.1</version><!-- {x-version-update:grpc-google-cloud-trace-v2:current} -->
       </dependency>
 
       <dependency>
@@ -1166,11 +1166,11 @@ exports['JavaLTS creates a release PR: options'] = `
 
 upstreamOwner: googleapis
 upstreamRepo: java-trace
-title: chore: release 0.20.4-sp.1
+title: chore: release 0.20.3-sp.1-SNAPSHOT
 branch: release-please/branches/master
 description: :robot: I have created a release \\*beep\\* \\*boop\\*
 ---
-### [0.20.4-sp.1](https://www.github.com/googleapis/java-trace/compare/0.20.3...v0.20.4-sp.1) (1983-10-10)
+### [0.20.3-sp.1-SNAPSHOT](https://www.github.com/googleapis/java-trace/compare/0.20.3...v0.20.3-sp.1-SNAPSHOT) (1983-10-10)
 
 
 ### Bug Fixes
@@ -1183,7 +1183,7 @@ This PR was generated with [Release Please](https://github.com/googleapis/releas
 primary: master
 force: true
 fork: false
-message: chore: release 0.20.4-sp.1
+message: chore: release 0.20.3-sp.1-SNAPSHOT
 `
 
 exports['JavaLTS creates a snapshot PR if an explicit release is requested, but a snapshot is needed: changes'] = `

--- a/docs/java-releases.md
+++ b/docs/java-releases.md
@@ -39,5 +39,8 @@ version with an associated major version bump.
 
 This is a special case versioning strategy where we adopt a custom versioning scheme
 and is meant to be used against an LTS branch. Consider an LTS branch cut from the
-mainline at version `1.2.3`. The next version proposed will be `1.2.4-lts.1`, followed
-by `1.2.4-lts.2`.
+mainline at version `1.2.3`. The next version proposed will be `1.2.3-sp.1`, followed
+by `1.2.3-lts.2`.
+
+For LTS releases, we use a special "lts-snapshot" bump which will make the version
+following `1.2.3-sp.1` be `1.2.3-sp.2-SNAPSHOT`.

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "main": "./build/src/index.js",
   "bin": "./build/src/bin/release-please.js",
   "scripts": {
-    "test": "cross-env ENVIRONMENT=test c8 mocha --recursive --timeout=5000 build/test",
+    "test": "cross-env ENVIRONMENT=test mocha --recursive --timeout=5000 build/test",
     "docs-test": "echo add docs tests",
     "test:snap": "SNAPSHOT_UPDATE=1 npm test",
     "clean": "gts clean",

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "main": "./build/src/index.js",
   "bin": "./build/src/bin/release-please.js",
   "scripts": {
-    "test": "cross-env ENVIRONMENT=test mocha --recursive --timeout=5000 build/test",
+    "test": "cross-env ENVIRONMENT=test c8 mocha --recursive --timeout=5000 build/test",
     "docs-test": "echo add docs tests",
     "test:snap": "SNAPSHOT_UPDATE=1 npm test",
     "clean": "gts clean",

--- a/src/releasers/java-lts.ts
+++ b/src/releasers/java-lts.ts
@@ -42,7 +42,7 @@ export class JavaLTS extends JavaYoshi {
     latestTag: GitHubTag | undefined,
     _preRelease = false
   ): Promise<ReleaseCandidate> {
-    const bumpType = this.snapshot ? 'snapshot' : 'lts';
+    const bumpType = this.snapshot ? 'snapshot' : 'lts-snapshot';
 
     const version = Version.parse(
       latestTag?.version ?? this.defaultInitialVersion()

--- a/src/releasers/java-lts.ts
+++ b/src/releasers/java-lts.ts
@@ -29,7 +29,7 @@ export class JavaLTS extends JavaYoshi {
     _latestTag: GitHubTag | undefined,
     currentVersions: VersionsMap
   ): Promise<VersionsMap> {
-    const bumpType = this.snapshot ? 'snapshot' : 'lts';
+    const bumpType = this.snapshot ? 'lts-snapshot' : 'lts';
     const newVersions: VersionsMap = new Map<string, string>();
     for (const [k, version] of currentVersions) {
       newVersions.set(k, Version.parse(version).bump(bumpType).toString());
@@ -42,7 +42,7 @@ export class JavaLTS extends JavaYoshi {
     latestTag: GitHubTag | undefined,
     _preRelease = false
   ): Promise<ReleaseCandidate> {
-    const bumpType = this.snapshot ? 'snapshot' : 'lts-snapshot';
+    const bumpType = this.snapshot ? 'lts-snapshot' : 'lts';
 
     const version = Version.parse(
       latestTag?.version ?? this.defaultInitialVersion()

--- a/src/releasers/java-lts.ts
+++ b/src/releasers/java-lts.ts
@@ -29,6 +29,11 @@ export class JavaLTS extends JavaYoshi {
     _latestTag: GitHubTag | undefined,
     currentVersions: VersionsMap
   ): Promise<VersionsMap> {
+    // Example versioning:
+    //   1.2.3
+    //   1.2.3-sp.1-SNAPSHOT
+    //   1.2.3-sp.1
+    //   1.2.3-sp.2-SNAPSHOT
     const bumpType = this.snapshot ? 'lts-snapshot' : 'lts';
     const newVersions: VersionsMap = new Map<string, string>();
     for (const [k, version] of currentVersions) {

--- a/src/releasers/java/bump_type.ts
+++ b/src/releasers/java/bump_type.ts
@@ -14,7 +14,7 @@
 
 import * as semver from 'semver';
 
-export type BumpType = 'major' | 'minor' | 'patch' | 'snapshot' | 'lts';
+export type BumpType = 'major' | 'minor' | 'patch' | 'snapshot' | 'lts' | 'lts-snapshot';
 
 export function maxBumpType(bumpTypes: BumpType[]): BumpType {
   if (bumpTypes.some(bumpType => bumpType === 'major')) {

--- a/src/releasers/java/bump_type.ts
+++ b/src/releasers/java/bump_type.ts
@@ -14,7 +14,13 @@
 
 import * as semver from 'semver';
 
-export type BumpType = 'major' | 'minor' | 'patch' | 'snapshot' | 'lts' | 'lts-snapshot';
+export type BumpType =
+  | 'major'
+  | 'minor'
+  | 'patch'
+  | 'snapshot'
+  | 'lts'
+  | 'lts-snapshot';
 
 export function maxBumpType(bumpTypes: BumpType[]): BumpType {
   if (bumpTypes.some(bumpType => bumpType === 'major')) {

--- a/src/releasers/java/version.ts
+++ b/src/releasers/java/version.ts
@@ -94,14 +94,21 @@ export class Version {
         break;
       case 'lts':
         if (this.lts) {
-          this.lts += 1;
-        } else {
           if (!this.snapshot) {
-            this.patch += 1;
+            this.lts += 1;
           }
+        } else {
           this.lts = 1;
         }
         this.snapshot = false;
+        break;
+      case 'lts-snapshot':
+        if (this.lts) {
+          this.lts += 1;
+        } else {
+          this.lts = 1;
+        }
+        this.snapshot = true;
         break;
       default:
         throw Error(`unsupported bump type: ${bumpType}`);

--- a/src/updaters/java/versions-manifest.ts
+++ b/src/updaters/java/versions-manifest.ts
@@ -33,20 +33,14 @@ export class VersionsManifest extends JavaUpdate {
       if (version.includes('SNAPSHOT')) {
         newLines.push(
           line.replace(
-            new RegExp(
-              `${packageName}:(.*):(.*)`,
-              'g'
-            ),
+            new RegExp(`${packageName}:(.*):(.*)`, 'g'),
             `${packageName}:$1:${version}`
           )
         );
       } else {
         newLines.push(
           line.replace(
-            new RegExp(
-              `${packageName}:(.*):(.*)`,
-              'g'
-            ),
+            new RegExp(`${packageName}:(.*):(.*)`, 'g'),
             `${packageName}:${version}:${version}`
           )
         );

--- a/src/updaters/java/versions-manifest.ts
+++ b/src/updaters/java/versions-manifest.ts
@@ -34,7 +34,7 @@ export class VersionsManifest extends JavaUpdate {
         newLines.push(
           line.replace(
             new RegExp(
-              `${packageName}:(.*):[0-9]+\\.[0-9]+\\.[0-9]+(-\\w+)?(-SNAPSHOT)?`,
+              `${packageName}:(.*):(.*)`,
               'g'
             ),
             `${packageName}:$1:${version}`
@@ -44,7 +44,7 @@ export class VersionsManifest extends JavaUpdate {
         newLines.push(
           line.replace(
             new RegExp(
-              `${packageName}:[0-9]+\\.[0-9]+\\.[0-9]+(-\\w+)?(-SNAPSHOT)?:[0-9]+\\.[0-9]+\\.[0-9]+(-\\w+)?(-SNAPSHOT)?`,
+              `${packageName}:(.*):(.*)`,
               'g'
             ),
             `${packageName}:${version}:${version}`

--- a/test/releasers/fixtures/java-yoshi/released-lts-versions.txt
+++ b/test/releasers/fixtures/java-yoshi/released-lts-versions.txt
@@ -1,0 +1,8 @@
+# Format:
+# module:released-version:current-version
+
+google-cloud-trace:0.108.0-beta-sp.1:0.108.0-beta-sp.1
+grpc-google-cloud-trace-v1:0.73.0-sp.1:0.73.0-sp.1
+grpc-google-cloud-trace-v2:0.73.0-sp.1:0.73.0-sp.1
+proto-google-cloud-trace-v1:0.73.0-sp.1:0.73.0-sp.1
+proto-google-cloud-trace-v2:0.73.0-sp.1:0.73.0-sp.1

--- a/test/releasers/fixtures/java-yoshi/versions-lts-snapshot.txt
+++ b/test/releasers/fixtures/java-yoshi/versions-lts-snapshot.txt
@@ -1,0 +1,8 @@
+# Format:
+# module:released-version:current-version
+
+google-cloud-trace:0.108.0-beta:0.108.0-beta-sp.1-SNAPSHOT
+grpc-google-cloud-trace-v1:0.73.0:0.73.0-sp.1-SNAPSHOT
+grpc-google-cloud-trace-v2:0.73.0:0.73.0-sp.1-SNAPSHOT
+proto-google-cloud-trace-v1:0.73.0:0.73.0-sp.1-SNAPSHOT
+proto-google-cloud-trace-v2:0.73.0:0.73.0-sp.1-SNAPSHOT

--- a/test/releasers/java-lts.ts
+++ b/test/releasers/java-lts.ts
@@ -247,7 +247,7 @@ describe('JavaLTS', () => {
     );
     getFileContentsStub
       .withArgs('versions.txt', 'master')
-      .resolves(buildFileContent('released-lts-versions.txt'));
+      .resolves(buildFileContent('released-versions.txt'));
     getFileContentsStub
       .withArgs('README.md', 'master')
       .resolves(buildFileContent('README.md'));

--- a/test/releasers/java-lts.ts
+++ b/test/releasers/java-lts.ts
@@ -86,7 +86,7 @@ describe('JavaLTS', () => {
     );
     getFileContentsStub
       .withArgs('versions.txt', 'master')
-      .resolves(buildFileContent('versions.txt'));
+      .resolves(buildFileContent('versions-lts-snapshot.txt'));
     getFileContentsStub
       .withArgs('README.md', 'master')
       .resolves(buildFileContent('README.md'));
@@ -168,7 +168,7 @@ describe('JavaLTS', () => {
     );
     getFileContentsStub
       .withArgs('versions.txt', 'master')
-      .resolves(buildFileContent('released-versions.txt'));
+      .resolves(buildFileContent('released-lts-versions.txt'));
     getFileContentsStub
       .withArgs('README.md', 'master')
       .resolves(buildFileContent('README.md'));
@@ -247,7 +247,7 @@ describe('JavaLTS', () => {
     );
     getFileContentsStub
       .withArgs('versions.txt', 'master')
-      .resolves(buildFileContent('released-versions.txt'));
+      .resolves(buildFileContent('released-lts-versions.txt'));
     getFileContentsStub
       .withArgs('README.md', 'master')
       .resolves(buildFileContent('README.md'));
@@ -294,7 +294,7 @@ describe('JavaLTS', () => {
     );
     getFileContentsStub
       .withArgs('versions.txt', 'master')
-      .resolves(buildFileContent('versions.txt'));
+      .resolves(buildFileContent('versions-lts-snapshot.txt'));
     getFileContentsStub.rejects(
       Object.assign(Error('not found'), {status: 404})
     );
@@ -354,7 +354,7 @@ describe('JavaLTS', () => {
     );
     getFileContentsStub
       .withArgs('versions.txt', 'master')
-      .resolves(buildFileContent('released-versions.txt'));
+      .resolves(buildFileContent('released-lts-versions.txt'));
     getFileContentsStub
       .withArgs('README.md', 'master')
       .resolves(buildFileContent('README.md'));
@@ -439,7 +439,7 @@ describe('JavaLTS', () => {
     );
     getFileContentsStub
       .withArgs('versions.txt', defaultBranch)
-      .resolves(buildFileContent('versions.txt'));
+      .resolves(buildFileContent('versions-lts-snapshot.txt'));
     getFileContentsStub
       .withArgs('README.md', defaultBranch)
       .resolves(buildFileContent('README.md'));
@@ -524,7 +524,7 @@ describe('JavaLTS', () => {
     );
     getFileContentsStub
       .withArgs('versions.txt', defaultBranch)
-      .resolves(buildFileContent('versions.txt'));
+      .resolves(buildFileContent('versions-lts-snapshot.txt'));
     getFileContentsStub
       .withArgs('README.md', defaultBranch)
       .resolves(buildFileContent('README.md'));

--- a/test/releasers/java/version.ts
+++ b/test/releasers/java/version.ts
@@ -179,11 +179,21 @@ describe('Version', () => {
         const version = Version.parse('1.23.45').bump('lts');
         expect(version.major).to.equal(1);
         expect(version.minor).to.equal(23);
-        expect(version.patch).to.equal(46);
+        expect(version.patch).to.equal(45);
         expect(version.extra).to.equal('');
         expect(version.lts).to.equal(1);
         expect(version.snapshot).to.equal(false);
-        expect(version.toString()).to.equal('1.23.46-sp.1');
+        expect(version.toString()).to.equal('1.23.45-sp.1');
+      });
+      it('should make an initial LTS snapshot bump', async () => {
+        const version = Version.parse('1.23.45').bump('lts-snapshot');
+        expect(version.major).to.equal(1);
+        expect(version.minor).to.equal(23);
+        expect(version.patch).to.equal(45);
+        expect(version.extra).to.equal('');
+        expect(version.lts).to.equal(1);
+        expect(version.snapshot).to.equal(true);
+        expect(version.toString()).to.equal('1.23.45-sp.1-SNAPSHOT');
       });
       it('should make an initial LTS bump on a SNAPSHOT', async () => {
         const version = Version.parse('1.23.45-SNAPSHOT').bump('lts');
@@ -199,14 +209,14 @@ describe('Version', () => {
         const version = Version.parse('1.23.45-beta').bump('lts');
         expect(version.major).to.equal(1);
         expect(version.minor).to.equal(23);
-        expect(version.patch).to.equal(46);
+        expect(version.patch).to.equal(45);
         expect(version.extra).to.equal('-beta');
         expect(version.lts).to.equal(1);
         expect(version.snapshot).to.equal(false);
-        expect(version.toString()).to.equal('1.23.46-beta-sp.1');
+        expect(version.toString()).to.equal('1.23.45-beta-sp.1');
       });
       it('should make a snapshot on an LTS version', async () => {
-        const version = Version.parse('1.23.45-beta-sp.1').bump('snapshot');
+        const version = Version.parse('1.23.45-beta-sp.1').bump('lts-snapshot');
         expect(version.major).to.equal(1);
         expect(version.minor).to.equal(23);
         expect(version.patch).to.equal(45);
@@ -216,7 +226,7 @@ describe('Version', () => {
         expect(version.toString()).to.equal('1.23.45-beta-sp.2-SNAPSHOT');
       });
       it('should make an LTS bump on an LTS version', async () => {
-        const version = Version.parse('1.23.45-beta-sp.1-SNAPSHOT').bump('lts');
+        const version = Version.parse('1.23.45-beta-sp.2-SNAPSHOT').bump('lts');
         expect(version.major).to.equal(1);
         expect(version.minor).to.equal(23);
         expect(version.patch).to.equal(45);


### PR DESCRIPTION
The LTS branch will not bump the minor version - it will preserve the
major/minor/patch of the version it was patched from.
