### PR TITLE
refactor: move simple-case process into base ReleasePR class

### DIFF
--- a/src/releasers/helm.ts
+++ b/src/releasers/helm.ts
@@ -13,12 +13,8 @@
 // limitations under the License.
 
 import {ReleasePR, ReleaseCandidate, PackageName} from '../release-pr';
-
-import {ConventionalCommits} from '../conventional-commits';
-import {GitHubTag, GitHubFileContents} from '../github';
-import {checkpoint, CheckpointType} from '../util/checkpoint';
+import {GitHubFileContents} from '../github';
 import {Update} from '../updaters/update';
-import {Commit} from '../graphql-to-commits';
 
 // Generic
 import {Changelog} from '../updaters/changelog';
@@ -30,49 +26,11 @@ export class Helm extends ReleasePR {
   private chartYmlContents?: GitHubFileContents;
   private _packageName?: string;
 
-  protected async _run(): Promise<number | undefined> {
-    // Make an effort to populate packageName from the contents of
-    // the package.json, rather than forcing this to be set:
-
-    const packageName = await this.getPackageName();
-    const latestTag: GitHubTag | undefined = await this.latestTag(
-      this.monorepoTags ? `${packageName.getComponent()}-` : undefined
-    );
-    const commits: Commit[] = await this.commits({
-      sha: latestTag ? latestTag.sha : undefined,
-      path: this.path,
-    });
-
-    const cc = new ConventionalCommits({
-      commits,
-      owner: this.gh.owner,
-      repository: this.gh.repo,
-      bumpMinorPreMajor: this.bumpMinorPreMajor,
-      changelogSections: this.changelogSections,
-    });
-    const candidate: ReleaseCandidate = await this.coerceReleaseCandidate(
-      cc,
-      latestTag
-    );
-    const changelogEntry: string = await cc.generateChangelogEntry({
-      version: candidate.version,
-      currentTag: `v${candidate.version}`,
-      previousTag: candidate.previousTag,
-    });
-
-    // don't create a release candidate until user facing changes
-    // (fix, feat, BREAKING CHANGE) have been made; a CHANGELOG that's
-    // one line is a good indicator that there were no interesting commits.
-    if (this.changelogEmpty(changelogEntry)) {
-      checkpoint(
-        `no user facing commits found since ${
-          latestTag ? latestTag.sha : 'beginning of time'
-        }`,
-        CheckpointType.Failure
-      );
-      return undefined;
-    }
-
+  protected async buildUpdates(
+    changelogEntry: string,
+    candidate: ReleaseCandidate,
+    packageName: PackageName
+  ): Promise<Update[]> {
     const updates: Update[] = [];
 
     updates.push(
@@ -93,14 +51,7 @@ export class Helm extends ReleasePR {
         contents: await this.getChartYmlContents(),
       })
     );
-
-    return await this.openPR({
-      sha: commits[0].sha!,
-      changelogEntry: `${changelogEntry}\n---\n`,
-      updates,
-      version: candidate.version,
-      includePackageName: this.monorepoTags,
-    });
+    return updates;
   }
 
   async getPackageName(): Promise<PackageName> {

--- a/src/releasers/java-yoshi.ts
+++ b/src/releasers/java-yoshi.ts
@@ -153,7 +153,7 @@ export class JavaYoshi extends ReleasePR {
     }
 
     const packageName = await this.getPackageName();
-    const updates = await this.buildUpdates(
+    const updates = await this.buildJavaUpdates(
       changelogEntry,
       candidateVersions,
       candidate,
@@ -203,7 +203,7 @@ export class JavaYoshi extends ReleasePR {
     return await super.coerceReleaseCandidate(cc, latestTag, preRelease);
   }
 
-  protected async buildUpdates(
+  protected async buildJavaUpdates(
     changelogEntry: string,
     candidateVersions: VersionsMap,
     candidate: ReleaseCandidate,

--- a/src/releasers/ocaml.ts
+++ b/src/releasers/ocaml.ts
@@ -12,19 +12,16 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import {ReleasePR, ReleaseCandidate} from '../release-pr';
-
-import {ConventionalCommits} from '../conventional-commits';
-import {GitHubTag, GitHubFileContents} from '../github';
-import {checkpoint, CheckpointType} from '../util/checkpoint';
+import {ReleasePR, ReleaseCandidate, PackageName} from '../release-pr';
+import {GitHubFileContents} from '../github';
 import {Update} from '../updaters/update';
-import {Commit} from '../graphql-to-commits';
 
 // Generic
 import {Changelog} from '../updaters/changelog';
 // OCaml
 import {Opam} from '../updaters/ocaml/opam';
 import {EsyJson} from '../updaters/ocaml/esy-json';
+import {ReleasePRConstructorOptions} from '..';
 
 const notEsyLock = (path: string) => !path.startsWith('esy.lock');
 
@@ -42,47 +39,17 @@ const CHANGELOG_SECTIONS = [
 ];
 
 export class OCaml extends ReleasePR {
-  protected async _run(): Promise<number | undefined> {
-    const packageName = await this.getPackageName();
-    const latestTag: GitHubTag | undefined = await this.latestTag(
-      this.monorepoTags ? `${packageName.getComponent()}-` : undefined
-    );
-    const commits: Commit[] = await this.commits({
-      sha: latestTag ? latestTag.sha : undefined,
-      path: this.path,
-    });
+  constructor(options: ReleasePRConstructorOptions) {
+    super(options);
+    // FIXME: this was previously hard-coded, do allow overriding?
+    this.changelogSections = CHANGELOG_SECTIONS;
+  }
 
-    const cc = new ConventionalCommits({
-      commits,
-      owner: this.gh.owner,
-      repository: this.gh.repo,
-      bumpMinorPreMajor: this.bumpMinorPreMajor,
-      // TODO: Is this configurable?
-      changelogSections: CHANGELOG_SECTIONS,
-    });
-    const candidate: ReleaseCandidate = await this.coerceReleaseCandidate(
-      cc,
-      latestTag
-    );
-    const changelogEntry: string = await cc.generateChangelogEntry({
-      version: candidate.version,
-      currentTag: `v${candidate.version}`,
-      previousTag: candidate.previousTag,
-    });
-
-    // don't create a release candidate until user facing changes
-    // (fix, feat, BREAKING CHANGE) have been made; a CHANGELOG that's
-    // one line is a good indicator that there were no interesting commits.
-    if (this.changelogEmpty(changelogEntry)) {
-      checkpoint(
-        `no user facing commits found since ${
-          latestTag ? latestTag.sha : 'beginning of time'
-        }`,
-        CheckpointType.Failure
-      );
-      return undefined;
-    }
-
+  protected async buildUpdates(
+    changelogEntry: string,
+    candidate: ReleaseCandidate,
+    packageName: PackageName
+  ): Promise<Update[]> {
     const updates: Update[] = [];
 
     const jsonPaths = await this.gh.findFilesByExtension('json');
@@ -126,13 +93,6 @@ export class OCaml extends ReleasePR {
         packageName: packageName.name,
       })
     );
-
-    return await this.openPR({
-      sha: commits[0].sha!,
-      changelogEntry: `${changelogEntry}\n---\n`,
-      updates,
-      version: candidate.version,
-      includePackageName: this.monorepoTags,
-    });
+    return updates;
   }
 }

--- a/src/releasers/simple.ts
+++ b/src/releasers/simple.ts
@@ -13,12 +13,7 @@
 // limitations under the License.
 
 import {ReleasePR, ReleaseCandidate, PackageName} from '../release-pr';
-
-import {ConventionalCommits} from '../conventional-commits';
-import {GitHubTag} from '../github';
-import {checkpoint, CheckpointType} from '../util/checkpoint';
 import {Update} from '../updaters/update';
-import {Commit} from '../graphql-to-commits';
 
 // Generic
 import {Changelog} from '../updaters/changelog';
@@ -26,62 +21,6 @@ import {Changelog} from '../updaters/changelog';
 import {VersionTxt} from '../updaters/version-txt';
 
 export class Simple extends ReleasePR {
-  protected async _run(): Promise<number | undefined> {
-    const packageName = await this.getPackageName();
-    const latestTag: GitHubTag | undefined = await this.latestTag(
-      this.monorepoTags ? `${packageName.getComponent()}-` : undefined
-    );
-    const commits: Commit[] = await this.commits({
-      sha: latestTag ? latestTag.sha : undefined,
-      path: this.path,
-    });
-
-    const cc = new ConventionalCommits({
-      commits,
-      owner: this.gh.owner,
-      repository: this.gh.repo,
-      bumpMinorPreMajor: this.bumpMinorPreMajor,
-      changelogSections: this.changelogSections,
-    });
-    const candidate: ReleaseCandidate = await this.coerceReleaseCandidate(
-      cc,
-      latestTag
-    );
-
-    const changelogEntry: string = await cc.generateChangelogEntry({
-      version: candidate.version,
-      currentTag: `v${candidate.version}`,
-      previousTag: candidate.previousTag,
-    });
-
-    // don't create a release candidate until user facing changes
-    // (fix, feat, BREAKING CHANGE) have been made; a CHANGELOG that's
-    // one line is a good indicator that there were no interesting commits.
-    if (this.changelogEmpty(changelogEntry)) {
-      checkpoint(
-        `no user facing commits found since ${
-          latestTag ? latestTag.sha : 'beginning of time'
-        }`,
-        CheckpointType.Failure
-      );
-      return undefined;
-    }
-
-    const updates = await this.buildUpdates(
-      changelogEntry,
-      candidate,
-      packageName
-    );
-
-    return await this.openPR({
-      sha: commits[0].sha!,
-      changelogEntry: `${changelogEntry}\n---\n`,
-      updates,
-      version: candidate.version,
-      includePackageName: this.monorepoTags,
-    });
-  }
-
   protected async buildUpdates(
     changelogEntry: string,
     candidate: ReleaseCandidate,

--- a/src/releasers/simple.ts
+++ b/src/releasers/simple.ts
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import {ReleasePR, ReleaseCandidate} from '../release-pr';
+import {ReleasePR, ReleaseCandidate, PackageName} from '../release-pr';
 
 import {ConventionalCommits} from '../conventional-commits';
 import {GitHubTag} from '../github';
@@ -67,6 +67,26 @@ export class Simple extends ReleasePR {
       return undefined;
     }
 
+    const updates = await this.buildUpdates(
+      changelogEntry,
+      candidate,
+      packageName
+    );
+
+    return await this.openPR({
+      sha: commits[0].sha!,
+      changelogEntry: `${changelogEntry}\n---\n`,
+      updates,
+      version: candidate.version,
+      includePackageName: this.monorepoTags,
+    });
+  }
+
+  protected async buildUpdates(
+    changelogEntry: string,
+    candidate: ReleaseCandidate,
+    packageName: PackageName
+  ): Promise<Update[]> {
     const updates: Update[] = [];
 
     updates.push(
@@ -87,12 +107,6 @@ export class Simple extends ReleasePR {
       })
     );
 
-    return await this.openPR({
-      sha: commits[0].sha!,
-      changelogEntry: `${changelogEntry}\n---\n`,
-      updates,
-      version: candidate.version,
-      includePackageName: this.monorepoTags,
-    });
+    return updates;
   }
 }

--- a/src/releasers/terraform-module.ts
+++ b/src/releasers/terraform-module.ts
@@ -12,13 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import {ReleasePR, ReleaseCandidate} from '../release-pr';
-
-import {ConventionalCommits} from '../conventional-commits';
-import {GitHubTag} from '../github';
-import {checkpoint, CheckpointType} from '../util/checkpoint';
+import {ReleaseCandidate, PackageName, ReleasePR} from '../release-pr';
 import {Update} from '../updaters/update';
-import {Commit} from '../graphql-to-commits';
 
 // Generic
 import {Changelog} from '../updaters/changelog';
@@ -27,47 +22,11 @@ import {ReadMe} from '../updaters/terraform/readme';
 import {ModuleVersion} from '../updaters/terraform/module-version';
 
 export class TerraformModule extends ReleasePR {
-  protected async _run(): Promise<number | undefined> {
-    const packageName = await this.getPackageName();
-    const latestTag: GitHubTag | undefined = await this.latestTag(
-      this.monorepoTags ? `${packageName.getComponent()}-` : undefined
-    );
-    const commits: Commit[] = await this.commits({
-      sha: latestTag ? latestTag.sha : undefined,
-      path: this.path,
-    });
-
-    const cc = new ConventionalCommits({
-      commits,
-      owner: this.gh.owner,
-      repository: this.gh.repo,
-      bumpMinorPreMajor: this.bumpMinorPreMajor,
-      changelogSections: this.changelogSections,
-    });
-    const candidate: ReleaseCandidate = await this.coerceReleaseCandidate(
-      cc,
-      latestTag
-    );
-
-    const changelogEntry: string = await cc.generateChangelogEntry({
-      version: candidate.version,
-      currentTag: `v${candidate.version}`,
-      previousTag: candidate.previousTag,
-    });
-
-    // don't create a release candidate until user facing changes
-    // (fix, feat, BREAKING CHANGE) have been made; a CHANGELOG that's
-    // one line is a good indicator that there were no interesting commits.
-    if (this.changelogEmpty(changelogEntry)) {
-      checkpoint(
-        `no user facing commits found since ${
-          latestTag ? latestTag.sha : 'beginning of time'
-        }`,
-        CheckpointType.Failure
-      );
-      return undefined;
-    }
-
+  protected async buildUpdates(
+    changelogEntry: string,
+    candidate: ReleaseCandidate,
+    packageName: PackageName
+  ): Promise<Update[]> {
     const updates: Update[] = [];
 
     updates.push(
@@ -111,14 +70,7 @@ export class TerraformModule extends ReleasePR {
         })
       );
     });
-
-    return await this.openPR({
-      sha: commits[0].sha!,
-      changelogEntry: `${changelogEntry}\n---\n`,
-      updates,
-      version: candidate.version,
-      includePackageName: this.monorepoTags,
-    });
+    return updates;
   }
 
   defaultInitialVersion(): string {


### PR DESCRIPTION
For the basic release PR classes, we should only need to specify the files (updaters) that are necessary. This will greatly ease the process for creating new release types.
