### PR TITLE
refactor: simplify ruby releaser

### DIFF
--- a/src/release-pr.ts
+++ b/src/release-pr.ts
@@ -48,7 +48,7 @@ export interface CandidateRelease {
   pullNumber: number;
 }
 
-interface GetCommitsOptions {
+export interface GetCommitsOptions {
   sha?: string;
   perPage?: number;
   labels?: boolean;


### PR DESCRIPTION
Ruby follows the basic workflow, so simplify to only specify the files to update