### PR TITLE
fix: Java replacer should handle `-sp.1` version replacements

### DIFF
--- a/__snapshots__/java-update.js
+++ b/__snapshots__/java-update.js
@@ -1,0 +1,83 @@
+exports['JavaUpdate updateContent updates an LTS snapshot version 1'] = `
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <parent>
+    <groupId>com.google.auth</groupId>
+    <artifactId>google-auth-library-parent</artifactId>
+    <version>v0.16.2-sp.1</version><!-- {x-version-update:google-auth-library-parent:current} -->
+    <relativePath>../pom.xml</relativePath>
+  </parent>
+
+  <groupId>com.google.auth</groupId>
+  <artifactId>google-auth-library-appengine</artifactId>
+  <version>v0.16.2-sp.1</version><!-- {x-version-update:google-auth-library-parent:current} -->
+  <name>Google Auth Library for Java - Google App Engine</name>
+
+  <distributionManagement>
+    <snapshotRepository>
+      <id>ossrh</id>
+      <url>https://oss.sonatype.org/content/repositories/snapshots</url>
+    </snapshotRepository>
+  </distributionManagement>
+
+  <build>
+    <sourceDirectory>java</sourceDirectory>
+    <testSourceDirectory>javatests</testSourceDirectory>
+    <plugins>
+      <plugin>
+        <groupId>org.sonatype.plugins</groupId>
+        <artifactId>nexus-staging-maven-plugin</artifactId>
+      </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-source-plugin</artifactId>
+      </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-javadoc-plugin</artifactId>
+      </plugin>
+    </plugins>
+  </build>
+
+  <dependencies>
+    <dependency>
+      <groupId>com.google.auth</groupId>
+      <artifactId>google-auth-library-credentials</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>com.google.auth</groupId>
+      <artifactId>google-auth-library-oauth2-http</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>com.google.http-client</groupId>
+      <artifactId>google-http-client</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>com.google.http-client</groupId>
+      <artifactId>google-http-client-jackson2</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>com.google.appengine</groupId>
+      <artifactId>appengine-api-1.0-sdk</artifactId>
+      <scope>provided</scope>
+    </dependency>
+    <dependency>
+      <groupId>com.google.guava</groupId>
+      <artifactId>guava</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>junit</groupId>
+      <artifactId>junit</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>com.google.auth</groupId>
+      <artifactId>google-auth-library-oauth2-http</artifactId>
+      <type>test-jar</type>
+      <scope>test</scope>
+    </dependency>
+  </dependencies>
+</project>
+`

--- a/src/updaters/java/java_update.ts
+++ b/src/updaters/java/java_update.ts
@@ -18,7 +18,7 @@ import {GitHubFileContents} from '../../github';
 const INLINE_UPDATE_REGEX = /{x-version-update:([\w\-_]+):(current|released)}/;
 const BLOCK_START_REGEX = /{x-version-update-start:([\w\-_]+):(current|released)}/;
 const BLOCK_END_REGEX = /{x-version-update-end}/;
-const VERSION_REGEX = /\d+\.\d+\.\d+(-\w+)?(-SNAPSHOT)?/;
+const VERSION_REGEX = /\d+\.\d+\.\d+(-\w+(\.\d+)?)?(-SNAPSHOT)?/;
 
 export class JavaUpdate implements Update {
   path: string;

--- a/test/updaters/fixtures/pom-java-lts-snapshot.xml
+++ b/test/updaters/fixtures/pom-java-lts-snapshot.xml
@@ -1,0 +1,81 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <parent>
+    <groupId>com.google.auth</groupId>
+    <artifactId>google-auth-library-parent</artifactId>
+    <version>0.16.2-sp.1-SNAPSHOT</version><!-- {x-version-update:google-auth-library-parent:current} -->
+    <relativePath>../pom.xml</relativePath>
+  </parent>
+
+  <groupId>com.google.auth</groupId>
+  <artifactId>google-auth-library-appengine</artifactId>
+  <version>0.16.2-sp.1-SNAPSHOT</version><!-- {x-version-update:google-auth-library-parent:current} -->
+  <name>Google Auth Library for Java - Google App Engine</name>
+
+  <distributionManagement>
+    <snapshotRepository>
+      <id>ossrh</id>
+      <url>https://oss.sonatype.org/content/repositories/snapshots</url>
+    </snapshotRepository>
+  </distributionManagement>
+
+  <build>
+    <sourceDirectory>java</sourceDirectory>
+    <testSourceDirectory>javatests</testSourceDirectory>
+    <plugins>
+      <plugin>
+        <groupId>org.sonatype.plugins</groupId>
+        <artifactId>nexus-staging-maven-plugin</artifactId>
+      </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-source-plugin</artifactId>
+      </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-javadoc-plugin</artifactId>
+      </plugin>
+    </plugins>
+  </build>
+
+  <dependencies>
+    <dependency>
+      <groupId>com.google.auth</groupId>
+      <artifactId>google-auth-library-credentials</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>com.google.auth</groupId>
+      <artifactId>google-auth-library-oauth2-http</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>com.google.http-client</groupId>
+      <artifactId>google-http-client</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>com.google.http-client</groupId>
+      <artifactId>google-http-client-jackson2</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>com.google.appengine</groupId>
+      <artifactId>appengine-api-1.0-sdk</artifactId>
+      <scope>provided</scope>
+    </dependency>
+    <dependency>
+      <groupId>com.google.guava</groupId>
+      <artifactId>guava</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>junit</groupId>
+      <artifactId>junit</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>com.google.auth</groupId>
+      <artifactId>google-auth-library-oauth2-http</artifactId>
+      <type>test-jar</type>
+      <scope>test</scope>
+    </dependency>
+  </dependencies>
+</project>

--- a/test/updaters/java-update.ts
+++ b/test/updaters/java-update.ts
@@ -16,7 +16,7 @@ import {readFileSync} from 'fs';
 import {resolve} from 'path';
 import * as snapshot from 'snap-shot-it';
 import {describe, it} from 'mocha';
-import { JavaUpdate } from '../../src/updaters/java/java_update';
+import {JavaUpdate} from '../../src/updaters/java/java_update';
 
 const fixturesPath = './test/updaters/fixtures';
 
@@ -27,7 +27,7 @@ describe('JavaUpdate', () => {
         resolve(fixturesPath, './pom-java-lts-snapshot.xml'),
         'utf8'
       ).replace(/\r\n/g, '\n');
-      const versions = new Map<string,string>();
+      const versions = new Map<string, string>();
       versions.set('google-auth-library-parent', 'v0.16.2-sp.1');
       const pom = new JavaUpdate({
         path: 'pom.xml',

--- a/test/updaters/java-update.ts
+++ b/test/updaters/java-update.ts
@@ -1,0 +1,43 @@
+// Copyright 2021 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import {readFileSync} from 'fs';
+import {resolve} from 'path';
+import * as snapshot from 'snap-shot-it';
+import {describe, it} from 'mocha';
+import { JavaUpdate } from '../../src/updaters/java/java_update';
+
+const fixturesPath = './test/updaters/fixtures';
+
+describe('JavaUpdate', () => {
+  describe('updateContent', () => {
+    it('updates an LTS snapshot version', async () => {
+      const oldContent = readFileSync(
+        resolve(fixturesPath, './pom-java-lts-snapshot.xml'),
+        'utf8'
+      ).replace(/\r\n/g, '\n');
+      const versions = new Map<string,string>();
+      versions.set('google-auth-library-parent', 'v0.16.2-sp.1');
+      const pom = new JavaUpdate({
+        path: 'pom.xml',
+        changelogEntry: '',
+        versions,
+        version: 'unused',
+        packageName: 'unused',
+      });
+      const newContent = pom.updateContent(oldContent);
+      snapshot(newContent);
+    });
+  });
+});


### PR DESCRIPTION
Fixes #873 