### PR TITLE
feat: add generic go releaser

### DIFF
--- a/__snapshots__/go.js
+++ b/__snapshots__/go.js
@@ -1,0 +1,39 @@
+exports['Go run creates a release PR: changes'] = `
+
+filename: CHANGES.md
+# Changelog
+
+### [0.123.5](https://www.github.com/googleapis/simple-test-repo/compare/v0.123.4...v0.123.5) (1983-10-10)
+
+
+### Bug Fixes
+
+* **deps:** update dependency com.google.cloud:google-cloud-spanner to v1.50.0 ([1f9663c](https://www.github.com/googleapis/simple-test-repo/commit/1f9663cf08ab1cf3b68d95dee4dc99b7c4aac373))
+* **deps:** update dependency com.google.cloud:google-cloud-storage to v1.120.0 ([fcd1c89](https://www.github.com/googleapis/simple-test-repo/commit/fcd1c890dc1526f4d62ceedad561f498195c8939))
+
+`
+
+exports['Go run creates a release PR: options'] = `
+
+upstreamOwner: googleapis
+upstreamRepo: simple-test-repo
+title: chore: release 0.123.5
+branch: release-v0.123.5
+description: :robot: I have created a release \\*beep\\* \\*boop\\*
+---
+### [0.123.5](https://www.github.com/googleapis/simple-test-repo/compare/v0.123.4...v0.123.5) (1983-10-10)
+
+
+### Bug Fixes
+
+* **deps:** update dependency com.google.cloud:google-cloud-spanner to v1.50.0 ([1f9663c](https://www.github.com/googleapis/simple-test-repo/commit/1f9663cf08ab1cf3b68d95dee4dc99b7c4aac373))
+* **deps:** update dependency com.google.cloud:google-cloud-storage to v1.120.0 ([fcd1c89](https://www.github.com/googleapis/simple-test-repo/commit/fcd1c890dc1526f4d62ceedad561f498195c8939))
+---
+
+
+This PR was generated with [Release Please](https://github.com/googleapis/release-please). See [documentation](https://github.com/googleapis/release-please#release-please).
+primary: main
+force: true
+fork: false
+message: chore: release 0.123.5
+`

--- a/src/releasers/go.ts
+++ b/src/releasers/go.ts
@@ -1,4 +1,4 @@
-// Copyright 2020 Google LLC
+// Copyright 2021 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/releasers/go.ts
+++ b/src/releasers/go.ts
@@ -1,0 +1,48 @@
+// Copyright 2020 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import {ReleasePR, ReleaseCandidate, PackageName} from '../release-pr';
+import {Update} from '../updaters/update';
+
+// Generic
+import {Changelog} from '../updaters/changelog';
+import {ReleasePRConstructorOptions} from '..';
+
+const DEFAULT_CHANGELOG_PATH = 'CHANGES.md';
+
+export class Go extends ReleasePR {
+  constructor(options: ReleasePRConstructorOptions) {
+    super(options);
+    this.changelogPath = options.changelogPath ?? DEFAULT_CHANGELOG_PATH;
+  }
+
+  protected async buildUpdates(
+    changelogEntry: string,
+    candidate: ReleaseCandidate,
+    packageName: PackageName
+  ): Promise<Update[]> {
+    const updates: Update[] = [];
+
+    updates.push(
+      new Changelog({
+        path: this.addPath(this.changelogPath),
+        changelogEntry,
+        version: candidate.version,
+        packageName: packageName.name,
+      })
+    );
+
+    return updates;
+  }
+}

--- a/src/releasers/index.ts
+++ b/src/releasers/index.ts
@@ -14,6 +14,7 @@
 
 import {ReleasePR} from '../release-pr';
 
+import {Go} from './go';
 import {GoYoshi} from './go-yoshi';
 import {JavaBom} from './java-bom';
 import {JavaLTS} from './java-lts';
@@ -51,7 +52,7 @@ export type ReleaseType =
 type Releasers = Record<ReleaseType, typeof ReleasePR>;
 
 const releasers: Releasers = {
-  go: GoYoshi, // TODO(codyoss): refactor this into a more generic go strategy.
+  go: Go,
   'go-yoshi': GoYoshi,
   'java-bom': JavaBom,
   'java-lts': JavaLTS,

--- a/test/releasers/go.ts
+++ b/test/releasers/go.ts
@@ -1,4 +1,4 @@
-// Copyright 2020 Google LLC
+// Copyright 2021 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/test/releasers/go.ts
+++ b/test/releasers/go.ts
@@ -1,0 +1,82 @@
+// Copyright 2020 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import {describe, it, afterEach} from 'mocha';
+import {Go} from '../../src/releasers/go';
+import {readPOJO, stubSuggesterWithSnapshot} from '../helpers';
+import * as nock from 'nock';
+import * as sinon from 'sinon';
+import {GitHub} from '../../src/github';
+
+nock.disableNetConnect();
+const sandbox = sinon.createSandbox();
+
+describe('Go', () => {
+  afterEach(() => {
+    sandbox.restore();
+  });
+  describe('run', () => {
+    it('creates a release PR', async function () {
+      const releasePR = new Go({
+        github: new GitHub({owner: 'googleapis', repo: 'simple-test-repo'}),
+        packageName: 'simple-test-repo',
+      });
+
+      // Indicates that there are no PRs currently waiting to be released:
+      sandbox
+        .stub(releasePR.gh, 'findMergedReleasePR')
+        .returns(Promise.resolve(undefined));
+
+      // Return latest tag used to determine next version #:
+      sandbox.stub(releasePR, 'latestTag').returns(
+        Promise.resolve({
+          sha: 'da6e52d956c1e35d19e75e0f2fdba439739ba364',
+          name: 'v0.123.4',
+          version: '0.123.4',
+        })
+      );
+
+      // Commits, used to build CHANGELOG, and propose next version bump:
+      sandbox
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        .stub(releasePR as any, 'commits')
+        .returns(Promise.resolve(readPOJO('commits-fix')));
+
+      // See if there are any release PRs already open, we do this as
+      // we consider opening a new release-pr:
+      sandbox
+        .stub(releasePR.gh, 'findOpenReleasePRs')
+        .returns(Promise.resolve([]));
+
+      // Lookup the default branch name:
+      sandbox.stub(releasePR.gh, 'getDefaultBranch').resolves('main');
+
+      // Fetch files from GitHub, in prep to update with code-suggester:
+      const getFileContentsStub = sandbox.stub(
+        releasePR.gh,
+        'getFileContentsOnBranch'
+      );
+      // CHANGELOG is not found, and will be created:
+      getFileContentsStub
+        .onCall(0)
+        .rejects(Object.assign(Error('not found'), {status: 404}));
+
+      // Call to add autorelease: pending label:
+      sandbox.stub(releasePR.gh, 'addLabels');
+
+      stubSuggesterWithSnapshot(sandbox, this.test!.fullTitle());
+      await releasePR.run();
+    });
+  });
+});


### PR DESCRIPTION
Adds a generic golang releaser. It only updates the changlog (defaults to `CHANGES.md`) as tags are the release version.

Fixes #882 
