### PR TITLE
fix(release-as): commits with Release-As footer now create release

### DIFF
--- a/__snapshots__/conventional-commits.js
+++ b/__snapshots__/conventional-commits.js
@@ -16,6 +16,15 @@ exports['ConventionalCommits generateChangelogEntry does not include content two
 * upgrade to Node 7 ([abc345](https://www.github.com/bcoe/release-please/commit/abc345))
 `
 
+exports['ConventionalCommits generateChangelogEntry includes any commits with a "Release-As" footer 1'] = `
+## v1.0.0 (1665-10-10)
+
+
+### meta
+
+* correct release ([abc345](https://www.github.com/bcoe/release-please/commit/abc345))
+`
+
 exports['ConventionalCommits generateChangelogEntry includes multi-line breaking changes 1'] = `
 ## v1.0.0 (1665-10-10)
 

--- a/package.json
+++ b/package.json
@@ -71,7 +71,7 @@
     "@types/npm-package-arg": "^6.1.0",
     "chalk": "^4.0.0",
     "code-suggester": "^1.4.0",
-    "conventional-changelog-conventionalcommits": "^4.4.0",
+    "conventional-changelog-conventionalcommits": "^4.6.0",
     "conventional-changelog-writer": "^5.0.0",
     "conventional-commits-filter": "^2.0.2",
     "figures": "^3.0.0",

--- a/src/util/to-conventional-changelog-format.ts
+++ b/src/util/to-conventional-changelog-format.ts
@@ -212,7 +212,7 @@ export default function toConventionalChangelogFormat(
       if (parent.type === 'token') {
         parent = ancestors.pop();
         let footerText = '';
-        const semanticFooter = node.value.toLowerCase() === 'release-as'
+        const semanticFooter = node.value.toLowerCase() === 'release-as';
         visit(
           parent,
           ['type', 'scope', 'breaking-change', 'separator', 'text', 'newline'],

--- a/src/util/to-conventional-changelog-format.ts
+++ b/src/util/to-conventional-changelog-format.ts
@@ -212,6 +212,7 @@ export default function toConventionalChangelogFormat(
       if (parent.type === 'token') {
         parent = ancestors.pop();
         let footerText = '';
+        const semanticFooter = node.value.toLowerCase() === 'release-as'
         visit(
           parent,
           ['type', 'scope', 'breaking-change', 'separator', 'text', 'newline'],
@@ -231,6 +232,12 @@ export default function toConventionalChangelogFormat(
             }
           }
         );
+        // Any footers that carry semantic meaning, e.g., Release-As, should
+        // be added to the footer field, for the benefits of post-processing:
+        if (semanticFooter) {
+          if (!headerCommit.footer) headerCommit.footer = '';
+          headerCommit.footer += `\n${footerText.toLowerCase()}`.trimStart();
+        }
         try {
           for (const commit of toConventionalChangelogFormat(
             parser.parser(footerText)

--- a/test/conventional-commits.ts
+++ b/test/conventional-commits.ts
@@ -240,5 +240,26 @@ fix(securitycenter): fixes security center.
       });
       snapshot(cl.replace(/[0-9]{4}-[0-9]{2}-[0-9]{2}/g, '1665-10-10'));
     });
+
+    it('includes any commits with a "Release-As" footer', async () => {
+      const cc = new ConventionalCommits({
+        commits: [
+          {
+            message: `meta: correct release
+
+Release-As: v3.0.0`,
+            sha: 'abc345',
+            files: [],
+          },
+        ],
+        owner: 'bcoe',
+        repository: 'release-please',
+        bumpMinorPreMajor: true,
+      });
+      const cl = await cc.generateChangelogEntry({
+        version: 'v1.0.0',
+      });
+      snapshot(cl.replace(/[0-9]{4}-[0-9]{2}-[0-9]{2}/g, '1665-10-10'));
+    });
   });
 });


### PR DESCRIPTION
If someone adds a `Release-As` commit, it should be reflected in the CHANGELOG. This has confused a few folks, especially if there have been no user facing commits except `release-as`.

Fixes #749
Refs: https://github.com/conventional-changelog/conventional-changelog/pull/796
