### PR TITLE
fix(ruby-yoshi): Fix the initial release of new Ruby-Yoshi libraries

### DIFF
--- a/src/releasers/ruby-yoshi.ts
+++ b/src/releasers/ruby-yoshi.ts
@@ -75,12 +75,14 @@ export class RubyYoshi extends ReleasePR {
         ),
         changelogSections: CHANGELOG_SECTIONS,
       });
+      const githubTag: GitHubTag | undefined = this.lastPackageVersion
+        ? {
+            version: this.lastPackageVersion,
+            name: this.lastPackageVersion,
+          } as GitHubTag
+        : undefined;
       const candidate: ReleaseCandidate = await this.coerceReleaseCandidate(
-        cc,
-        {
-          version: this.lastPackageVersion,
-          name: this.lastPackageVersion,
-        } as GitHubTag
+        cc, githubTag
       );
       const changelogEntry: string = await cc.generateChangelogEntry({
         version: candidate.version,

--- a/src/releasers/ruby-yoshi.ts
+++ b/src/releasers/ruby-yoshi.ts
@@ -76,13 +76,14 @@ export class RubyYoshi extends ReleasePR {
         changelogSections: CHANGELOG_SECTIONS,
       });
       const githubTag: GitHubTag | undefined = this.lastPackageVersion
-        ? {
+        ? ({
             version: this.lastPackageVersion,
             name: this.lastPackageVersion,
-          } as GitHubTag
+          } as GitHubTag)
         : undefined;
       const candidate: ReleaseCandidate = await this.coerceReleaseCandidate(
-        cc, githubTag
+        cc,
+        githubTag
       );
       const changelogEntry: string = await cc.generateChangelogEntry({
         version: candidate.version,

--- a/test/releasers/ruby-yoshi.ts
+++ b/test/releasers/ruby-yoshi.ts
@@ -1,0 +1,100 @@
+// Copyright 2021 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import * as assert from 'assert';
+import {describe, it, afterEach} from 'mocha';
+import {GitHub} from '../../src/github';
+import * as sinon from 'sinon';
+import {stubFilesFromFixtures} from './utils';
+import {buildMockCommit, stubSuggesterWithSnapshot} from '../helpers';
+import {RubyYoshi} from '../../src/releasers/ruby-yoshi';
+
+const sandbox = sinon.createSandbox();
+
+function stubFilesToUpdate(github: GitHub, files: string[]) {
+  stubFilesFromFixtures({
+    fixturePath: './test/updaters/fixtures',
+    sandbox,
+    github,
+    files,
+  });
+}
+
+const TAG_SHA = 'da6e52d956c1e35d19e75e0f2fdba439739ba364';
+
+const COMMITS = [
+  buildMockCommit(
+    'fix(deps): update dependency com.google.cloud:google-cloud-storage to v1.120.0'
+  ),
+  buildMockCommit(
+    'fix(deps): update dependency com.google.cloud:google-cloud-spanner to v1.50.0'
+  ),
+  buildMockCommit('chore: update common templates'),
+];
+
+function stubGithub(releasePR: RubyYoshi) {
+  sandbox
+    .stub(releasePR.gh, 'findMergedReleasePR')
+    .returns(Promise.resolve(undefined));
+  sandbox.stub(releasePR.gh, 'findOpenReleasePRs').returns(Promise.resolve([]));
+  sandbox.stub(releasePR.gh, 'addLabels');
+  sandbox.stub(releasePR.gh, 'getDefaultBranch').resolves('master');
+}
+
+describe('RubyYoshi', () => {
+  afterEach(() => {
+    sandbox.restore();
+  });
+  const pkgName = 'google-cloud-automl';
+
+  describe('run', () => {
+    it('creates a release PR with a previous release', async function () {
+      const releasePR = new RubyYoshi({
+        github: new GitHub({owner: 'googleapis', repo: 'ruby-test-repo'}),
+        versionFile: 'version.rb',
+        bumpMinorPreMajor: true,
+        monorepoTags: true,
+        packageName: pkgName,
+        lastPackageVersion: '0.5.0',
+      });
+
+      stubSuggesterWithSnapshot(sandbox, this.test!.fullTitle());
+      stubGithub(releasePR);
+      sandbox.stub(releasePR.gh, 'getTagSha').resolves(TAG_SHA);
+      sandbox.stub(releasePR.gh, 'commitsSinceSha').resolves(COMMITS);
+      stubFilesToUpdate(releasePR.gh, ['version.rb']);
+
+      const pr = await releasePR.run();
+      assert.strictEqual(pr, 22);
+    });
+
+    it('creates a release PR with no previous release', async function () {
+      const releasePR = new RubyYoshi({
+        github: new GitHub({owner: 'googleapis', repo: 'ruby-test-repo'}),
+        versionFile: 'version.rb',
+        bumpMinorPreMajor: true,
+        monorepoTags: true,
+        packageName: pkgName,
+      });
+
+      stubSuggesterWithSnapshot(sandbox, this.test!.fullTitle());
+      stubGithub(releasePR);
+      sandbox.stub(releasePR.gh, 'commitsSinceSha').resolves(COMMITS);
+      stubFilesToUpdate(releasePR.gh, ['version.rb']);
+
+      const pr = await releasePR.run();
+      assert.strictEqual(pr, 22);
+    });
+  });
+});

--- a/test/releasers/ruby-yoshi.ts
+++ b/test/releasers/ruby-yoshi.ts
@@ -48,6 +48,7 @@ function stubGithub(releasePR: RubyYoshi) {
     .stub(releasePR.gh, 'findMergedReleasePR')
     .returns(Promise.resolve(undefined));
   sandbox.stub(releasePR.gh, 'findOpenReleasePRs').returns(Promise.resolve([]));
+  sandbox.stub(releasePR.gh, 'openPR').resolves(22);
   sandbox.stub(releasePR.gh, 'addLabels');
   sandbox.stub(releasePR.gh, 'getDefaultBranch').resolves('master');
 }

--- a/test/releasers/ruby-yoshi.ts
+++ b/test/releasers/ruby-yoshi.ts
@@ -43,12 +43,18 @@ const COMMITS = [
   buildMockCommit('chore: update common templates'),
 ];
 
-function stubGithub(releasePR: RubyYoshi) {
+function stubGithub(releasePR: RubyYoshi, expectedVersion: string) {
   sandbox
     .stub(releasePR.gh, 'findMergedReleasePR')
     .returns(Promise.resolve(undefined));
   sandbox.stub(releasePR.gh, 'findOpenReleasePRs').returns(Promise.resolve([]));
-  sandbox.stub(releasePR.gh, 'openPR').resolves(22);
+  sandbox.stub(releasePR.gh, 'openPR').callsFake(arg => {
+    if (arg.updates[0].version === expectedVersion) {
+      return Promise.resolve(22);
+    } else {
+      return Promise.resolve(21);
+    }
+  });
   sandbox.stub(releasePR.gh, 'addLabels');
   sandbox.stub(releasePR.gh, 'getDefaultBranch').resolves('master');
 }
@@ -71,7 +77,7 @@ describe('RubyYoshi', () => {
       });
 
       stubSuggesterWithSnapshot(sandbox, this.test!.fullTitle());
-      stubGithub(releasePR);
+      stubGithub(releasePR, '0.5.1');
       sandbox.stub(releasePR.gh, 'getTagSha').resolves(TAG_SHA);
       sandbox.stub(releasePR.gh, 'commitsSinceSha').resolves(COMMITS);
       stubFilesToUpdate(releasePR.gh, ['version.rb']);
@@ -90,7 +96,7 @@ describe('RubyYoshi', () => {
       });
 
       stubSuggesterWithSnapshot(sandbox, this.test!.fullTitle());
-      stubGithub(releasePR);
+      stubGithub(releasePR, '0.1.0');
       sandbox.stub(releasePR.gh, 'commitsSinceSha').resolves(COMMITS);
       stubFilesToUpdate(releasePR.gh, ['version.rb']);
 


### PR DESCRIPTION
Ruby-Yoshi libraries are currently failing if there is no preexisting release. This is because there is no last package version, and the RubyYoshi releaser is responding by sending a malformed GitHubTag (with undefined name and version) to coerceReleaseCandidate. This PR should fix the releaser so it properly sends undefined as the GitHubTag for this case.