### PR TITLE
fix: convert unnecessary error logs to warnings

### DIFF
--- a/src/github-release.ts
+++ b/src/github-release.ts
@@ -145,9 +145,7 @@ export class GitHubRelease {
         body: params.release.body,
       };
     } else {
-      console.warn(
-        `failed to parse version information from ${params.version}`
-      );
+      logger.warn(`failed to parse version information from ${params.version}`);
       return undefined;
     }
   }

--- a/src/github.ts
+++ b/src/github.ts
@@ -1119,7 +1119,7 @@ export class GitHub {
     // If the PR is being created from a fork, it will not have permission
     // to add and remove labels from the PR:
     if (this.fork) {
-      logger.error(
+      logger.warn(
         'release labels were not added, due to PR being created from fork'
       );
       return false;
@@ -1189,7 +1189,7 @@ export class GitHub {
 
     // Short-circuit if there have been no changes to the pull-request body.
     if (openReleasePR && openReleasePR.body === options.body) {
-      logger.error(
+      logger.info(
         `PR https://github.com/${this.owner}/${this.repo}/pull/${openReleasePR.number} remained the same`
       );
       return undefined;
@@ -1257,7 +1257,7 @@ export class GitHub {
         // if the file is missing and create = false, just continue
         // to the next update, otherwise create the file.
         if (!update.create) {
-          logger.error(`file ${chalk.green(update.path)} did not exist`);
+          logger.warn(`file ${chalk.green(update.path)} did not exist`);
           continue;
         }
       }

--- a/src/graphql-to-commits.ts
+++ b/src/graphql-to-commits.ts
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 import {PageInfo, GitHub} from './github';
+import {logger} from './util/logger';
 
 const CONVENTIONAL_COMMIT_REGEX = /^[\w]+(\(\w+\))?!?: /;
 
@@ -142,7 +143,7 @@ async function graphqlToCommit(
         // TODO: figure out why prEdge.node.number sometimes links to
         // data in GitHub that no longer exists, this would only cause
         // issues for mono-repos that use commit-split.
-        console.warn(err);
+        logger.warn(err);
         break;
       }
       continue;

--- a/src/release-pr.ts
+++ b/src/release-pr.ts
@@ -157,7 +157,7 @@ export class ReleasePR {
     // (fix, feat, BREAKING CHANGE) have been made; a CHANGELOG that's
     // one line is a good indicator that there were no interesting commits.
     if (this.changelogEmpty(changelogEntry)) {
-      logger.error(
+      logger.warn(
         `no user facing commits found since ${
           latestTag ? latestTag.sha : 'beginning of time'
         }`
@@ -184,7 +184,7 @@ export class ReleasePR {
   async run(): Promise<number | undefined> {
     await this.validateConfiguration();
     if (this.snapshot && !this.supportsSnapshots()) {
-      logger.error('snapshot releases not supported for this releaser');
+      logger.warn('snapshot releases not supported for this releaser');
       return;
     }
     const mergedPR = await this.gh.findMergedReleasePR(
@@ -195,7 +195,7 @@ export class ReleasePR {
     );
     if (mergedPR) {
       // a PR already exists in the autorelease: pending state.
-      logger.error(
+      logger.warn(
         `pull #${mergedPR.number} ${mergedPR.sha} has not yet been released`
       );
       return undefined;
@@ -257,7 +257,7 @@ export class ReleasePR {
         if (includePackageName && !pr.title.includes(` ${packageName.name} `)) {
           continue;
         }
-        logger.error(`closing pull #${pr.number}`);
+        logger.info(`closing pull #${pr.number}`);
         await this.gh.closePR(pr.number);
       }
     }
@@ -484,13 +484,13 @@ export class ReleasePR {
     await this.validateConfiguration();
     const mergedPR = await this.findMergedRelease();
     if (!mergedPR) {
-      logger.error('No merged release PR found');
+      logger.warn('No merged release PR found');
       return undefined;
     }
     const branchName = BranchName.parse(mergedPR.headRefName);
     const version = await this.detectReleaseVersion(mergedPR, branchName);
     if (!version) {
-      logger.error('Unable to detect release version');
+      logger.warn('Unable to detect release version');
       return undefined;
     }
     return this.buildReleaseForVersion(version, mergedPR);

--- a/src/releasers/go-yoshi.ts
+++ b/src/releasers/go-yoshi.ts
@@ -114,7 +114,7 @@ export class GoYoshi extends ReleasePR {
     // (fix, feat, BREAKING CHANGE) have been made; a CHANGELOG that's
     // one line is a good indicator that there were no interesting commits.
     if (this.changelogEmpty(changelogEntry)) {
-      logger.error(
+      logger.warn(
         `no user facing commits found since ${
           latestTag ? latestTag.sha : 'beginning of time'
         }`

--- a/src/releasers/java-yoshi.ts
+++ b/src/releasers/java-yoshi.ts
@@ -72,7 +72,7 @@ export class JavaYoshi extends ReleasePR {
       // of release based on whether a snapshot is needed or not
       this.snapshot = snapshotNeeded;
     } else if (!snapshotNeeded) {
-      logger.error('release asked for a snapshot, but no snapshot is needed');
+      logger.warn('release asked for a snapshot, but no snapshot is needed');
       return undefined;
     }
 
@@ -94,7 +94,7 @@ export class JavaYoshi extends ReleasePR {
           labels: true,
         });
     if (commits.length === 0) {
-      logger.error(
+      logger.warn(
         `no commits found since ${
           latestTag ? latestTag.sha : 'beginning of time'
         }`
@@ -139,7 +139,7 @@ export class JavaYoshi extends ReleasePR {
     // (fix, feat, BREAKING CHANGE) have been made; a CHANGELOG that's
     // one line is a good indicator that there were no interesting commits.
     if (this.changelogEmpty(changelogEntry) && !this.snapshot) {
-      logger.error(
+      logger.warn(
         `no user facing commits found since ${
           latestTag ? latestTag.sha : 'beginning of time'
         }`

--- a/src/releasers/python.ts
+++ b/src/releasers/python.ts
@@ -108,7 +108,7 @@ export class Python extends ReleasePR {
         );
       }
     } else {
-      logger.error(
+      logger.warn(
         parsedPyProject
           ? 'invalid pyproject.toml'
           : `file ${chalk.green('pyproject.toml')} did not exist`

--- a/src/releasers/ruby-yoshi.ts
+++ b/src/releasers/ruby-yoshi.ts
@@ -53,7 +53,7 @@ export class RubyYoshi extends ReleasePR {
       path: packageName.name,
     });
     if (commits.length === 0) {
-      logger.error(`no commits found since ${lastReleaseSha}`);
+      logger.warn(`no commits found since ${lastReleaseSha}`);
       return undefined;
     } else {
       const cc = new ConventionalCommits({
@@ -95,7 +95,7 @@ export class RubyYoshi extends ReleasePR {
       // (fix, feat, BREAKING CHANGE) have been made; a CHANGELOG that's
       // one line is a good indicator that there were no interesting commits.
       if (this.changelogEmpty(changelogEntry)) {
-        logger.error(
+        logger.warn(
           `no user facing commits found since ${
             lastReleaseSha ? lastReleaseSha : 'beginning of time'
           }`

--- a/src/releasers/rust.ts
+++ b/src/releasers/rust.ts
@@ -61,7 +61,7 @@ export class Rust extends ReleasePR {
     // (fix, feat, BREAKING CHANGE) have been made; a CHANGELOG that's
     // one line is a good indicator that there were no interesting commits.
     if (this.changelogEmpty(changelogEntry)) {
-      logger.error(
+      logger.warn(
         `no user facing commits found since ${
           latestTag ? latestTag.sha : 'beginning of time'
         }`
@@ -188,7 +188,7 @@ export class Rust extends ReleasePR {
         }`
       );
     } else {
-      logger.error(`no commits found since ${sha}`);
+      logger.warn(`no commits found since ${sha}`);
     }
 
     return commits;

--- a/src/updaters/changelog.ts
+++ b/src/updaters/changelog.ts
@@ -38,7 +38,7 @@ export class Changelog implements Update {
     // Handle both H2 (features/BREAKING CHANGES) and H3 (fixes).
     const lastEntryIndex = content.search(/\n###? v?[0-9[]/s);
     if (lastEntryIndex === -1) {
-      logger.error(`${this.path} not found`);
+      logger.warn(`${this.path} not found`);
       logger.info(`creating ${this.path}`);
       return `${this.header()}\n${this.changelogEntry}\n`;
     } else {

--- a/src/updaters/php-manifest.ts
+++ b/src/updaters/php-manifest.ts
@@ -41,7 +41,7 @@ export class PHPManifest implements Update {
 
   updateContent(content: string): string {
     if (!this.versions || this.versions.size === 0) {
-      logger.error(`no updates necessary for ${this.path}`);
+      logger.info(`no updates necessary for ${this.path}`);
       return content;
     }
     const parsed = JSON.parse(content);

--- a/src/updaters/root-composer.ts
+++ b/src/updaters/root-composer.ts
@@ -36,7 +36,7 @@ export class RootComposer implements Update {
 
   updateContent(content: string): string {
     if (!this.versions || this.versions.size === 0) {
-      logger.error(`no updates necessary for ${this.path}`);
+      logger.info(`no updates necessary for ${this.path}`);
       return content;
     }
     const parsed = JSON.parse(content);


### PR DESCRIPTION
Extraneous error logging is polluting downstream logs (e.g. in the release-please GitHub app logs). This PR converts somewhat important notices to warnings for cases that are not actually errors.