### PR TITLE
fix: finding commits to non-existent branch should return empty array

### DIFF
--- a/src/github.ts
+++ b/src/github.ts
@@ -799,7 +799,7 @@ export class GitHub {
 
   private async mergeCommitsGraphQL(
     cursor?: string
-  ): Promise<PullRequestHistory> {
+  ): Promise<PullRequestHistory|null> {
     const targetBranch = await this.getDefaultBranch();
     const response = await this.graphqlRequest({
       query: `query pullRequestsSince($owner: String!, $repo: String!, $num: Int!, $targetBranch: String!, $cursor: String) {
@@ -845,6 +845,11 @@ export class GitHub {
       num: 25,
       targetBranch,
     });
+
+    // if the branch does exist, return null
+    if (!response.repository.ref) {
+      return null;
+    }
     const history = response.repository.ref.target.history;
     const commits = (history.nodes || []) as GraphQLCommit[];
     return {
@@ -919,9 +924,13 @@ export class GitHub {
     let cursor: string | undefined = undefined;
     let results = 0;
     while (results < maxResults) {
-      const response: PullRequestHistory = await this.mergeCommitsGraphQL(
+      const response: PullRequestHistory|null = await this.mergeCommitsGraphQL(
         cursor
       );
+      // no response usually means that the branch can't be found
+      if (!response) {
+        break;
+      }
       for (let i = 0; i < response.data.length; i++) {
         results += 1;
         yield response.data[i];

--- a/src/github.ts
+++ b/src/github.ts
@@ -848,6 +848,9 @@ export class GitHub {
 
     // if the branch does exist, return null
     if (!response.repository.ref) {
+      logger.warn(
+        `Could not find commits for branch ${targetBranch} - it likely does not exist.`
+      );
       return null;
     }
     const history = response.repository.ref.target.history;

--- a/src/github.ts
+++ b/src/github.ts
@@ -799,7 +799,7 @@ export class GitHub {
 
   private async mergeCommitsGraphQL(
     cursor?: string
-  ): Promise<PullRequestHistory|null> {
+  ): Promise<PullRequestHistory | null> {
     const targetBranch = await this.getDefaultBranch();
     const response = await this.graphqlRequest({
       query: `query pullRequestsSince($owner: String!, $repo: String!, $num: Int!, $targetBranch: String!, $cursor: String) {
@@ -924,9 +924,8 @@ export class GitHub {
     let cursor: string | undefined = undefined;
     let results = 0;
     while (results < maxResults) {
-      const response: PullRequestHistory|null = await this.mergeCommitsGraphQL(
-        cursor
-      );
+      const response: PullRequestHistory | null =
+        await this.mergeCommitsGraphQL(cursor);
       // no response usually means that the branch can't be found
       if (!response) {
         break;

--- a/test/fixtures/commits-since-missing-branch.json
+++ b/test/fixtures/commits-since-missing-branch.json
@@ -1,0 +1,5 @@
+{
+  "repository": {
+    "ref": null
+  }
+}

--- a/test/github.ts
+++ b/test/github.ts
@@ -644,6 +644,23 @@ describe('GitHub', () => {
       snapshot(commitsSinceSha);
       req.done();
     });
+
+    it('returns empty commits if branch does not exist', async () => {
+      const graphql = JSON.parse(
+        readFileSync(
+          resolve(fixturesPath, 'commits-since-missing-branch.json'),
+          'utf8'
+        )
+      );
+      req.post('/graphql').reply(200, {
+        data: graphql,
+      });
+      const commitsSinceSha = await github.commitsSince(_commit => {
+        return true;
+      });
+      expect(commitsSinceSha.length).to.eql(0);
+      req.done();
+    });
   });
 
   describe('findMergeCommit', () => {


### PR DESCRIPTION
Currently this scenario crashes as the graphQL response contains a null value

Fixes #944
