### PR TITLE
fix: throw custom error class for missing release notes error

### DIFF
--- a/src/errors/index.ts
+++ b/src/errors/index.ts
@@ -58,3 +58,14 @@ export class DuplicateReleaseError extends GitHubAPIError {
     this.name = DuplicateReleaseError.name;
   }
 }
+
+export class MissingReleaseNotesError extends Error {
+  changelogContents: string;
+  version: string;
+  constructor(changelogContents: string, version: string) {
+    super(`could not find changelog entry corresponding to release ${version}`);
+    this.changelogContents = changelogContents;
+    this.version = version;
+    this.name = MissingReleaseNotesError.name;
+  }
+}

--- a/src/util/release-notes.ts
+++ b/src/util/release-notes.ts
@@ -12,6 +12,14 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+import {MissingReleaseNotesError} from '../errors';
+
+/**
+ * Parse release notes for a specific release from the CHANGELOG contents
+ *
+ * @param {string} changelogContents The entire CHANGELOG contents
+ * @param {string} version The release version to extract notes from
+ */
 export function extractReleaseNotes(
   changelogContents: string,
   version: string
@@ -23,7 +31,7 @@ export function extractReleaseNotes(
   );
   const match = changelogContents.match(latestRe);
   if (!match) {
-    throw Error('could not find changelog entry corresponding to release PR');
+    throw new MissingReleaseNotesError(changelogContents, version);
   }
   return match[1];
 }

--- a/test/util/release-notes.ts
+++ b/test/util/release-notes.ts
@@ -17,6 +17,7 @@ import {describe, it} from 'mocha';
 import {resolve} from 'path';
 import {extractReleaseNotes} from '../../src/util/release-notes';
 import snapshot = require('snap-shot-it');
+import assert = require('assert');
 
 const fixturesPath = './test/fixtures';
 
@@ -56,6 +57,21 @@ describe('extractReleaseNotes', () => {
     ).replace(/\r\n/g, '\n');
     const latestReleaseNotes = extractReleaseNotes(changelogContent, 'v5.0.0');
     snapshot(latestReleaseNotes);
+  });
+
+  it('throws on missing release notes', () => {
+    const changelogContent = readFileSync(
+      resolve(fixturesPath, './CHANGELOG-bug-140.md'),
+      'utf8'
+    ).replace(/\r\n/g, '\n');
+    assert.throws(
+      () => {
+        extractReleaseNotes(changelogContent, 'v6.0.0');
+      },
+      {
+        name: 'MissingReleaseNotesError',
+      }
+    );
   });
 
   describe('php-yoshi', () => {


### PR DESCRIPTION
Throwing a typed error will allow the caller to handle appropriately (file an issue, etc).

Fixes #947
