### PR TITLE
fix: retry looking for pending merged release

### DIFF
--- a/src/release-pr.ts
+++ b/src/release-pr.ts
@@ -189,12 +189,21 @@ export class ReleasePR {
       logger.warn('snapshot releases not supported for this releaser');
       return;
     }
-    const mergedPR = await this.gh.findMergedReleasePR(
+    let mergedPR = await this.gh.findMergedReleasePR(
       this.labels,
       undefined,
       true,
       100
     );
+    // try twice in case a release PR was just merged
+    if (!mergedPR) {
+      mergedPR = await this.gh.findMergedReleasePR(
+        this.labels,
+        undefined,
+        true,
+        100
+      );
+    }
     if (mergedPR) {
       // a PR already exists in the autorelease: pending state.
       logger.warn(
@@ -202,7 +211,7 @@ export class ReleasePR {
       );
       return undefined;
     } else {
-      return this._run();
+      return await this._run();
     }
   }
 

--- a/test/releasers/node.ts
+++ b/test/releasers/node.ts
@@ -62,7 +62,7 @@ function mockGithub(options: {
     // once in openPR and once again in closeStaleReleasePRs
     .atMost(2)
     .resolves([]);
-  mock.expects('findMergedReleasePR').atMost(1).resolves(undefined);
+  mock.expects('findMergedReleasePR').atMost(2).resolves(undefined);
   let headRefName = 'release-';
   if (branchComponent) {
     headRefName += branchComponent;


### PR DESCRIPTION
Hopefully retrying this query will prevent the extra release PR from being created

Fixes #826
