### PR TITLE
fix(github-release): private repo not found error

### DIFF
--- a/src/errors/index.ts
+++ b/src/errors/index.ts
@@ -41,6 +41,15 @@ export class MissingRequiredFileError extends ConfigurationError {
   }
 }
 
+export class PathNotFoundError extends Error {
+  path: string;
+  constructor(path: string) {
+    super(`Could not find requested path: ${path}`);
+    this.path = path;
+    this.name = PathNotFoundError.name;
+  }
+}
+
 export class GitHubAPIError extends Error {
   body: RequestErrorBody | undefined;
   status: number;

--- a/src/github.ts
+++ b/src/github.ts
@@ -98,7 +98,12 @@ import {Update} from './updaters/update';
 import {BranchName} from './util/branch-name';
 import {RELEASE_PLEASE, GH_API_URL} from './constants';
 import {GitHubConstructorOptions} from '.';
-import {DuplicateReleaseError, GitHubAPIError, AuthError} from './errors';
+import {
+  DuplicateReleaseError,
+  GitHubAPIError,
+  AuthError,
+  PathNotFoundError,
+} from './errors';
 
 export interface OctokitAPIs {
   graphql: Function;
@@ -1542,7 +1547,7 @@ export class GitHub {
 
     const blobDescriptor = repoTree.data.tree.find(tree => tree.path === path);
     if (!blobDescriptor) {
-      throw new Error(`Could not find requested path: ${path}`);
+      throw new PathNotFoundError(path);
     }
 
     const resp = await this.request('GET /repos/:owner/:repo/git/blobs/:sha', {
@@ -1585,7 +1590,7 @@ export class GitHub {
       try {
         return await this.getFileContentsWithSimpleAPI(path, branch);
       } catch (err) {
-        if (err.status === 403) {
+        if (err.status === 403 || err.status === 404) {
           return await this.getFileContentsWithDataAPI(path, branch);
         }
         throw err;

--- a/src/releasers/java-yoshi.ts
+++ b/src/releasers/java-yoshi.ts
@@ -30,7 +30,11 @@ import {JavaUpdate} from '../updaters/java/java_update';
 import {isStableArtifact} from './java/stability';
 import {fromSemverReleaseType} from './java/bump_type';
 import {logger} from '../util/logger';
-import {GitHubAPIError, MissingRequiredFileError} from '../errors';
+import {
+  GitHubAPIError,
+  MissingRequiredFileError,
+  PathNotFoundError,
+} from '../errors';
 
 const CHANGELOG_SECTIONS = [
   {type: 'feat', section: 'Features'},
@@ -57,15 +61,16 @@ export class JavaYoshi extends ReleasePR {
           'versions.txt'
         );
       } catch (e) {
-        if (e instanceof GitHubAPIError) {
-          if (e.status === 404) {
-            // on missing file, throw a configuration error
-            throw new MissingRequiredFileError(
-              'versions.txt',
-              JavaYoshi.name,
-              this.gh.repo
-            );
-          }
+        if (
+          (e instanceof GitHubAPIError && e.status === 404) ||
+          e instanceof PathNotFoundError
+        ) {
+          // on missing file, throw a configuration error
+          throw new MissingRequiredFileError(
+            'versions.txt',
+            JavaYoshi.name,
+            this.gh.repo
+          );
         }
         throw e;
       }

--- a/test/releasers/java-yoshi.ts
+++ b/test/releasers/java-yoshi.ts
@@ -674,6 +674,10 @@ describe('JavaYoshi', () => {
         '/repos/googleapis/java-trace/contents/versions.txt?ref=refs%2Fheads%2Fmaster'
       )
       .reply(404);
+
+    nock('https://api.github.com/')
+      .get('/repos/googleapis/java-trace/git/trees/master')
+      .reply(200, {tree: []});
     await assert.rejects(
       async () => {
         return releasePR.run();


### PR DESCRIPTION
- [x] Make sure to open an issue as a [bug/issue](https://github.com/googleapis/release-please/issues/new/choose) before writing your code!  That way we can discuss the change, evaluate designs, and agree on the general idea
- [x] Ensure the tests and linter pass
- [x] Code coverage does not decrease (if any source code was changed)
- [ ] Appropriate docs were updated (if necessary)

Fixes #772 🦕

Have found the cause of the cryptic "Not found" error occurring on private repos. I'm not sure if 403 is actually ever thrown but left it there in case...