### PR TITLE
feat(manifest): support hard-coded last-release-sha

### DIFF
--- a/__snapshots__/manifest.js
+++ b/__snapshots__/manifest.js
@@ -1082,3 +1082,115 @@ fork: false
 message: chore: release main
 logger: [object Object]
 `
+
+exports['Manifest pullRequest uses last-release-sha: changes'] = `
+
+filename: node/pkg1/CHANGELOG.md
+# Changelog
+
+## [4.0.0](https://www.github.com/fake/repo/compare/pkg1-v3.2.1...pkg1-v4.0.0) (1983-10-10)
+
+
+### ⚠ BREAKING CHANGES
+
+* **@node/pkg1:** major new feature
+
+### Features
+
+* **@node/pkg1:** major new feature ([e3ab0ab](https://www.github.com/fake/repo/commit/e3ab0abfd66e66324f685ceeececf35c))
+
+filename: node/pkg1/package.json
+{
+  "name": "@node/pkg1",
+  "version": "4.0.0"
+}
+
+filename: node/pkg2/CHANGELOG.md
+# Changelog
+
+## [0.2.0](https://www.github.com/fake/repo/compare/pkg2-v0.1.2...pkg2-v0.2.0) (1983-10-10)
+
+
+### Features
+
+* **@node/pkg2:** new feature ([6cefc4f](https://www.github.com/fake/repo/commit/6cefc4f5b1f432a24f7c066c5dd95e68))
+
+filename: node/pkg2/package.json
+{
+  "name": "@node/pkg2",
+  "version": "0.2.0",
+  "dependencies": {
+    "@node/pkg1": "^0.123.4"
+  }
+}
+
+filename: python/CHANGELOG.md
+# Changelog
+
+### [1.2.4](https://www.github.com/fake/repo/compare/foolib-v1.2.3...foolib-v1.2.4) (1983-10-10)
+
+
+### Bug Fixes
+
+* **foolib:** bufix python foolib ([8df9117](https://www.github.com/fake/repo/commit/8df9117959264dc5b7b6c72ff36b8846))
+
+filename: python/setup.cfg
+version=1.2.4
+
+filename: python/setup.py
+version = "1.2.4"
+
+filename: python/src/foolib/version.py
+__version__ = "1.2.4"
+
+filename: .release-please-manifest.json
+{
+  "node/pkg1": "4.0.0",
+  "node/pkg2": "0.2.0",
+  "python": "1.2.4"
+}
+
+`
+
+exports['Manifest pullRequest uses last-release-sha: options'] = `
+
+upstreamOwner: fake
+upstreamRepo: repo
+title: chore: release main
+branch: release-please/branches/main
+description: :robot: I have created a release \\*beep\\* \\*boop\\*
+---
+<details><summary>@node/pkg1: 4.0.0</summary>
+
+
+### ⚠ BREAKING CHANGES
+
+* **@node/pkg1:** major new feature
+
+### Features
+
+* **@node/pkg1:** major new feature ([e3ab0ab](https://www.github.com/fake/repo/commit/e3ab0abfd66e66324f685ceeececf35c))
+</details>
+<details><summary>@node/pkg2: 0.2.0</summary>
+
+
+### Features
+
+* **@node/pkg2:** new feature ([6cefc4f](https://www.github.com/fake/repo/commit/6cefc4f5b1f432a24f7c066c5dd95e68))
+</details>
+<details><summary>foolib: 1.2.4</summary>
+
+
+### Bug Fixes
+
+* **foolib:** bufix python foolib ([8df9117](https://www.github.com/fake/repo/commit/8df9117959264dc5b7b6c72ff36b8846))
+</details>
+
+
+This PR was generated with [Release Please](https://github.com/googleapis/release-please). See [documentation](https://github.com/googleapis/release-please#release-please).
+primary: main
+force: true
+fork: false
+message: chore: release main
+logger: [object Object]
+`

--- a/docs/manifest-releaser.md
+++ b/docs/manifest-releaser.md
@@ -94,11 +94,29 @@ documented in comments)
 {
   // if this is the first time running `manifest-pr` on a repo
   // this key will limit how far back (exclusive) to pull commits
-  // for conventional commit parsing.
+  // for conventional commit parsing. Once release-please has generated
+  // at least one release PR, this setting will subsequently be ignored.
+  // release-please will check for a manifest file at the bootstrap-sha
+  // and if it doesn't find one it will fallback to checking at HEAD.
   // Notes:
   //   - full sha required.
   //   - only applicable at top-level config.
   "bootstrap-sha": "6fc119838885b0cb831e78ddd23ac01cb819e585",
+
+  // release-please's normal behavior is to find the last merged release PR
+  // and use the associated commit sha as the previous marker from which to
+  // gather commits for the new release. With this setting you can manually
+  // set the commit sha release-please will use from which to gather commits
+  // for the current release.
+  // This can be useful when you've accidentally merged a bad release PR.
+  // While you can revert the changes from that PR and delete tags/releases
+  // GitHub does not allow you to delete PRs so release-please will find
+  // that last PR.
+  // Notes:
+  //   - full sha required.
+  //   - only applicable at top-level config.
+  //   - never ignored: remove/change it once a good release PR is merged
+  "last-release-sha": "7td2b9838885b3adf52e78ddd23ac01cb819e631",
 
   // see Plugins section below
   // absence defaults to [] (i.e. no plugins)


### PR DESCRIPTION
allow specifying an arbitrary sha to represent the last release. This is
helpful to use when trying to revert the last release PR. While you can
revert the changes from a bad release PR and delete associated tags/releases,
GitHub does not allow you to delete the actual PR so release-please will
still find it and consider it the last release.

worked for us in the wild: https://github.com/looker-open-source/sdk-codegen/pull/772