### PR TITLE
feat(prerelease): support "normal" form for python pre-releases

### DIFF
--- a/__snapshots__/python.js
+++ b/__snapshots__/python.js
@@ -22,6 +22,197 @@ exports['Python getOpenPROptions returns release PR changes with semver patch bu
 
 `
 
+exports['Python run calls latestTag with preRelease set to true: changes'] = `
+
+filename: CHANGELOG.md
+# Changelog
+
+### [0.123.5](https://www.github.com/googleapis/py-test-repo/compare/v0.123.4...v0.123.5) (1983-10-10)
+
+
+### Bug Fixes
+
+* **deps:** update dependency com.google.cloud:google-cloud-spanner to v1.50.0 ([08ca011](https://www.github.com/googleapis/py-test-repo/commit/08ca01180a91c0a1ba8992b491db9212))
+* **deps:** update dependency com.google.cloud:google-cloud-storage to v1.120.0 ([845db13](https://www.github.com/googleapis/py-test-repo/commit/845db1381b3d5d20151cad2588f85feb))
+
+filename: setup.cfg
+# Copyright 2020 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+[metadata]
+name = google-crc32c
+version = 0.123.5
+description = A python wrapper of the C library 'Google CRC32C'
+url = https://github.com/googleapis/python-crc32c
+long_description = file: README.md
+long_description_content_type = text/markdown
+author = Google LLC
+author_email = googleapis-packages@google.com
+
+license = Apache 2.0
+platforms = Posix, MacOS X, Windows
+classifiers =
+    Development Status :: 4 - Beta
+    Intended Audience :: Developers
+    License :: OSI Approved :: Apache Software License
+    Operating System :: OS Independent
+    Programming Language :: Python :: 3
+    Programming Language :: Python :: 3.5
+    Programming Language :: Python :: 3.6
+    Programming Language :: Python :: 3.7
+    Programming Language :: Python :: 3.8
+    
+[options]
+zip_safe = True
+python_requires = >=3.5
+
+[options.extras_require]
+testing = pytest
+
+
+filename: setup.py
+# Copyright 2018 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import io
+import os
+
+import setuptools
+
+name = "google-cloud-automl"
+description = "Cloud AutoML API client library"
+version = "0.123.5"
+release_status = "Development Status :: 3 - Alpha"
+dependencies = [
+    "google-api-core[grpc] >= 1.14.0, < 2.0.0dev",
+    'enum34; python_version < "3.4"',
+]
+extras = {
+    "pandas": ["pandas>=0.24.0"],
+    "storage": ["google-cloud-storage >= 1.18.0, < 2.0.0dev"],
+}
+
+package_root = os.path.abspath(os.path.dirname(__file__))
+
+readme_filename = os.path.join(package_root, "README.rst")
+with io.open(readme_filename, encoding="utf-8") as readme_file:
+    readme = readme_file.read()
+
+packages = [
+    package for package in setuptools.find_packages() if package.startswith("google")
+]
+
+namespaces = ["google"]
+if "google.cloud" in packages:
+    namespaces.append("google.cloud")
+
+setuptools.setup(
+    name=name,
+    version=version,
+    description=description,
+    long_description=readme,
+    author="Google LLC",
+    author_email="googleapis-packages@oogle.com",
+    license="Apache 2.0",
+    url="https://github.com/GoogleCloudPlatform/google-cloud-python",
+    classifiers=[
+        release_status,
+        "Intended Audience :: Developers",
+        "License :: OSI Approved :: Apache Software License",
+        "Programming Language :: Python",
+        "Programming Language :: Python :: 2",
+        "Programming Language :: Python :: 2.7",
+        "Programming Language :: Python :: 3",
+        "Programming Language :: Python :: 3.5",
+        "Programming Language :: Python :: 3.6",
+        "Programming Language :: Python :: 3.7",
+        "Operating System :: OS Independent",
+        "Topic :: Internet",
+    ],
+    platforms="Posix; MacOS X; Windows",
+    packages=packages,
+    namespace_packages=namespaces,
+    install_requires=dependencies,
+    extras_require=extras,
+    python_requires=">=2.7,!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*",
+    include_package_data=True,
+    zip_safe=False,
+)
+filename: pyproject.toml
+[project]
+name = 'project'
+version = "0.123.5"
+
+filename: project/__init__.py
+__version__ = '0.123.5'
+
+filename: src/version.py
+# Copyright 2020 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+__version__ = '0.123.5'
+
+`
+
+exports['Python run calls latestTag with preRelease set to true: options'] = `
+
+upstreamOwner: googleapis
+upstreamRepo: py-test-repo
+title: chore: release 0.123.5
+branch: release-v0.123.5
+description: :robot: I have created a release \\*beep\\* \\*boop\\*
+---
+### [0.123.5](https://www.github.com/googleapis/py-test-repo/compare/v0.123.4...v0.123.5) (1983-10-10)
+
+
+### Bug Fixes
+
+* **deps:** update dependency com.google.cloud:google-cloud-spanner to v1.50.0 ([08ca011](https://www.github.com/googleapis/py-test-repo/commit/08ca01180a91c0a1ba8992b491db9212))
+* **deps:** update dependency com.google.cloud:google-cloud-storage to v1.120.0 ([845db13](https://www.github.com/googleapis/py-test-repo/commit/845db1381b3d5d20151cad2588f85feb))
+---
+
+
+This PR was generated with [Release Please](https://github.com/googleapis/release-please). See [documentation](https://github.com/googleapis/release-please#release-please).
+primary: master
+force: true
+fork: false
+message: chore: release 0.123.5
+logger: [object Object]
+`
+
 exports['Python run creates a release PR relative to a path: changes'] = `
 
 filename: projects/python/CHANGELOG.md

--- a/src/release-pr.ts
+++ b/src/release-pr.ts
@@ -87,6 +87,7 @@ export class ReleasePR {
   pullRequestTitlePattern?: string;
   extraFiles: string[];
   forManifestReleaser: boolean;
+  preRelease = false;
 
   constructor(options: ReleasePRConstructorOptions) {
     this.bumpMinorPreMajor = options.bumpMinorPreMajor || false;
@@ -210,7 +211,8 @@ export class ReleasePR {
   protected async _run(): Promise<number | undefined> {
     const packageName = await this.getPackageName();
     const latestTag: GitHubTag | undefined = await this.latestTag(
-      this.monorepoTags ? `${packageName.getComponent()}-` : undefined
+      this.monorepoTags ? `${packageName.getComponent()}-` : undefined,
+      this.preRelease
     );
     const commits: Commit[] = await this.commits({
       sha: latestTag ? latestTag.sha : undefined,
@@ -571,6 +573,10 @@ export class ReleasePR {
     // Consider any version with a '-' as a pre-release version
     if (!preRelease && version.indexOf('-') >= 0) {
       return null;
+    }
+    // Allow the '-' separator to be omitted.
+    if (preRelease && !version.includes('-') && version.match(/[a-zB-Z]/)) {
+      version = version.replace(/([a-zA-Z])/, '-$1');
     }
     return semver.valid(version);
   }

--- a/src/release-pr.ts
+++ b/src/release-pr.ts
@@ -87,7 +87,7 @@ export class ReleasePR {
   pullRequestTitlePattern?: string;
   extraFiles: string[];
   forManifestReleaser: boolean;
-  preRelease = false;
+  enableSimplePrereleaseParsing = false;
 
   constructor(options: ReleasePRConstructorOptions) {
     this.bumpMinorPreMajor = options.bumpMinorPreMajor || false;
@@ -212,7 +212,7 @@ export class ReleasePR {
     const packageName = await this.getPackageName();
     const latestTag: GitHubTag | undefined = await this.latestTag(
       this.monorepoTags ? `${packageName.getComponent()}-` : undefined,
-      this.preRelease
+      this.enableSimplePrereleaseParsing
     );
     const commits: Commit[] = await this.commits({
       sha: latestTag ? latestTag.sha : undefined,
@@ -289,7 +289,7 @@ export class ReleasePR {
   protected async coerceReleaseCandidate(
     cc: ConventionalCommits,
     latestTag: GitHubTag | undefined,
-    preRelease = false
+    enableSimplePrereleaseParsing = false
   ): Promise<ReleaseCandidate> {
     const releaseAsRe =
       /release-as:\s*v?([0-9]+\.[0-9]+\.[0-9a-z]+(-[0-9a-z.]+)?)\s*/i;
@@ -315,7 +315,7 @@ export class ReleasePR {
 
     if (releaseAsCommit) {
       version = forcedVersion!;
-    } else if (preRelease) {
+    } else if (enableSimplePrereleaseParsing) {
       // Handle pre-release format v1.0.0-alpha1, alpha2, etc.
       const [prefix, suffix] = version.split('-');
       const match = suffix?.match(/(?<type>[^0-9]+)(?<number>[0-9]+)/);

--- a/src/releasers/go.ts
+++ b/src/releasers/go.ts
@@ -19,6 +19,8 @@ import {Update} from '../updaters/update';
 import {Changelog} from '../updaters/changelog';
 
 export class Go extends ReleasePR {
+  enableSimplePrereleaseParsing = true;
+
   protected async buildUpdates(
     changelogEntry: string,
     candidate: ReleaseCandidate,

--- a/src/releasers/node.ts
+++ b/src/releasers/node.ts
@@ -27,6 +27,7 @@ import {SamplesPackageJson} from '../updaters/samples-package-json';
 export class Node extends ReleasePR {
   private pkgJsonContents?: GitHubFileContents;
   private _packageName?: string;
+  enableSimplePrereleaseParsing = true;
 
   protected async buildUpdates(
     changelogEntry: string,

--- a/src/releasers/python.ts
+++ b/src/releasers/python.ts
@@ -48,7 +48,7 @@ const CHANGELOG_SECTIONS = [
 ];
 
 export class Python extends ReleasePR {
-  preRelease = true;
+  enableSimplePrereleaseParsing = true;
 
   constructor(options: ReleasePRConstructorOptions) {
     super(options);

--- a/src/releasers/python.ts
+++ b/src/releasers/python.ts
@@ -48,6 +48,8 @@ const CHANGELOG_SECTIONS = [
 ];
 
 export class Python extends ReleasePR {
+  preRelease = true;
+
   constructor(options: ReleasePRConstructorOptions) {
     super(options);
     this.changelogSections = options.changelogSections ?? CHANGELOG_SECTIONS;

--- a/test/fixtures/latest-tag-python.json
+++ b/test/fixtures/latest-tag-python.json
@@ -1,0 +1,130 @@
+{
+  "repository": {
+    "ref": {
+      "target": {
+        "history": {
+          "nodes": [
+            {
+              "associatedPullRequests": {
+                "nodes": [
+                  {
+                    "number": 4,
+                    "title": "chore: release v2.0.0b2",
+                    "baseRefName": "main",
+                    "headRefName": "release-v2.0.0b2",
+                    "labels": {
+                      "nodes": [
+                        {
+                          "name": "autorelease: tagged"
+                        }
+                      ]
+                    },
+                    "body": "This pull request was generated using releasetool.\n\n02-03-2021 11:56 PST\n\n### New Features\n- feat: initial commit\n\n### Internal / Testing Changes\n- build: add java structure",
+                    "mergeCommit": {
+                      "oid": "bc329592af60713fe28586dc6d9dfb03aa2dbe1a"
+                    }
+                  }
+                ]
+              },
+              "sha": "bc329592af60713fe28586dc6d9dfb03aa2dbe1a",
+              "message": "chore: release v2.0.0-rc1"
+            },
+            {
+              "associatedPullRequests": {
+                "nodes": [
+                  {
+                    "number": 2,
+                    "title": "chore: release v1.3.0",
+                    "baseRefName": "main",
+                    "headRefName": "release-v1.3.0",
+                    "labels": {
+                      "nodes": [
+                        {
+                          "name": "autorelease: tagged"
+                        }
+                      ]
+                    },
+                    "body": "This pull request was generated using releasetool.\n\n02-03-2021 11:56 PST\n\n### New Features\n- feat: initial commit\n\n### Internal / Testing Changes\n- build: add java structure",
+                    "mergeCommit": {
+                      "oid": "92af60713fe28586dc6d9dfb03aa2dbe1abc3295"
+                    }
+                  }
+                ]
+              },
+              "sha": "92af60713fe28586dc6d9dfb03aa2dbe1abc3295",
+              "message": "chore: release v1.3.0"
+            },
+            {
+              "associatedPullRequests": {
+                "nodes": [
+                  {
+                    "number": 1,
+                    "title": "chore: release v1.2.0",
+                    "baseRefName": "main",
+                    "headRefName": "release-v1.2.0",
+                    "labels": {
+                      "nodes": [
+                        {
+                          "name": "autorelease: tagged"
+                        }
+                      ]
+                    },
+                    "body": "This pull request was generated using releasetool.\n\n02-03-2021 11:56 PST\n\n### New Features\n- feat: initial commit\n\n### Internal / Testing Changes\n- build: add java structure",
+                    "mergeCommit": {
+                      "oid": "959ee48c95f254300eb040c46ebdc8248317efe4"
+                    }
+                  }
+                ]
+              },
+              "sha": "959ee48c95f254300eb040c46ebdc8248317efe4",
+              "message": "chore: release v1.2.0"
+            },
+            {
+              "associatedPullRequests": {
+                "nodes": [
+                  {
+                    "number": 3,
+                    "title": "chore: release v1.1.0",
+                    "baseRefName": "main",
+                    "headRefName": "release-v1.1.0",
+                    "labels": {
+                      "nodes": [
+                        {
+                          "name": "autorelease: tagged"
+                        }
+                      ]
+                    },
+                    "body": "This pull request was generated using releasetool.\n\n02-03-2021 11:56 PST\n\n### New Features\n- feat: initial commit\n\n### Internal / Testing Changes\n- build: add java structure",
+                    "mergeCommit": {
+                      "oid": "959ee48c95f254300eb040c46ebdc8248317efe4"
+                    }
+                  }
+                ]
+              },
+              "sha": "959ee48c95f254300eb040c46ebdc8248317efe4",
+              "message": "chore: release v1.1.0"
+            },
+            {
+              "associatedPullRequests": {
+                "nodes": []
+              },
+              "sha": "c6d9dfb03aa2dbe1abc329592af60713fe28586d",
+              "message": "build: add java structure"
+            },
+            {
+              "associatedPullRequests": {
+                "nodes": []
+              },
+              "sha": "c8f1498c92c323bfa8f5ffe84e0ade1c37e4ea6e",
+              "message": "feat: initial commit"
+            }
+          ],
+          "pageInfo": {
+            "hasNextPage": false,
+            "endCursor": "e6daec403626c9987c7af0d97b34f324cd84320a 12"
+          }
+        }
+      }
+    }
+  }
+}

--- a/test/release-pr.ts
+++ b/test/release-pr.ts
@@ -361,6 +361,18 @@ describe('Release-PR', () => {
       expect(latestTag!.version).to.equal('1.3.0');
       req.done();
     });
+
+    it('- prefix is optional for pre-release suffixes', async () => {
+      const graphql = JSON.parse(
+        readFileSync(resolve(fixturesPath, 'latest-tag-python.json'), 'utf8')
+      );
+      req.post('/graphql').reply(200, {
+        data: graphql,
+      });
+      const latestTag = await releasePR.latestTag(undefined, true);
+      expect(latestTag!.version).to.equal('2.0.0-b2');
+      req.done();
+    });
   });
 
   it('returns early if outstanding release is found', async () => {


### PR DESCRIPTION
This PR adds partial support for Python's "normal" form pre-release tags, by coercing them into the type of pre-release currently supported by release-please (`-1.0.0b2` becomes `-1.0.0-b2`).

Python now also has the ability to handle pre-releases enabled by default, we likely might want to enable this feature for all languages but thought I'd start with one.

We do not fully support the form `1.0.0b2` for release tags, but using `Release-As:` can still be used.