### PR TITLE
ci: disable fail-fast

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -8,6 +8,7 @@ jobs:
   test:
     runs-on: ubuntu-latest
     strategy:
+      fail-fast: false
       matrix:
         node: [10, 12, 14, 15]
     steps:


### PR DESCRIPTION
Thank you for opening a Pull Request! Before submitting your PR, there are a few things you can do to make sure it goes smoothly:
- [x] Make sure to open an issue as a [bug/issue](https://github.com/googleapis/release-please/issues/new/choose) before writing your code!  That way we can discuss the change, evaluate designs, and agree on the general idea
- [x] Ensure the tests and linter pass
- [ ] Code coverage does not decrease (if any source code was changed)
- [ ] Appropriate docs were updated (if necessary)

https://docs.github.com/en/actions/reference/workflow-syntax-for-github-actions#jobsjob_idstrategyfail-fast

I think it would be interesting to not cancel one job when another fails.
For example, this [job](https://github.com/googleapis/release-please/runs/3285384956?check_suite_focus=true) was cancelled because an installed dependency requires at least Node.js 12.20. It would be interesting to know if the CI will succeed or fail again with a higher version.

EDIT: should it be updated in https://github.com/googleapis/synthtool/blob/master/synthtool/gcp/templates/node_library/.github/workflows/ci.yaml?