### PR TITLE
fix: krm releaser manifest mode

### DIFF
--- a/src/releasers/krm-blueprint.ts
+++ b/src/releasers/krm-blueprint.ts
@@ -42,11 +42,16 @@ export class KRMBlueprint extends ReleasePR {
     );
     const versionsMap: Map<string, string> = new Map();
     if (candidate.previousTag) {
-      versionsMap.set('previous', candidate.previousTag);
+      // if previousTag of form pkgName-vX.x.x, we only require vX.x.x for attrib update
+      const previousVersion = candidate.previousTag.replace(
+        `${packageName.name}-`,
+        ''
+      );
+      versionsMap.set('previousVersion', previousVersion);
     }
 
     // Update version in all yaml files with attribution annotation
-    const yamlPaths = await this.gh.findFilesByExtension('yaml');
+    const yamlPaths = await this.gh.findFilesByExtension('yaml', this.path);
     for (const yamlPath of yamlPaths) {
       const contents: GitHubFileContents = await this.gh.getFileContents(
         this.addPath(yamlPath)

--- a/src/updaters/krm/krm-blueprint-version.ts
+++ b/src/updaters/krm/krm-blueprint-version.ts
@@ -38,8 +38,8 @@ export class KRMBlueprintVersion implements Update {
     // match starting cnrm/ ending with semver to prevent wrong updates like pinned config.kubernetes.io/function
     let matchRegex = '(cnrm/.*/)(v[0-9]+.[0-9]+.[0-9]+)+(-w+)?';
     // if explicit previous version, match only that version
-    if (this.versions?.has('previous')) {
-      matchRegex = `(cnrm/.*/)(${this.versions.get('previous')})+(-w+)?`;
+    if (this.versions?.has('previousVersion')) {
+      matchRegex = `(cnrm/.*/)(${this.versions.get('previousVersion')})+(-w+)?`;
     }
     const oldVersion = content.match(new RegExp(matchRegex));
 


### PR DESCRIPTION
Fixes some issues that came up when testing KRM releaser in manifest mode
- `previousTag` may contain package info if in manifest mode
- only find files in corresponding package path if provided
