### PR TITLE
feat: handle single quotes in version-rb

### DIFF
--- a/__snapshots__/version-rb.js
+++ b/__snapshots__/version-rb.js
@@ -1,3 +1,29 @@
+exports['version.rb updateContent updates content with single quotes in version.rb 1'] = `
+# Copyright 2019 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the 'License');
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an 'AS IS' BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+module Google
+  module Cloud
+    module Bigtable
+      VERSION = '0.6.0'.freeze
+    end
+  end
+end
+
+`
+
 exports['version.rb updateContent updates version in version.rb 1'] = `
 # Copyright 2019 Google LLC
 #

--- a/src/updaters/version-rb.ts
+++ b/src/updaters/version-rb.ts
@@ -34,8 +34,8 @@ export class VersionRB implements Update {
 
   updateContent(content: string): string {
     return content.replace(
-      /"[0-9]+\.[0-9]+\.[0-9](-\w+)?"/,
-      `"${this.version}"`
+      /(["'])[0-9]+\.[0-9]+\.[0-9](-\w+)?["']/,
+      `$1${this.version}$1`
     );
   }
 }

--- a/test/updaters/version-rb.ts
+++ b/test/updaters/version-rb.ts
@@ -36,5 +36,22 @@ describe('version.rb', () => {
       const newContent = version.updateContent(oldContent);
       snapshot(newContent);
     });
+
+    it('updates content with single quotes in version.rb', async () => {
+      const oldContent = readFileSync(
+        resolve(fixturesPath, './version.rb'),
+        'utf8'
+      )
+        .replace(/\r\n/g, '\n')
+        .replace(/"/g, "'");
+      const version = new VersionRB({
+        path: 'version.rb',
+        changelogEntry: '',
+        version: '0.6.0',
+        packageName: '',
+      });
+      const newContent = version.updateContent(oldContent);
+      snapshot(newContent);
+    });
   });
 });


### PR DESCRIPTION
This fixes the linked issue by applying a small fix to `updaters/version-rb.ts`. 

Fixes #1018 🦕
