### PR TITLE
fix(ruby): The Ruby releaser defaults to the correct version.rb path

### DIFF
--- a/__snapshots__/ruby.js
+++ b/__snapshots__/ruby.js
@@ -11,6 +11,30 @@ filename: projects/ruby/CHANGELOG.md
 * **deps:** update dependency com.google.cloud:google-cloud-spanner to v1.50.0 ([08ca011](https://www.github.com/googleapis/ruby-test-repo/commit/08ca01180a91c0a1ba8992b491db9212))
 * **deps:** update dependency com.google.cloud:google-cloud-storage to v1.120.0 ([845db13](https://www.github.com/googleapis/ruby-test-repo/commit/845db1381b3d5d20151cad2588f85feb))
 
+filename: projects/ruby/lib/google/cloud/automl/version.rb
+# Copyright 2019 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+module Google
+  module Cloud
+    module Bigtable
+      VERSION = "0.5.1".freeze
+    end
+  end
+end
+
 `
 
 exports['Ruby run creates a release PR relative to a path: options'] = `
@@ -60,6 +84,30 @@ filename: projects/ruby/HISTORY.md
 
 * **deps:** update dependency com.google.cloud:google-cloud-spanner to v1.50.0 ([08ca011](https://www.github.com/googleapis/ruby-test-repo/commit/08ca01180a91c0a1ba8992b491db9212))
 * **deps:** update dependency com.google.cloud:google-cloud-storage to v1.120.0 ([845db13](https://www.github.com/googleapis/ruby-test-repo/commit/845db1381b3d5d20151cad2588f85feb))
+
+filename: projects/ruby/lib/blah/version.rb
+# Copyright 2019 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+module Google
+  module Cloud
+    module Bigtable
+      VERSION = "0.6.0".freeze
+    end
+  end
+end
 
 `
 
@@ -111,7 +159,7 @@ filename: CHANGELOG.md
 * **deps:** update dependency com.google.cloud:google-cloud-spanner to v1.50.0 ([08ca011](https://www.github.com/googleapis/ruby-test-repo/commit/08ca01180a91c0a1ba8992b491db9212))
 * **deps:** update dependency com.google.cloud:google-cloud-storage to v1.120.0 ([845db13](https://www.github.com/googleapis/ruby-test-repo/commit/845db1381b3d5d20151cad2588f85feb))
 
-filename: version.rb
+filename: lib/google/cloud/automl/version.rb
 # Copyright 2019 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/releasers/ruby.ts
+++ b/src/releasers/ruby.ts
@@ -42,6 +42,8 @@ export class Ruby extends ReleasePR {
     packageName: PackageName
   ): Promise<Update[]> {
     const updates: Update[] = [];
+    const versionFile: string = this.versionFile ? this.versionFile :
+      `lib/${packageName.name.replace(/-/g, '/')}/version.rb`;
 
     updates.push(
       new Changelog({
@@ -54,7 +56,7 @@ export class Ruby extends ReleasePR {
 
     updates.push(
       new VersionRB({
-        path: this.addPath(this.versionFile),
+        path: this.addPath(versionFile),
         changelogEntry,
         version: candidate.version,
         packageName: packageName.name,

--- a/src/releasers/ruby.ts
+++ b/src/releasers/ruby.ts
@@ -42,8 +42,9 @@ export class Ruby extends ReleasePR {
     packageName: PackageName
   ): Promise<Update[]> {
     const updates: Update[] = [];
-    const versionFile: string = this.versionFile ? this.versionFile :
-      `lib/${packageName.name.replace(/-/g, '/')}/version.rb`;
+    const versionFile: string = this.versionFile
+      ? this.versionFile
+      : `lib/${packageName.name.replace(/-/g, '/')}/version.rb`;
 
     updates.push(
       new Changelog({

--- a/test/releasers/ruby.ts
+++ b/test/releasers/ruby.ts
@@ -72,14 +72,13 @@ describe('Ruby', () => {
   describe('run', () => {
     it('creates a release PR with defaults', async function () {
       const releasePR = new Ruby({
-        versionFile: 'version.rb',
         github: new GitHub({owner: 'googleapis', repo: 'ruby-test-repo'}),
         packageName: pkgName,
       });
 
       stubSuggesterWithSnapshot(sandbox, this.test!.fullTitle());
       stubGithub(releasePR);
-      stubFilesToUpdate(releasePR.gh, ['version.rb']);
+      stubFilesToUpdate(releasePR.gh, ['lib/google/cloud/automl/version.rb']);
       const pr = await releasePR.run();
       assert.strictEqual(pr, 22);
     });
@@ -93,7 +92,8 @@ describe('Ruby', () => {
 
       stubSuggesterWithSnapshot(sandbox, this.test!.fullTitle());
       stubGithub(releasePR);
-      stubFilesToUpdate(releasePR.gh, ['version.rb']);
+      stubFilesToUpdate(releasePR.gh,
+        ['projects/ruby/lib/google/cloud/automl/version.rb']);
       const pr = await releasePR.run();
       assert.strictEqual(pr, 22);
     });
@@ -106,6 +106,7 @@ describe('Ruby', () => {
         bumpMinorPreMajor: true,
         monorepoTags: true,
         changelogPath: 'HISTORY.md',
+        versionFile: 'lib/blah/version.rb'
       });
 
       stubSuggesterWithSnapshot(sandbox, this.test!.fullTitle());
@@ -114,7 +115,7 @@ describe('Ruby', () => {
       const latestTag = {...LATEST_TAG};
       latestTag.name = pkgName + '/v' + latestTag.version;
       stubGithub(releasePR, commits, latestTag);
-      stubFilesToUpdate(releasePR.gh, ['projects/ruby/version.rb']);
+      stubFilesToUpdate(releasePR.gh, ['projects/ruby/lib/blah/version.rb']);
       const pr = await releasePR.run();
       assert.strictEqual(pr, 22);
     });

--- a/test/releasers/ruby.ts
+++ b/test/releasers/ruby.ts
@@ -92,8 +92,9 @@ describe('Ruby', () => {
 
       stubSuggesterWithSnapshot(sandbox, this.test!.fullTitle());
       stubGithub(releasePR);
-      stubFilesToUpdate(releasePR.gh,
-        ['projects/ruby/lib/google/cloud/automl/version.rb']);
+      stubFilesToUpdate(releasePR.gh, [
+        'projects/ruby/lib/google/cloud/automl/version.rb',
+      ]);
       const pr = await releasePR.run();
       assert.strictEqual(pr, 22);
     });
@@ -106,7 +107,7 @@ describe('Ruby', () => {
         bumpMinorPreMajor: true,
         monorepoTags: true,
         changelogPath: 'HISTORY.md',
-        versionFile: 'lib/blah/version.rb'
+        versionFile: 'lib/blah/version.rb',
       });
 
       stubSuggesterWithSnapshot(sandbox, this.test!.fullTitle());


### PR DESCRIPTION
Currently, if the `versionFile` option is not provided to the `ruby` releaser, it effectively defaults to `{path}/`, which is never a correct path to a `version.rb` file. Hence, the `versionFile` option is effectively required for the `ruby` releaser. This is a particular problem for the release-please probot app, which does not currently support `versionFile` in its config schema.

This PR provides a valid default equal to the expected path to the `version.rb` file based on Ruby conventions. It works for individual library repos but not monorepos (i.e. it does not prepend a package name subdirectory). This is okay for now because Ruby does not currently have any monorepo cases where this default is needed. And it is consistent with `changelogPath` which behaves the same way.

This also fixes the Ruby releaser tests which were previously stubbing the wrong version.rb path. They were passing previously, but were printing warnings due to the stubbed getFileContentsOnBranch call returning a 404, and were consequently not updating a version file as would be expected in a normal Ruby release. The expected snapshots were also updated accordingly.