### PR TITLE
fix: typo in `--bump-patch-for-minor-pre-major` option

### DIFF
--- a/__snapshots__/cli.js
+++ b/__snapshots__/cli.js
@@ -28,7 +28,7 @@ Options:
   --bump-minor-pre-major            should we bump the semver minor prior to the
                                     first major release
                                                       [boolean] [default: false]
-  --bump-minor-for-patch-pre-major  should we bump the semver patch instead of
+  --bump-patch-for-minor-pre-major  should we bump the semver patch instead of
                                     the minor for non-breaking changes prior to
                                     the first major release
                                                       [boolean] [default: false]
@@ -83,7 +83,7 @@ Options:
   --bump-minor-pre-major            should we bump the semver minor prior to the
                                     first major release
                                                       [boolean] [default: false]
-  --bump-minor-for-patch-pre-major  should we bump the semver patch instead of
+  --bump-patch-for-minor-pre-major  should we bump the semver patch instead of
                                     the minor for non-breaking changes prior to
                                     the first major release
                                                       [boolean] [default: false]
@@ -181,7 +181,7 @@ Options:
   --bump-minor-pre-major            should we bump the semver minor prior to the
                                     first major release
                                                       [boolean] [default: false]
-  --bump-minor-for-patch-pre-major  should we bump the semver patch instead of
+  --bump-patch-for-minor-pre-major  should we bump the semver patch instead of
                                     the minor for non-breaking changes prior to
                                     the first major release
                                                       [boolean] [default: false]

--- a/src/bin/release-please.ts
+++ b/src/bin/release-please.ts
@@ -61,7 +61,7 @@ function releaserCommon(ya: YargsOptionsBuilder) {
     default: false,
     type: 'boolean',
   });
-  ya.option('bump-minor-for-patch-pre-major', {
+  ya.option('bump-patch-for-minor-pre-major', {
     describe:
       'should we bump the semver patch instead of the minor for non-breaking' +
       ' changes prior to the first major release',


### PR DESCRIPTION
The option `--bump-minor-for-patch-pre-major` didn't work. This was because of the typo in the option name, I believe the actual name for the option supposed to be `--bump-patch-for-minor-pre-major`. Changing it makes it work.

Fixes #1049