### PR TITLE
fix: limit PR description to 65536 characters

### DIFF
--- a/src/constants.ts
+++ b/src/constants.ts
@@ -17,3 +17,4 @@ export const GH_API_URL = 'https://api.github.com';
 export const RELEASE_PLEASE = 'release-please';
 export const RELEASE_PLEASE_CONFIG = `${RELEASE_PLEASE}-config.json`;
 export const RELEASE_PLEASE_MANIFEST = `.${RELEASE_PLEASE}-manifest.json`;
+export const MAX_ISSUE_SIZE = 65536;

--- a/src/github.ts
+++ b/src/github.ts
@@ -96,7 +96,7 @@ import {
 } from './graphql-to-commits';
 import {Update} from './updaters/update';
 import {BranchName} from './util/branch-name';
-import {RELEASE_PLEASE, GH_API_URL} from './constants';
+import {RELEASE_PLEASE, GH_API_URL, MAX_ISSUE_SIZE} from './constants';
 import {GitHubConstructorOptions} from '.';
 import {DuplicateReleaseError, GitHubAPIError, AuthError} from './errors';
 
@@ -1326,7 +1326,7 @@ export class GitHub {
       upstreamRepo: this.repo,
       title: options.title,
       branch: options.branch,
-      description: options.body,
+      description: options.body.slice(0, MAX_ISSUE_SIZE),
       primary: defaultBranch,
       force: true,
       fork: this.fork,


### PR DESCRIPTION
Was seeing `body is too long (maximum is 65536 characters)` for very large mono-repo updates.