### PR TITLE
chore: correct step output key in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -173,19 +173,19 @@ jobs:
       - uses: actions/checkout@v2
         # these if statements ensure that a publication only occurs when
         # a new release is created:
-        if: ${{ steps.release.outputs.release_created }}
+        if: ${{ steps.release.outputs.releases_created }}
       - uses: actions/setup-node@v1
         with:
           node-version: 12
           registry-url: 'https://registry.npmjs.org'
-        if: ${{ steps.release.outputs.release_created }}
+        if: ${{ steps.release.outputs.releases_created }}
       # if you are using Yarn, substitute the command below with `yarn install --frozen-lockfile`
       - run: npm ci
-        if: ${{ steps.release.outputs.release_created }}
+        if: ${{ steps.release.outputs.releases_created }}
       - run: npm publish
         env:
           NODE_AUTH_TOKEN: ${{secrets.NPM_TOKEN}}
-        if: ${{ steps.release.outputs.release_created }}
+        if: ${{ steps.release.outputs.releases_created }}
 ```
 
 > So that you can keep 2FA enabled for npm publications, we recommend setting


### PR DESCRIPTION
Just a quick doc update - seems like the output keyname for a release being created has changed and it wasn't reflected in docs. See this output from `release-please` for evidence: https://github.com/willarmiros/test-package-lock-repo/runs/3617929254?check_suite_focus=true#step:3:4