### PR TITLE
feat: github release notes optional header/footer

### DIFF
--- a/README.md
+++ b/README.md
@@ -232,6 +232,8 @@ release-please github-release --repo-url=googleapis/nodejs-firestore \
 | `--repo-url`      | is the URL of the repository on GitHub.                 |
 | `--token`         | a token with write access to `--repo-url`.              |
 | `--path`          | create a release from a path other than the repository's root |
+| `--notes-header`  | prepend release notes with templated block of text. |
+| `--notes-footer`  | prepend release notes with templated block of text. |
 
 ### Running as a GitHub App
 

--- a/__snapshots__/cli.js
+++ b/__snapshots__/cli.js
@@ -62,6 +62,20 @@ Options:
                                                       [boolean] [default: false]
   --release-label                   set a pull request label other than
                                     "autorelease: tagged"               [string]
+  --notes-header                    optionally add block of text before github
+                                    release notes. Text can be templated with
+                                    handlebars.js syntax. The template will have
+                                    these partials exposed: {{> version | tag |
+                                    githubRepo | githubOwner | changelogPath |
+                                    PRNumber | PRSha | PRTitle }}. Literal line
+                                    feeds replaced with newlines.       [string]
+  --notes-footer                    optionally add block of text after github
+                                    release notes. Text can be templated with
+                                    handlebars.js syntax. The template will have
+                                    these partials exposed: {{> version | tag |
+                                    githubRepo | githubOwner | changelogPath |
+                                    PRNumber | PRSha | PRTitle }}. Literal line
+                                    feeds replaced with newlines.       [string]
 `
 
 exports['CLI flags latest-tag flags 1'] = `

--- a/__snapshots__/release-notes.js
+++ b/__snapshots__/release-notes.js
@@ -98,3 +98,24 @@ exports['extractReleaseNotes php-yoshi extracts appropriate release notes, when 
 </details>
 
 `
+
+exports['generateReleaseNotes renders notes with header and footer 1'] = `
+
+HEADER
+1|999999|pr_title|CHANGELOG.md|googleapis|foo|v1.2.0|1.2.0
+
+
+### Bug Fixes
+
+* candidate issue should only be updated every 15 minutes. ([#70](https://www.github.com/googleapis/release-please/issues/70)) ([edcd1f7](https://www.github.com/googleapis/release-please/commit/edcd1f7))
+
+
+### Features
+
+* add GitHub action for generating candidate issue ([#69](https://www.github.com/googleapis/release-please/issues/69)) ([6373aed](https://www.github.com/googleapis/release-please/commit/6373aed))
+* checkbox based releases ([#77](https://www.github.com/googleapis/release-please/issues/77)) ([1e4193c](https://www.github.com/googleapis/release-please/commit/1e4193c))
+
+FOOTER
+1|999999|pr_title|CHANGELOG.md|googleapis|foo|v1.2.0|1.2.0
+
+`

--- a/docs/manifest-releaser.md
+++ b/docs/manifest-releaser.md
@@ -147,6 +147,18 @@ documented in comments)
   // set default conventional commit => changelog sections mapping/appearance.
   // absence defaults to https://git.io/JqCZL
   "changelog-sections": [...]
+  
+  // Optionally add block of text before github release notes. Text can be templated
+  // with handlebars.js syntax. The template will have these partials exposed:
+  // {{> version|tag|githubRepo|githubOwner|changelogPath|PRNumber|PRSha|PRTitle }}.
+  // Literal \n's will be replaced with newlines.
+  "release-notes-extra-header": "header template",
+  
+  // Optionally add block of text after github release notes. Text can be templated
+  // with handlebars.js syntax. The template will have these partials exposed:
+  // {{> version|tag|githubRepo|githubOwner|changelogPath|PRNumber|PRSha|PRTitle }}.
+  // Literal \n's will be replaced with newlines.
+  "release-notes-extra-footer": "footer template",
 
   // when `manifest-release` creates GitHub Releases per package, create
   // those as "Draft" releases (which can later be manually published).
@@ -207,7 +219,8 @@ documented in comments)
       "release-as": "",
       "package-name": "coolio-pkg",
       // our change log is located at path/to/myPyPkgA/docs/CHANGES.rst
-      "changelog-path": "docs/CHANGES.rst"
+      "changelog-path": "docs/CHANGES.rst",
+      "release-notes-extra-header": "header template"
     },
   }
 

--- a/package.json
+++ b/package.json
@@ -73,7 +73,9 @@
     "conventional-changelog-conventionalcommits": "^4.6.0",
     "conventional-changelog-writer": "^5.0.0",
     "conventional-commits-filter": "^2.0.2",
+    "detect-indent": "^6.1.0",
     "figures": "^3.0.0",
+    "handlebars": "^4.7.7",
     "js-yaml": "^4.0.0",
     "parse-github-repo-url": "^1.4.1",
     "semver": "^7.0.0",
@@ -81,8 +83,7 @@
     "typescript": "^3.8.3",
     "unist-util-visit": "^2.0.3",
     "unist-util-visit-parents": "^3.1.1",
-    "yargs": "^16.0.0",
-    "detect-indent": "^6.1.0"
+    "yargs": "^16.0.0"
   },
   "engines": {
     "node": ">=10.12.0"

--- a/src/bin/release-please.ts
+++ b/src/bin/release-please.ts
@@ -214,6 +214,22 @@ export const parser = yargs
         describe: 'set a pull request label other than "autorelease: tagged"',
         type: 'string',
       });
+      yargs.option('notes-header', {
+        describe:
+          'optionally add block of text before github release notes. Text can be templated ' +
+          'with handlebars.js syntax. The template will have these partials exposed: ' +
+          '{{> version | tag | githubRepo | githubOwner | changelogPath | PRNumber | PRSha | PRTitle }}. ' +
+          'Literal line feeds replaced with newlines.',
+        type: 'string',
+      });
+      yargs.option('notes-footer', {
+        describe:
+          'optionally add block of text after github release notes. Text can be templated ' +
+          'with handlebars.js syntax. The template will have these partials exposed: ' +
+          '{{> version | tag | githubRepo | githubOwner | changelogPath | PRNumber | PRSha | PRTitle }}. ' +
+          'Literal line feeds replaced with newlines.',
+        type: 'string',
+      });
     },
     (argv: GitHubReleaseFactoryOptions) => {
       factory.runCommand('github-release', argv).catch(handleError);

--- a/src/index.ts
+++ b/src/index.ts
@@ -36,6 +36,8 @@ export interface GitHubReleaseOptions {
   releaseLabel?: string;
   draft?: boolean;
   skipGithubRelease?: boolean;
+  notesHeader?: string;
+  notesFooter?: string;
 }
 
 // Used by ReleasePR: Factory and Constructor
@@ -101,6 +103,8 @@ export type ManifestPackage = Pick<
   | 'packageName'
   | 'bumpMinorPreMajor'
   | 'bumpPatchForMinorPreMajor'
+  | 'notesHeader'
+  | 'notesFooter'
   | 'releaseAs'
   | 'changelogSections'
   | 'changelogPath'

--- a/test/factory.ts
+++ b/test/factory.ts
@@ -197,6 +197,8 @@ describe('factory', () => {
       });
       expect(ghr.constructor.name).to.equal('GitHubRelease');
       expect(ghr.draft).to.be.false;
+      expect(ghr.notesHeader).to.be.undefined;
+      expect(ghr.notesFooter).to.be.undefined;
       expect(ghr.gh.owner).to.equal('googleapis');
       expect(ghr.gh.repo).to.equal('simple-test-repo');
       expect(ghr.gh.token).to.be.undefined;
@@ -235,9 +237,13 @@ describe('factory', () => {
         lastPackageVersion: '0.0.1',
         versionFile: 'some/ruby/version.rb',
         draft: true,
+        notesHeader: 'HEADER',
+        notesFooter: 'FOOTER',
       });
       expect(ghr.constructor.name).to.equal('GitHubRelease');
       expect(ghr.draft).to.be.true;
+      expect(ghr.notesHeader).to.equal('HEADER');
+      expect(ghr.notesFooter).to.equal('FOOTER');
       expect(ghr.gh.owner).to.equal('googleapis');
       expect(ghr.gh.repo).to.equal('ruby-test-repo');
       expect(ghr.gh.token).to.equal('some-token');


### PR DESCRIPTION
Add `--notes-header` and `--notes-footer` options for `github-release`
command (adds them to the manifest too), so that the user can pass
text templated with handlebars.js to be added before/after the resulting
GitHub release notes.

This allows customizing GitHub release notes by the user, e.g. adding
release installation instructions at the end of the changelog displayed
on the release page.

Partials exposed to the templating engine to be used by the user:
```
{{> version | tag | githubRepo | githubOwner | changelogPath | PRNumber | PRSha | PRTitle }}
```

Usage:
```shell
release-please.js github-release --notes-header "Hi." --notes-footer "## Documentation:\nhttp://example.org/docs/v{{> version }}/"
```

Resulting GitHub release notes:
```markdown
Hi.

## Features:
...release changelog here...

## Documentation:
http://example.org/docs/v1.0.0/
```

Fixes #1039

Signed-off-by: Ilya Lesikov <ilya@lesikov.com>