### PR TITLE
feat: github-release can customize the label applied to the pull request

### DIFF
--- a/__snapshots__/cli.js
+++ b/__snapshots__/cli.js
@@ -50,6 +50,8 @@ Options:
                                     associated with the release for future tag
                                     creation upon "un-drafting" the release.
                                                       [boolean] [default: false]
+  --release-label                   set a pull request label other than
+                                    "autorelease: tagged"               [string]
 `
 
 exports['CLI flags latest-tag flags 1'] = `

--- a/src/bin/release-please.ts
+++ b/src/bin/release-please.ts
@@ -193,6 +193,10 @@ export const parser = yargs
         type: 'boolean',
         default: false,
       });
+      yargs.option('release-label', {
+        describe: 'set a pull request label other than "autorelease: tagged"',
+        type: 'string',
+      });
     },
     (argv: GitHubReleaseFactoryOptions) => {
       factory.runCommand('github-release', argv).catch(handleError);


### PR DESCRIPTION
The `GitHubReleaseOptions` interface already includes a `releaseLabel` field that controls the label applied to the pull request when `github-release` is run. (When this field is undefined, the logic in `github-release.ts` falls back to `autorelease: tagged`.) If I understand Yargs correctly, this change will allow this field to be set via Yargs.
