### PR TITLE
feat: allow forcing latest tag

### DIFF
--- a/__snapshots__/cli.js
+++ b/__snapshots__/cli.js
@@ -49,6 +49,11 @@ Options:
                                     <email@example.com>").              [string]
   --changelog-path                  where can the CHANGELOG be found in the
                                     project?           [default: "CHANGELOG.md"]
+  --latest-tag-version              Override the detected latest tag version
+                                                                        [string]
+  --latest-tag-sha                  Override the detected latest tag SHA[string]
+  --latest-tag-name                 Override the detected latest tag name
+                                                                        [string]
   --draft                           mark release as a draft. no tag is created
                                     but tag_name and target_commitish are
                                     associated with the release for future tag
@@ -110,6 +115,11 @@ Options:
                                     <email@example.com>").              [string]
   --changelog-path                  where can the CHANGELOG be found in the
                                     project?           [default: "CHANGELOG.md"]
+  --latest-tag-version              Override the detected latest tag version
+                                                                        [string]
+  --latest-tag-sha                  Override the detected latest tag SHA[string]
+  --latest-tag-name                 Override the detected latest tag name
+                                                                        [string]
 `
 
 exports['CLI flags manifest-pr flags 1'] = `
@@ -212,4 +222,9 @@ Options:
                                     <email@example.com>").              [string]
   --changelog-path                  where can the CHANGELOG be found in the
                                     project?           [default: "CHANGELOG.md"]
+  --latest-tag-version              Override the detected latest tag version
+                                                                        [string]
+  --latest-tag-sha                  Override the detected latest tag SHA[string]
+  --latest-tag-name                 Override the detected latest tag name
+                                                                        [string]
 `

--- a/src/bin/release-please.ts
+++ b/src/bin/release-please.ts
@@ -99,6 +99,18 @@ function releaserCommon(ya: YargsOptionsBuilder) {
     default: 'CHANGELOG.md',
     describe: 'where can the CHANGELOG be found in the project?',
   });
+  ya.option('latest-tag-version', {
+    describe: 'Override the detected latest tag version',
+    type: 'string',
+  });
+  ya.option('latest-tag-sha', {
+    describe: 'Override the detected latest tag SHA',
+    type: 'string',
+  });
+  ya.option('latest-tag-name', {
+    describe: 'Override the detected latest tag name',
+    type: 'string',
+  });
 }
 
 function releaseType(ya: YargsOptionsBuilder, defaultType?: string) {

--- a/src/factory.ts
+++ b/src/factory.ts
@@ -261,11 +261,27 @@ function releasePR(options: ReleasePRFactoryOptions): ReleasePR {
   const [GHFactoryOptions, RPFactoryOptions] = getGitHubFactoryOpts(options);
   const github = gitHubInstance(GHFactoryOptions);
 
-  const {releaseType, label, ...RPConstructorOptions} = RPFactoryOptions;
+  const {
+    releaseType,
+    label,
+    latestTagName,
+    latestTagSha,
+    latestTagVersion,
+    ...RPConstructorOptions
+  } = RPFactoryOptions;
+  let latestTag: GitHubTag | undefined = undefined;
+  if (latestTagName && latestTagSha && latestTagVersion) {
+    latestTag = {
+      name: latestTagName,
+      sha: latestTagSha,
+      version: latestTagVersion,
+    };
+  }
   const labels = getLabels(label);
   return new (factory.releasePRClass(releaseType))({
     github,
     labels,
+    latestTag,
     ...RPConstructorOptions,
   });
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import {OctokitAPIs, GitHub} from './github';
+import {OctokitAPIs, GitHub, GitHubTag} from './github';
 import {ReleaseType} from './releasers';
 import {ReleasePR} from './release-pr';
 import {ChangelogSection} from './conventional-commits';
@@ -118,6 +118,7 @@ export interface ReleasePRConstructorOptions
     ReleaserConstructorOptions {
   labels?: string[];
   skipDependencyUpdates?: boolean;
+  latestTag?: GitHubTag;
 }
 
 // GitHubRelease Constructor options
@@ -148,6 +149,9 @@ export interface ReleasePRFactoryOptions
     GitHubFactoryOptions,
     ReleaserFactory {
   label?: string;
+  latestTagName?: string;
+  latestTagSha?: string;
+  latestTagVersion?: string;
 }
 
 // GitHubRelease factory/builder options

--- a/src/release-pr.ts
+++ b/src/release-pr.ts
@@ -88,6 +88,7 @@ export class ReleasePR {
   extraFiles: string[];
   forManifestReleaser: boolean;
   enableSimplePrereleaseParsing = false;
+  latestTagOverride?: GitHubTag;
 
   constructor(options: ReleasePRConstructorOptions) {
     this.bumpMinorPreMajor = options.bumpMinorPreMajor || false;
@@ -112,6 +113,7 @@ export class ReleasePR {
     this.pullRequestTitlePattern = options.pullRequestTitlePattern;
     this.extraFiles = options.extraFiles ?? [];
     this.forManifestReleaser = options.skipDependencyUpdates ?? false;
+    this.latestTagOverride = options.latestTag;
   }
 
   // A releaser can override this method to automatically detect the
@@ -593,6 +595,10 @@ export class ReleasePR {
     prefix?: string,
     preRelease = false
   ): Promise<GitHubTag | undefined> {
+    if (this.latestTagOverride) {
+      return this.latestTagOverride;
+    }
+
     const branchPrefix = prefix?.endsWith('-')
       ? prefix.replace(/-$/, '')
       : prefix;


### PR DESCRIPTION
Allows you to skip the latest tag lookup and specify the previous tag and sha to base the release on.

Example:
```
release-please release-pr --token=$GITHUB_TOKEN \
  --repo-url=googleapis/google-cloud-go --package-name=asset \
  --path=asset --release-type=go-yoshi --monorepo-tags=true  \
  --debug --latest-tag-name=asset/v1.0.0 \
  --latest-tag-sha=79837291073d538f8ca768b04afc642bdd25d69b \
  --latest-tag-version=1.0.0
```

Creates: https://github.com/googleapis/google-cloud-go/pull/4812