### PR TITLE
feat: support GitHub automated release notes

### DIFF
--- a/__snapshots__/cli.js
+++ b/__snapshots__/cli.js
@@ -62,6 +62,8 @@ Options:
                                     associated with the release for future tag
                                     creation upon "un-drafting" the release.
                                                       [boolean] [default: false]
+  --github-release-notes            use GitHub's auto-generated release notes
+                                                                       [boolean]
   --release-label                   set a pull request label other than
                                     "autorelease: tagged"               [string]
 `

--- a/__snapshots__/github.js
+++ b/__snapshots__/github.js
@@ -529,6 +529,14 @@ exports['GitHub commitsSinceSha returns commits immediately before sha 1'] = [
   }
 ]
 
+exports['GitHub createRelease should create a release that uses GitHub generated release notes 1'] = {
+  "tag_name": "v1.2.3",
+  "target_commitish": "abc123",
+  "name": "my package v1.2.3",
+  "draft": false,
+  "generate_release_notes": true
+}
+
 exports['GitHub createRelease should create a release with a package prefix 1'] = {
   "tag_name": "v1.2.3",
   "target_commitish": "abc123",

--- a/src/bin/release-please.ts
+++ b/src/bin/release-please.ts
@@ -210,6 +210,11 @@ export const parser = yargs
         type: 'boolean',
         default: false,
       });
+      yargs.option('github-release-notes', {
+        describe: "use GitHub's auto-generated release notes",
+        type: 'boolean',
+        default: undefined,
+      });
       yargs.option('release-label', {
         describe: 'set a pull request label other than "autorelease: tagged"',
         type: 'string',

--- a/src/github-release.ts
+++ b/src/github-release.ts
@@ -40,12 +40,14 @@ export class GitHubRelease {
   gh: GitHub;
   draft: boolean;
   releaseLabel: string;
+  githubReleaseNotes?: boolean;
 
   constructor(options: GitHubReleaseConstructorOptions) {
     this.draft = !!options.draft;
     this.gh = options.github;
     this.releasePR = options.releasePR;
     this.releaseLabel = options.releaseLabel ?? GITHUB_RELEASE_LABEL;
+    this.githubReleaseNotes = options.githubReleaseNotes;
   }
 
   async createRelease(): Promise<
@@ -75,7 +77,8 @@ export class GitHubRelease {
         candidate.tag,
         candidate.sha,
         candidate.notes,
-        this.draft
+        this.draft,
+        this.githubReleaseNotes
       );
     } else {
       candidate = await this.releasePR.buildRelease();
@@ -86,7 +89,8 @@ export class GitHubRelease {
         candidate.tag,
         candidate.sha,
         candidate.notes,
-        this.draft
+        this.draft,
+        this.githubReleaseNotes
       );
       return [candidate, release];
     } else {

--- a/src/github.ts
+++ b/src/github.ts
@@ -1618,21 +1618,26 @@ export class GitHub {
       tagName: string,
       sha: string,
       releaseNotes: string,
-      draft: boolean
+      draft: boolean,
+      githubReleaseNotes?: boolean
     ): Promise<ReleaseCreateResponse> => {
       logger.info(`creating release ${tagName}`);
       const name = packageName ? `${packageName} ${tagName}` : tagName;
-      return (
-        await this.request('POST /repos/:owner/:repo/releases', {
-          owner: this.owner,
-          repo: this.repo,
-          tag_name: tagName,
-          target_commitish: sha,
-          body: releaseNotes,
-          name,
-          draft: draft,
-        })
-      ).data;
+      const body: {[key: string]: string | boolean} = {
+        owner: this.owner,
+        repo: this.repo,
+        tag_name: tagName,
+        target_commitish: sha,
+        name,
+        draft,
+      };
+      if (githubReleaseNotes) {
+        body.generate_release_notes = githubReleaseNotes;
+      } else {
+        body.body = releaseNotes;
+      }
+      return (await this.request('POST /repos/:owner/:repo/releases', body))
+        .data;
     },
     e => {
       if (e instanceof RequestError) {

--- a/src/index.ts
+++ b/src/index.ts
@@ -37,6 +37,9 @@ export interface GitHubReleaseOptions {
   releaseLabel?: string;
   draft?: boolean;
   skipGithubRelease?: boolean;
+  // Generate release notes using .github/release.yml:
+  // https://github.blog/2021-10-04-beta-github-releases-improving-release-experience/
+  githubReleaseNotes?: boolean;
 }
 
 // Used by ReleasePR: Factory and Constructor
@@ -106,6 +109,7 @@ export type ManifestPackage = Pick<
   | 'changelogSections'
   | 'changelogPath'
   | 'skipGithubRelease'
+  | 'githubReleaseNotes'
 > & {
   // these items are not optional in the manifest context.
   path: string;

--- a/test/cli.ts
+++ b/test/cli.ts
@@ -259,7 +259,7 @@ describe('CLI', () => {
     });
   });
   describe('github-release', () => {
-    it('instantiates a GitHub released based on command line arguments', async () => {
+    it('instantiates a GitHub release based on command line arguments', async () => {
       sandbox.replace(factory, 'call', callStub);
       const pkgName = 'cli-package';
       const cmd =
@@ -272,6 +272,7 @@ describe('CLI', () => {
       assert.ok(instanceToRun! instanceof GitHubRelease);
       assert.strictEqual(instanceToRun.gh.owner, 'googleapis');
       assert.strictEqual(instanceToRun.gh.repo, 'release-please-cli');
+      assert.strictEqual(instanceToRun.githubReleaseNotes, undefined);
 
       const jsonPkg = `{"name": "${pkgName}"}`;
       sandbox.stub(instanceToRun.releasePR.gh, 'getFileContents').resolves({
@@ -287,7 +288,7 @@ describe('CLI', () => {
       // Defaults to Node.js release type:
       assert.strictEqual(instanceToRun.releasePR.constructor.name, 'Node');
     });
-    it('instantiates a GitHub released without releaseType', async () => {
+    it('instantiates a GitHub release without releaseType', async () => {
       sandbox.replace(factory, 'call', callStub);
       const cmd = 'github-release --repo-url=googleapis/release-please-cli ';
       parser.parse(cmd);
@@ -298,6 +299,14 @@ describe('CLI', () => {
         (await instanceToRun.releasePR.getPackageName()).name,
         ''
       );
+    });
+    it('instantiates a GitHub release passing github-release-notes', async () => {
+      sandbox.replace(factory, 'call', callStub);
+      const cmd =
+        'github-release --repo-url=googleapis/release-please-cli --github-release-notes';
+      parser.parse(cmd);
+      assert.ok(instanceToRun! instanceof GitHubRelease);
+      assert.strictEqual(instanceToRun.githubReleaseNotes, true);
     });
   });
 });

--- a/test/github-release.ts
+++ b/test/github-release.ts
@@ -120,7 +120,7 @@ describe('GitHubRelease', () => {
       mock
         .expects('createRelease')
         .once()
-        .withExactArgs('foo', 'v1.0.3', 'abc123', '\n* entry', false)
+        .withExactArgs('foo', 'v1.0.3', 'abc123', '\n* entry', false, undefined)
         .once()
         .resolves({
           name: 'foo v1.0.3',
@@ -155,7 +155,14 @@ describe('GitHubRelease', () => {
       mockGithubLabelsAndComment(mock, true);
       mock
         .expects('createRelease')
-        .withExactArgs('foo', 'v1A.B.C', 'abc123', '\n* entry', false)
+        .withExactArgs(
+          'foo',
+          'v1A.B.C',
+          'abc123',
+          '\n* entry',
+          false,
+          undefined
+        )
         .once()
         .resolves({
           name: 'foo v1A.B.C',
@@ -183,7 +190,7 @@ describe('GitHubRelease', () => {
       mockGithubLabelsAndComment(mock, true);
       mock
         .expects('createRelease')
-        .withExactArgs('foo', 'v1.0.3', 'abc123', '\n* entry', true)
+        .withExactArgs('foo', 'v1.0.3', 'abc123', '\n* entry', true, undefined)
         .once()
         .resolves({
           name: 'foo v1.0.3',
@@ -217,7 +224,8 @@ describe('GitHubRelease', () => {
           'bigquery/v1.0.3',
           'abc123',
           '\n* entry',
-          false
+          false,
+          undefined
         )
         .once()
         .resolves({
@@ -262,7 +270,14 @@ describe('GitHubRelease', () => {
       mockGithubLabelsAndComment(mock, true);
       mock
         .expects('createRelease')
-        .withExactArgs('foo', 'foo/v1.0.3', 'abc123', '\n* entry', false)
+        .withExactArgs(
+          'foo',
+          'foo/v1.0.3',
+          'abc123',
+          '\n* entry',
+          false,
+          undefined
+        )
         .once()
         .resolves({
           name: 'foo foo/v1.0.3',
@@ -312,7 +327,8 @@ describe('GitHubRelease', () => {
           'foo-v1.0.3',
           'abc123',
           '\n* entry',
-          false
+          false,
+          undefined
         )
         .once()
         .resolves({
@@ -358,7 +374,8 @@ describe('GitHubRelease', () => {
           'v1.0.3',
           'abc123',
           '\n* entry',
-          false
+          false,
+          undefined
         )
         .once()
         .resolves({
@@ -390,7 +407,7 @@ describe('GitHubRelease', () => {
       mock
         .expects('createRelease')
         .once()
-        .withExactArgs('', 'v1.0.3', 'abc123', '\n* entry', false)
+        .withExactArgs('', 'v1.0.3', 'abc123', '\n* entry', false, undefined)
         .once()
         .resolves({
           name: 'v1.0.3',
@@ -436,7 +453,7 @@ describe('GitHubRelease', () => {
       mockGithubLabelsAndComment(mock, true);
       mock
         .expects('createRelease')
-        .withExactArgs('foo', 'v1.0.3', 'abc123', '\n* entry', false)
+        .withExactArgs('foo', 'v1.0.3', 'abc123', '\n* entry', false, undefined)
         .once()
         .resolves({
           name: 'foo v1.0.3',
@@ -470,7 +487,7 @@ describe('GitHubRelease', () => {
       mockGithubLabelsAndComment(mock, true);
       mock
         .expects('createRelease')
-        .withExactArgs('foo', 'v1.0.3', 'abc123', '\n* entry', false)
+        .withExactArgs('foo', 'v1.0.3', 'abc123', '\n* entry', false, undefined)
         .once()
         .resolves({
           name: 'foo v1.0.3',
@@ -505,7 +522,14 @@ describe('GitHubRelease', () => {
       mockGithubLabelsAndComment(mock, true);
       mock
         .expects('createRelease')
-        .withExactArgs('foo', 'v1.0.3-lts.1', 'abc123', '\n* entry', false)
+        .withExactArgs(
+          'foo',
+          'v1.0.3-lts.1',
+          'abc123',
+          '\n* entry',
+          false,
+          undefined
+        )
         .once()
         .resolves({
           name: 'foo v1.0.3-lts.1',
@@ -605,7 +629,7 @@ describe('GitHubRelease', () => {
       mockGithubLabelsAndComment(mock, true, 'custom-label');
       mock
         .expects('createRelease')
-        .withExactArgs('foo', 'v1.0.3', 'abc123', '\n* entry', false)
+        .withExactArgs('foo', 'v1.0.3', 'abc123', '\n* entry', false, undefined)
         .once()
         .resolves({
           name: 'foo v1.0.3',
@@ -647,7 +671,7 @@ describe('GitHubRelease', () => {
       mock
         .expects('createRelease')
         .once()
-        .withExactArgs('foo', 'v1.0.3', 'abc123', '\n* entry', false)
+        .withExactArgs('foo', 'v1.0.3', 'abc123', '\n* entry', false, undefined)
         .once()
         .resolves(expectedCreateReleaseResponse);
 
@@ -686,7 +710,7 @@ describe('GitHubRelease', () => {
       mock
         .expects('createRelease')
         .once()
-        .withExactArgs('foo', 'v1.0.3', 'abc123', '\n* entry', false)
+        .withExactArgs('foo', 'v1.0.3', 'abc123', '\n* entry', false, undefined)
         .once()
         .resolves(expectedCreateReleaseResponse);
 

--- a/test/github.ts
+++ b/test/github.ts
@@ -893,6 +893,33 @@ describe('GitHub', () => {
         );
       });
     });
+
+    it('should create a release that uses GitHub generated release notes', async () => {
+      req
+        .post('/repos/fake/fake/releases', body => {
+          snapshot(body);
+          return true;
+        })
+        .reply(200, {
+          tag_name: 'v1.2.3',
+          draft: false,
+          html_url: 'https://github.com/fake/fake/releases/v1.2.3',
+          upload_url:
+            'https://uploads.github.com/repos/fake/fake/releases/1/assets{?name,label}',
+        });
+      const release = await github.createRelease(
+        'my package',
+        'v1.2.3',
+        'abc123',
+        'Some release notes',
+        false,
+        true
+      );
+      req.done();
+      expect(release).to.not.be.undefined;
+      expect(release!.tag_name).to.eql('v1.2.3');
+      expect(release!.draft).to.be.false;
+    });
   });
 
   describe('commentOnIssue', () => {


### PR DESCRIPTION
This will allow you to use `release-please` for version bumps and CHANGELOG generation, in conjunction with GitHub's new [auto-generated release notes](https://github.blog/2021-10-04-beta-github-releases-improving-release-experience/#introducing-auto-generated-release-notes).

---

@ilya-lesikov I had your PR in mind working on this, in a perfect world we'd be able to use GitHub's new `.github/release.yml` to customize releases, without needing to add templating support to `release-please`.

Looking at the features in GitHub's auto-generated releases, I don't think it quite matches what you're looking for though?

CC: @MylesBorins


