### PR TITLE
fix: backfill commit files for merge/rebase/direct commits

### DIFF
--- a/__snapshots__/github.js
+++ b/__snapshots__/github.js
@@ -2,6 +2,24 @@ exports['GitHub commentOnIssue can create a comment 1'] = {
   "body": "This is a comment"
 }
 
+exports['GitHub commitsSince backfills commit files without pull requests 1'] = [
+  {
+    "sha": "e6daec403626c9987c7af0d97b34f324cd84320a",
+    "message": "Merge pull request #7 from chingor13/feature-branch-plain-merge\n\nfeat: feature that will be plain merged",
+    "files": [],
+    "pullRequest": {
+      "sha": "e6daec403626c9987c7af0d97b34f324cd84320a",
+      "number": 7,
+      "baseBranchName": "main",
+      "headBranchName": "feature-branch-plain-merge",
+      "title": "feat: feature that will be plain merged",
+      "body": "",
+      "labels": [],
+      "files": []
+    }
+  }
+]
+
 exports['GitHub commitsSince finds commits up until a condition 1'] = [
   {
     "sha": "e6daec403626c9987c7af0d97b34f324cd84320a",

--- a/src/manifest.ts
+++ b/src/manifest.ts
@@ -768,7 +768,6 @@ export class Manifest {
           );
         }
         this._pathsByComponent[component] = path;
-        logger.info(this._pathsByComponent);
       }
     }
     return this._pathsByComponent;


### PR DESCRIPTION
For merge/rebase/direct commits, the `mergeCommitIterator` was not returning the list of files (no matching pull request found). We now backfill the commits from the REST API.
