### PR TITLE
fix: reimplement draft releases

### DIFF
--- a/__snapshots__/cli.js
+++ b/__snapshots__/cli.js
@@ -49,34 +49,34 @@ release-please manifest-pr
 create a release-PR using a manifest file
 
 Options:
-  --help            Show help                                          [boolean]
-  --version         Show version number                                [boolean]
-  --debug           print verbose errors (use only for local debugging).
+  --help                Show help                                      [boolean]
+  --version             Show version number                            [boolean]
+  --debug               print verbose errors (use only for local debugging).
                                                       [boolean] [default: false]
-  --trace           print extra verbose errors (use only for local debugging).
-                                                      [boolean] [default: false]
-  --token           GitHub token with repo write permissions
-  --api-url         URL to use when making API requests
+  --trace               print extra verbose errors (use only for local
+                        debugging).                   [boolean] [default: false]
+  --token               GitHub token with repo write permissions
+  --api-url             URL to use when making API requests
                                     [string] [default: "https://api.github.com"]
-  --graphql-url     URL to use when making GraphQL requests
+  --graphql-url         URL to use when making GraphQL requests
                                     [string] [default: "https://api.github.com"]
-  --default-branch  The branch to open release PRs against and tag releases on
-                              [deprecated: use --target-branch instead] [string]
-  --target-branch   The branch to open release PRs against and tag releases on
-                                                                        [string]
-  --repo-url        GitHub URL to generate release for                [required]
-  --dry-run         Prepare but do not take action    [boolean] [default: false]
-  --label           comma-separated list of labels to add to from release PR
+  --default-branch      The branch to open release PRs against and tag releases
+                        on    [deprecated: use --target-branch instead] [string]
+  --target-branch       The branch to open release PRs against and tag releases
+                        on                                              [string]
+  --repo-url            GitHub URL to generate release for            [required]
+  --dry-run             Prepare but do not take action[boolean] [default: false]
+  --label               comma-separated list of labels to add to from release PR
                                                [default: "autorelease: pending"]
-  --fork            should the PR be created from a fork
+  --fork                should the PR be created from a fork
                                                       [boolean] [default: false]
-  --draft           mark pull request as a draft      [boolean] [default: false]
-  --signoff         Add Signed-off-by line at the end of the commit log message
-                    using the user and email provided. (format "Name
-                    <email@example.com>").                              [string]
-  --config-file     where can the config file be found in the project?
+  --draft-pull-request  mark pull request as a draft  [boolean] [default: false]
+  --signoff             Add Signed-off-by line at the end of the commit log
+                        message using the user and email provided. (format "Name
+                        <email@example.com>").                          [string]
+  --config-file         where can the config file be found in the project?
                                          [default: "release-please-config.json"]
-  --manifest-file   where can the manifest file be found in the project?
+  --manifest-file       where can the manifest file be found in the project?
                                       [default: ".release-please-manifest.json"]
 `
 
@@ -176,7 +176,7 @@ Options:
                                                [default: "autorelease: pending"]
   --fork                            should the PR be created from a fork
                                                       [boolean] [default: false]
-  --draft                           mark pull request as a draft
+  --draft-pull-request              mark pull request as a draft
                                                       [boolean] [default: false]
   --signoff                         Add Signed-off-by line at the end of the
                                     commit log message using the user and email

--- a/__snapshots__/github.js
+++ b/__snapshots__/github.js
@@ -393,22 +393,32 @@ exports['GitHub commitsSince paginates through commits 1'] = [
   }
 ]
 
+exports['GitHub createRelease should create a draft release 1'] = {
+  "tag_name": "v1.2.3",
+  "body": "Some release notes",
+  "sha": "abc123",
+  "draft": true
+}
+
 exports['GitHub createRelease should create a release with a package prefix 1'] = {
   "tag_name": "v1.2.3",
   "body": "Some release notes",
-  "sha": "abc123"
+  "sha": "abc123",
+  "draft": false
 }
 
 exports['GitHub createRelease should raise a DuplicateReleaseError if already_exists 1'] = {
   "tag_name": "v1.2.3",
   "body": "Some release notes",
-  "sha": "abc123"
+  "sha": "abc123",
+  "draft": false
 }
 
 exports['GitHub createRelease should raise a RequestError for other validation errors 1'] = {
   "tag_name": "v1.2.3",
   "body": "Some release notes",
-  "sha": "abc123"
+  "sha": "abc123",
+  "draft": false
 }
 
 exports['GitHub findFilesByExtension returns files matching the requested pattern 1'] = [

--- a/src/bin/release-please.ts
+++ b/src/bin/release-please.ts
@@ -84,7 +84,7 @@ interface ReleaseArgs {
 }
 
 interface PullRequestArgs {
-  draft?: boolean;
+  draftPullRequest?: boolean;
   label?: string;
   signoff?: string;
 }
@@ -129,7 +129,8 @@ interface BootstrapArgs
     ManifestConfigArgs,
     VersioningArgs,
     PullRequestArgs,
-    PullRequestStrategyArgs {
+    PullRequestStrategyArgs,
+    ReleaseArgs {
   initialVersion?: string;
 }
 
@@ -207,7 +208,7 @@ function pullRequestOptions(yargs: yargs.Argv): yargs.Argv {
       type: 'boolean',
       default: false,
     })
-    .option('draft', {
+    .option('draft-pull-request', {
       describe: 'mark pull request as a draft',
       type: 'boolean',
       default: false,
@@ -374,7 +375,7 @@ const createReleasePullRequestCommand: yargs.CommandModule<
           releaseType: argv.releaseType,
           component: argv.component,
           packageName: argv.packageName,
-          draft: argv.draft,
+          draftPullRequest: argv.draftPullRequest,
           bumpMinorPreMajor: argv.bumpMinorPreMajor,
           bumpPatchForMinorPreMajor: argv.bumpPatchForMinorPreMajor,
           changelogPath: argv.changelogPath,
@@ -565,7 +566,9 @@ const bootstrapCommand: yargs.CommandModule<{}, BootstrapArgs> = {
   command: 'bootstrap',
   describe: 'configure release manifest',
   builder(yargs) {
-    return manifestOptions(pullRequestStrategyOptions(gitHubOptions(yargs)))
+    return manifestOptions(
+      releaseOptions(pullRequestStrategyOptions(gitHubOptions(yargs)))
+    )
       .option('initial-version', {
         description: 'current version',
       })
@@ -591,6 +594,7 @@ const bootstrapCommand: yargs.CommandModule<{}, BootstrapArgs> = {
       component: argv.component,
       packageName: argv.packageName,
       draft: argv.draft,
+      draftPullRequest: argv.draftPullRequest,
       bumpMinorPreMajor: argv.bumpMinorPreMajor,
       bumpPatchForMinorPreMajor: argv.bumpPatchForMinorPreMajor,
       changelogPath: argv.changelogPath,
@@ -648,7 +652,7 @@ interface HandleError {
 }
 
 function extractManifestOptions(
-  argv: (GitHubArgs & PullRequestArgs) | ReleaseArgs
+  argv: GitHubArgs & (PullRequestArgs | ReleaseArgs)
 ): ManifestOptions {
   const manifestOptions: ManifestOptions = {};
   if ('fork' in argv && argv.fork !== undefined) {
@@ -665,6 +669,9 @@ function extractManifestOptions(
   }
   if ('draft' in argv && argv.draft !== undefined) {
     manifestOptions.draft = argv.draft;
+  }
+  if ('draftPullRequest' in argv && argv.draftPullRequest !== undefined) {
+    manifestOptions.draftPullRequest = argv.draftPullRequest;
   }
   return manifestOptions;
 }

--- a/src/manifest.ts
+++ b/src/manifest.ts
@@ -53,6 +53,7 @@ export interface ReleaserConfig {
   releaseAs?: string;
   skipGithubRelease?: boolean;
   draft?: boolean;
+  draftPullRequest?: boolean;
   component?: string;
   packageName?: string;
 
@@ -81,6 +82,7 @@ interface ReleaserConfigJson {
   'release-as'?: string;
   'skip-github-release'?: boolean;
   draft?: boolean;
+  'draft-pull-request'?: boolean;
   label?: string;
   'release-label'?: string;
 
@@ -102,7 +104,7 @@ export interface ManifestOptions {
   labels?: string[];
   releaseLabels?: string[];
   draft?: boolean;
-  releaseDraft?: boolean;
+  draftPullRequest?: boolean;
 }
 
 interface ReleaserPackageConfig extends ReleaserConfigJson {
@@ -155,6 +157,8 @@ export class Manifest {
   private manifestPath: string;
   private bootstrapSha?: string;
   private lastReleaseSha?: string;
+  private draft?: boolean;
+  private draftPullRequest?: boolean;
 
   /**
    * Create a Manifest from explicit config in code. This assumes that the
@@ -204,6 +208,8 @@ export class Manifest {
     this.labels = manifestOptions?.labels || DEFAULT_LABELS;
     this.bootstrapSha = manifestOptions?.bootstrapSha;
     this.lastReleaseSha = manifestOptions?.lastReleaseSha;
+    this.draft = manifestOptions?.draft;
+    this.draftPullRequest = manifestOptions?.draftPullRequest;
   }
 
   /**
@@ -458,7 +464,7 @@ export class Manifest {
       const releasePullRequest = await strategy.buildReleasePullRequest(
         pathCommits,
         latestRelease,
-        config.draft,
+        config.draftPullRequest ?? this.draftPullRequest,
         this.labels
       );
       if (releasePullRequest) {
@@ -664,7 +670,7 @@ export class Manifest {
           releases.push({
             ...release,
             pullRequest,
-            draft: config.draft,
+            draft: config.draft ?? this.draft,
           });
         }
       }
@@ -795,6 +801,7 @@ function extractReleaserConfig(config: ReleaserPackageConfig): ReleaserConfig {
     releaseAs: config['release-as'],
     skipGithubRelease: config['skip-github-release'],
     draft: config.draft,
+    draftPullRequest: config['draft-pull-request'],
     component: config['component'],
     packageName: config['package-name'],
     versionFile: config['version-file'],

--- a/src/manifest.ts
+++ b/src/manifest.ts
@@ -70,6 +70,7 @@ export interface CandidateReleasePullRequest {
 
 export interface CandidateRelease extends Release {
   pullRequest: PullRequest;
+  draft?: boolean;
 }
 
 interface ReleaserConfigJson {
@@ -663,6 +664,7 @@ export class Manifest {
           releases.push({
             ...release,
             pullRequest,
+            draft: config.draft,
           });
         }
       }
@@ -726,7 +728,9 @@ export class Manifest {
   private async createRelease(
     release: CandidateRelease
   ): Promise<GitHubRelease> {
-    const githubRelease = await this.github.createRelease(release);
+    const githubRelease = await this.github.createRelease(release, {
+      draft: release.draft,
+    });
 
     // comment on pull request
     const comment = `:robot: Release is at ${githubRelease.url} :sunflower:`;

--- a/test/cli.ts
+++ b/test/cli.ts
@@ -782,9 +782,9 @@ describe('CLI', () => {
         sinon.assert.calledOnce(createPullRequestsStub);
       });
 
-      it('handles --draft', async () => {
+      it('handles --draft-pull-request', async () => {
         await parser.parseAsync(
-          'release-pr --repo-url=googleapis/release-please-cli --release-type=java-yoshi --draft'
+          'release-pr --repo-url=googleapis/release-please-cli --release-type=java-yoshi --draft-pull-request'
         );
 
         sinon.assert.calledOnceWithExactly(gitHubCreateStub, {
@@ -796,8 +796,8 @@ describe('CLI', () => {
           fromConfigStub,
           fakeGitHub,
           'main',
-          sinon.match({releaseType: 'java-yoshi'}),
-          sinon.match({draft: true}),
+          sinon.match({releaseType: 'java-yoshi', draftPullRequest: true}),
+          sinon.match.any,
           undefined
         );
         sinon.assert.calledOnce(createPullRequestsStub);
@@ -1115,7 +1115,7 @@ describe('CLI', () => {
           fakeGitHub,
           'main',
           sinon.match({releaseType: 'java-yoshi', draft: true}),
-          sinon.match({draft: true}),
+          sinon.match.any,
           undefined
         );
         sinon.assert.calledOnce(createReleasesStub);

--- a/test/github.ts
+++ b/test/github.ts
@@ -494,7 +494,7 @@ describe('GitHub', () => {
       expect(release).to.not.be.undefined;
       expect(release.tagName).to.eql('v1.2.3');
       expect(release.sha).to.eql('abc123');
-      // expect(release!.draft).to.be.false; // FIXME
+      expect(release.draft).to.be.false;
     });
 
     it('should raise a DuplicateReleaseError if already_exists', async () => {
@@ -556,6 +556,35 @@ describe('GitHub', () => {
           !!error.cause
         );
       });
+    });
+
+    it('should create a draft release', async () => {
+      req
+        .post('/repos/fake/fake/releases', body => {
+          snapshot(body);
+          return true;
+        })
+        .reply(200, {
+          tag_name: 'v1.2.3',
+          draft: true,
+          html_url: 'https://github.com/fake/fake/releases/v1.2.3',
+          upload_url:
+            'https://uploads.github.com/repos/fake/fake/releases/1/assets{?name,label}',
+          target_commitish: 'abc123',
+        });
+      const release = await github.createRelease(
+        {
+          tag: new TagName(Version.parse('1.2.3')),
+          sha: 'abc123',
+          notes: 'Some release notes',
+        },
+        {draft: true}
+      );
+      req.done();
+      expect(release).to.not.be.undefined;
+      expect(release.tagName).to.eql('v1.2.3');
+      expect(release.sha).to.eql('abc123');
+      expect(release.draft).to.be.true;
     });
   });
 

--- a/test/manifest.ts
+++ b/test/manifest.ts
@@ -84,10 +84,10 @@ function mockPullRequests(
 
 function mockCreateRelease(
   github: GitHub,
-  releases: {sha: string; tagName: string}[]
+  releases: {sha: string; tagName: string; draft?: boolean}[]
 ) {
   const releaseStub = sandbox.stub(github, 'createRelease');
-  for (const {sha, tagName} of releases) {
+  for (const {sha, tagName, draft} of releases) {
     releaseStub
       .withArgs(
         sinon.match.has(
@@ -100,6 +100,7 @@ function mockCreateRelease(
         sha,
         url: 'https://path/to/release',
         notes: 'some release notes',
+        draft,
       });
   }
 }
@@ -1509,6 +1510,7 @@ describe('Manifest', () => {
         .to.be.a('string')
         .and.satisfy((msg: string) => msg.startsWith('### Bug Fixes'));
     });
+
     it('should handle a multiple manifest release', async () => {
       mockPullRequests(
         github,
@@ -1607,6 +1609,7 @@ describe('Manifest', () => {
         .to.be.a('string')
         .and.satisfy((msg: string) => msg.startsWith('### Features'));
     });
+
     it('should handle a single standalone release', async () => {
       mockPullRequests(
         github,
@@ -1738,6 +1741,52 @@ describe('Manifest', () => {
       expect(releases[2].notes)
         .to.be.a('string')
         .and.satisfy((msg: string) => msg.startsWith('### Features'));
+    });
+
+    it('should build draft releases', async () => {
+      mockPullRequests(
+        github,
+        [],
+        [
+          {
+            headBranchName: 'release-please/branches/main',
+            baseBranchName: 'main',
+            number: 1234,
+            title: 'chore: release main',
+            body: pullRequestBody('release-notes/single-manifest.txt'),
+            labels: ['autorelease: pending'],
+            files: [],
+            sha: 'abc123',
+          },
+        ]
+      );
+      const getFileContentsStub = sandbox.stub(
+        github,
+        'getFileContentsOnBranch'
+      );
+      getFileContentsStub
+        .withArgs('package.json', 'main')
+        .resolves(
+          buildGitHubFileRaw(
+            JSON.stringify({name: '@google-cloud/release-brancher'})
+          )
+        );
+      const manifest = new Manifest(
+        github,
+        'main',
+        {
+          '.': {
+            releaseType: 'node',
+            draft: true,
+          },
+        },
+        {
+          '.': Version.parse('1.3.1'),
+        }
+      );
+      const releases = await manifest.buildReleases();
+      expect(releases).lengthOf(1);
+      expect(releases[0].draft).to.be.true;
     });
   });
 
@@ -2038,6 +2087,73 @@ describe('Manifest', () => {
       sinon.assert.calledOnceWithExactly(
         removeLabelsStub,
         ['some-pull-request-label'],
+        1234
+      );
+    });
+    it('should create a draft release', async () => {
+      mockPullRequests(
+        github,
+        [],
+        [
+          {
+            headBranchName: 'release-please/branches/main',
+            baseBranchName: 'main',
+            number: 1234,
+            title: 'chore: release main',
+            body: pullRequestBody('release-notes/single-manifest.txt'),
+            labels: ['autorelease: pending'],
+            files: [],
+            sha: 'abc123',
+          },
+        ]
+      );
+      const getFileContentsStub = sandbox.stub(
+        github,
+        'getFileContentsOnBranch'
+      );
+      getFileContentsStub
+        .withArgs('package.json', 'main')
+        .resolves(
+          buildGitHubFileRaw(
+            JSON.stringify({name: '@google-cloud/release-brancher'})
+          )
+        );
+      mockCreateRelease(github, [
+        {sha: 'abc123', tagName: 'release-brancher-v1.3.1', draft: true},
+      ]);
+      const commentStub = sandbox.stub(github, 'commentOnIssue').resolves();
+      const addLabelsStub = sandbox.stub(github, 'addIssueLabels').resolves();
+      const removeLabelsStub = sandbox
+        .stub(github, 'removeIssueLabels')
+        .resolves();
+      const manifest = new Manifest(
+        github,
+        'main',
+        {
+          '.': {
+            releaseType: 'node',
+            draft: true,
+          },
+        },
+        {
+          '.': Version.parse('1.3.1'),
+        }
+      );
+      const releases = await manifest.createReleases();
+      expect(releases).lengthOf(1);
+      expect(releases[0]!.tagName).to.eql('release-brancher-v1.3.1');
+      expect(releases[0]!.sha).to.eql('abc123');
+      expect(releases[0]!.notes).to.eql('some release notes');
+      expect(releases[0]!.draft).to.be.true;
+      sinon.assert.calledOnce(commentStub);
+      sinon.assert.calledOnceWithExactly(
+        addLabelsStub,
+        ['autorelease: tagged'],
+        1234
+      );
+      sinon.assert.calledOnceWithExactly(
+        removeLabelsStub,
+        ['autorelease: pending'],
         1234
       );
     });


### PR DESCRIPTION
We introduced the ability to open draft PRs, but it was overloading the `--draft` option. This is now separated into `--draft-pull-request` option.