### PR TITLE
refactor: rename release-notes to changelog-notes and make it swappable

### DIFF
--- a/__snapshots__/default-changelog-notes.js
+++ b/__snapshots__/default-changelog-notes.js
@@ -1,4 +1,4 @@
-exports['ReleaseNotes buildNotes should build default release notes 1'] = `
+exports['DefaultChangelogNotes buildNotes should build default release notes 1'] = `
 ### [1.2.3](https://github.com/googleapis/java-asset/compare/v1.2.2...v1.2.3) (1983-10-10)
 
 
@@ -16,7 +16,7 @@ exports['ReleaseNotes buildNotes should build default release notes 1'] = `
 * some bugfix ([sha2](https://github.com/googleapis/java-asset/commit/sha2))
 `
 
-exports['ReleaseNotes buildNotes should build with custom changelog sections 1'] = `
+exports['DefaultChangelogNotes buildNotes should build with custom changelog sections 1'] = `
 ### [1.2.3](https://github.com/googleapis/java-asset/compare/v1.2.2...v1.2.3) (1983-10-10)
 
 
@@ -39,7 +39,7 @@ exports['ReleaseNotes buildNotes should build with custom changelog sections 1']
 * some documentation ([sha3](https://github.com/googleapis/java-asset/commit/sha3))
 `
 
-exports['ReleaseNotes buildNotes should handle BREAKING CHANGE notes 1'] = `
+exports['DefaultChangelogNotes buildNotes should handle BREAKING CHANGE notes 1'] = `
 ### [1.2.3](https://github.com/googleapis/java-asset/compare/v1.2.2...v1.2.3) (1983-10-10)
 
 
@@ -52,7 +52,7 @@ exports['ReleaseNotes buildNotes should handle BREAKING CHANGE notes 1'] = `
 * some bugfix ([sha2](https://github.com/googleapis/java-asset/commit/sha2))
 `
 
-exports['ReleaseNotes buildNotes should ignore RELEASE AS notes 1'] = `
+exports['DefaultChangelogNotes buildNotes should ignore RELEASE AS notes 1'] = `
 ### [1.2.3](https://github.com/googleapis/java-asset/compare/v1.2.2...v1.2.3) (1983-10-10)
 
 
@@ -65,7 +65,7 @@ exports['ReleaseNotes buildNotes should ignore RELEASE AS notes 1'] = `
 * some bugfix ([sha2](https://github.com/googleapis/java-asset/commit/sha2))
 `
 
-exports['ReleaseNotes buildNotes with commit parsing handles Release-As footers 1'] = `
+exports['DefaultChangelogNotes buildNotes with commit parsing handles Release-As footers 1'] = `
 ### [1.2.3](https://github.com/googleapis/java-asset/compare/v1.2.2...v1.2.3) (1983-10-10)
 
 
@@ -78,7 +78,7 @@ exports['ReleaseNotes buildNotes with commit parsing handles Release-As footers 
 * correct release ([1f64add](https://github.com/googleapis/java-asset/commit/1f64add37f426e87ce1b777616a137ec))
 `
 
-exports['ReleaseNotes buildNotes with commit parsing should handle BREAKING CHANGE body 1'] = `
+exports['DefaultChangelogNotes buildNotes with commit parsing should handle BREAKING CHANGE body 1'] = `
 ### [1.2.3](https://github.com/googleapis/java-asset/compare/v1.2.2...v1.2.3) (1983-10-10)
 
 
@@ -91,7 +91,7 @@ exports['ReleaseNotes buildNotes with commit parsing should handle BREAKING CHAN
 * some feature ([78abf20](https://github.com/googleapis/java-asset/commit/78abf20625d3ff86d627b5c6e0cacd06))
 `
 
-exports['ReleaseNotes buildNotes with commit parsing should handle a breaking change 1'] = `
+exports['DefaultChangelogNotes buildNotes with commit parsing should handle a breaking change 1'] = `
 ### [1.2.3](https://github.com/googleapis/java-asset/compare/v1.2.2...v1.2.3) (1983-10-10)
 
 
@@ -104,7 +104,7 @@ exports['ReleaseNotes buildNotes with commit parsing should handle a breaking ch
 * some bugfix ([05670cf](https://github.com/googleapis/java-asset/commit/05670cf2e850beffe53bb2691f8701c7))
 `
 
-exports['ReleaseNotes buildNotes with commit parsing should handle bug links 1'] = `
+exports['DefaultChangelogNotes buildNotes with commit parsing should handle bug links 1'] = `
 ### [1.2.3](https://github.com/googleapis/java-asset/compare/v1.2.2...v1.2.3) (1983-10-10)
 
 
@@ -113,7 +113,7 @@ exports['ReleaseNotes buildNotes with commit parsing should handle bug links 1']
 * some fix ([71489e6](https://github.com/googleapis/java-asset/commit/71489e63ad212c54598f5bdcbedec5f6)), closes [#123](https://github.com/googleapis/java-asset/issues/123)
 `
 
-exports['ReleaseNotes buildNotes with commit parsing should handle git trailers 1'] = `
+exports['DefaultChangelogNotes buildNotes with commit parsing should handle git trailers 1'] = `
 ### [1.2.3](https://github.com/googleapis/java-asset/compare/v1.2.2...v1.2.3) (1983-10-10)
 
 
@@ -126,7 +126,7 @@ exports['ReleaseNotes buildNotes with commit parsing should handle git trailers 
 * some fix ([c538c97](https://github.com/googleapis/java-asset/commit/c538c973dc84b83ee6b699cf6433f0b3))
 `
 
-exports['ReleaseNotes buildNotes with commit parsing should handle meta commits 1'] = `
+exports['DefaultChangelogNotes buildNotes with commit parsing should handle meta commits 1'] = `
 ### [1.2.3](https://github.com/googleapis/java-asset/compare/v1.2.2...v1.2.3) (1983-10-10)
 
 
@@ -145,7 +145,7 @@ exports['ReleaseNotes buildNotes with commit parsing should handle meta commits 
 * **securitycenter:** fixes security center. ([3cf10aa](https://github.com/googleapis/java-asset/commit/3cf10aa5f94cd40a1d0d08e573eb737f))
 `
 
-exports['ReleaseNotes buildNotes with commit parsing should handle multi-line breaking change, if prefixed with list 1'] = `
+exports['DefaultChangelogNotes buildNotes with commit parsing should handle multi-line breaking change, if prefixed with list 1'] = `
 ### [1.2.3](https://github.com/googleapis/java-asset/compare/v1.2.2...v1.2.3) (1983-10-10)
 
 
@@ -160,7 +160,7 @@ exports['ReleaseNotes buildNotes with commit parsing should handle multi-line br
 * upgrade to Node 7 ([a931c2d](https://github.com/googleapis/java-asset/commit/a931c2d29e9849c6989dfd4712226699))
 `
 
-exports['ReleaseNotes buildNotes with commit parsing should handle multi-line breaking changes 1'] = `
+exports['DefaultChangelogNotes buildNotes with commit parsing should handle multi-line breaking changes 1'] = `
 ### [1.2.3](https://github.com/googleapis/java-asset/compare/v1.2.2...v1.2.3) (1983-10-10)
 
 
@@ -173,7 +173,7 @@ exports['ReleaseNotes buildNotes with commit parsing should handle multi-line br
 * upgrade to Node 7 ([8916be7](https://github.com/googleapis/java-asset/commit/8916be74596394c27516696b957fd0d7))
 `
 
-exports['ReleaseNotes buildNotes with commit parsing should not include content two newlines after BREAKING CHANGE 1'] = `
+exports['DefaultChangelogNotes buildNotes with commit parsing should not include content two newlines after BREAKING CHANGE 1'] = `
 ### [1.2.3](https://github.com/googleapis/java-asset/compare/v1.2.2...v1.2.3) (1983-10-10)
 
 
@@ -186,7 +186,7 @@ exports['ReleaseNotes buildNotes with commit parsing should not include content 
 * upgrade to Node 7 ([66925b0](https://github.com/googleapis/java-asset/commit/66925b06f59fc4fdd3031c498e1b0098))
 `
 
-exports['ReleaseNotes buildNotes with commit parsing should parse multiple commit messages from a single commit 1'] = `
+exports['DefaultChangelogNotes buildNotes with commit parsing should parse multiple commit messages from a single commit 1'] = `
 ### [1.2.3](https://github.com/googleapis/java-asset/compare/v1.2.2...v1.2.3) (1983-10-10)
 
 

--- a/src/bin/release-please.ts
+++ b/src/bin/release-please.ts
@@ -18,7 +18,7 @@ import {coerceOption} from '../util/coerce-option';
 import * as yargs from 'yargs';
 import {GitHub, GH_API_URL, GH_GRAPHQL_URL} from '../github';
 import {Manifest, ManifestOptions, ROOT_PROJECT_PATH} from '../manifest';
-import {ChangelogSection} from '../release-notes';
+import {ChangelogSection} from '../changelog-notes';
 import {logger, setLogger, CheckpointLogger} from '../util/logger';
 import {
   getReleaserTypes,

--- a/src/changelog-notes.ts
+++ b/src/changelog-notes.ts
@@ -1,0 +1,37 @@
+// Copyright 2021 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import {ConventionalCommit} from './commit';
+
+export interface BuildNotesOptions {
+  host?: string;
+  owner: string;
+  repository: string;
+  version: string;
+  previousTag?: string;
+  currentTag: string;
+}
+
+export interface ChangelogNotes {
+  buildNotes(
+    commits: ConventionalCommit[],
+    options: BuildNotesOptions
+  ): Promise<string>;
+}
+
+export interface ChangelogSection {
+  type: string;
+  section: string;
+  hidden?: boolean;
+}

--- a/src/changelog-notes/default.ts
+++ b/src/changelog-notes/default.ts
@@ -12,43 +12,34 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import {ConventionalCommit} from './commit';
+import {
+  ChangelogSection,
+  ChangelogNotes,
+  BuildNotesOptions,
+} from '../changelog-notes';
+import {ConventionalCommit} from '../commit';
 
 // eslint-disable-next-line @typescript-eslint/no-var-requires
 const conventionalChangelogWriter = require('conventional-changelog-writer');
 // eslint-disable-next-line @typescript-eslint/no-var-requires
 const presetFactory = require('conventional-changelog-conventionalcommits');
+const DEFAULT_HOST = 'https://github.com';
 
-export interface ChangelogSection {
-  type: string;
-  section: string;
-  hidden?: boolean;
-}
-
-interface ReleaseNotesOptions {
+interface DefaultChangelogNotesOptions {
   changelogSections?: ChangelogSection[];
   commitPartial?: string;
   headerPartial?: string;
   mainTemplate?: string;
 }
 
-interface BuildNotesOptions {
-  host?: string;
-  owner: string;
-  repository: string;
-  version: string;
-  previousTag?: string;
-  currentTag: string;
-}
-
-export class ReleaseNotes {
+export class DefaultChangelogNotes implements ChangelogNotes {
   // allow for customized commit template.
   private changelogSections?: ChangelogSection[];
   private commitPartial?: string;
   private headerPartial?: string;
   private mainTemplate?: string;
 
-  constructor(options: ReleaseNotesOptions = {}) {
+  constructor(options: DefaultChangelogNotesOptions = {}) {
     this.changelogSections = options.changelogSections;
     this.commitPartial = options.commitPartial;
     this.headerPartial = options.headerPartial;
@@ -60,7 +51,7 @@ export class ReleaseNotes {
     options: BuildNotesOptions
   ): Promise<string> {
     const context = {
-      host: options.host || 'https://github.com',
+      host: options.host || DEFAULT_HOST,
       owner: options.owner,
       repository: options.repository,
       version: options.version,

--- a/src/manifest.ts
+++ b/src/manifest.ts
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import {ChangelogSection} from './release-notes';
+import {ChangelogSection} from './changelog-notes';
 import {GitHub, GitHubRelease} from './github';
 import {Version, VersionsMap} from './version';
 import {Commit} from './commit';

--- a/test/changelog-notes/default-changelog-notes.ts
+++ b/test/changelog-notes/default-changelog-notes.ts
@@ -14,11 +14,15 @@
 
 import {describe, it} from 'mocha';
 import {expect} from 'chai';
-import {ReleaseNotes} from '../src/release-notes';
-import {buildCommitFromFixture, buildMockCommit, safeSnapshot} from './helpers';
-import {parseConventionalCommits} from '../src/commit';
+import {
+  buildCommitFromFixture,
+  buildMockCommit,
+  safeSnapshot,
+} from '../helpers';
+import {DefaultChangelogNotes} from '../../src/changelog-notes/default';
+import {parseConventionalCommits} from '../../src/commit';
 
-describe('ReleaseNotes', () => {
+describe('DefaultChangelogNotes', () => {
   const commits = [
     {
       sha: 'sha1',
@@ -63,20 +67,20 @@ describe('ReleaseNotes', () => {
       currentTag: 'v1.2.3',
     };
     it('should build default release notes', async () => {
-      const releaseNotes = new ReleaseNotes();
-      const notes = await releaseNotes.buildNotes(commits, notesOptions);
+      const changelogNotes = new DefaultChangelogNotes();
+      const notes = await changelogNotes.buildNotes(commits, notesOptions);
       expect(notes).to.is.string;
       safeSnapshot(notes);
     });
     it('should build with custom changelog sections', async () => {
-      const releaseNotes = new ReleaseNotes({
+      const changelogNotes = new DefaultChangelogNotes({
         changelogSections: [
           {type: 'feat', section: 'Features'},
           {type: 'fix', section: 'Bug Fixes'},
           {type: 'docs', section: 'Documentation'},
         ],
       });
-      const notes = await releaseNotes.buildNotes(commits, notesOptions);
+      const notes = await changelogNotes.buildNotes(commits, notesOptions);
       expect(notes).to.is.string;
       safeSnapshot(notes);
     });
@@ -94,8 +98,8 @@ describe('ReleaseNotes', () => {
           breaking: true,
         },
       ];
-      const releaseNotes = new ReleaseNotes();
-      const notes = await releaseNotes.buildNotes(commits, notesOptions);
+      const changelogNotes = new DefaultChangelogNotes();
+      const notes = await changelogNotes.buildNotes(commits, notesOptions);
       expect(notes).to.is.string;
       safeSnapshot(notes);
     });
@@ -113,16 +117,16 @@ describe('ReleaseNotes', () => {
           breaking: true,
         },
       ];
-      const releaseNotes = new ReleaseNotes();
-      const notes = await releaseNotes.buildNotes(commits, notesOptions);
+      const changelogNotes = new DefaultChangelogNotes();
+      const notes = await changelogNotes.buildNotes(commits, notesOptions);
       expect(notes).to.is.string;
       safeSnapshot(notes);
     });
     describe('with commit parsing', () => {
       it('should handle a breaking change', async () => {
         const commits = [buildMockCommit('fix!: some bugfix')];
-        const releaseNotes = new ReleaseNotes();
-        const notes = await releaseNotes.buildNotes(
+        const changelogNotes = new DefaultChangelogNotes();
+        const notes = await changelogNotes.buildNotes(
           parseConventionalCommits(commits),
           notesOptions
         );
@@ -131,8 +135,8 @@ describe('ReleaseNotes', () => {
       });
       it('should parse multiple commit messages from a single commit', async () => {
         const commits = [buildCommitFromFixture('multiple-messages')];
-        const releaseNotes = new ReleaseNotes();
-        const notes = await releaseNotes.buildNotes(
+        const changelogNotes = new DefaultChangelogNotes();
+        const notes = await changelogNotes.buildNotes(
           parseConventionalCommits(commits),
           notesOptions
         );
@@ -141,8 +145,8 @@ describe('ReleaseNotes', () => {
       });
       it('should handle BREAKING CHANGE body', async () => {
         const commits = [buildCommitFromFixture('breaking-body')];
-        const releaseNotes = new ReleaseNotes();
-        const notes = await releaseNotes.buildNotes(
+        const changelogNotes = new DefaultChangelogNotes();
+        const notes = await changelogNotes.buildNotes(
           parseConventionalCommits(commits),
           notesOptions
         );
@@ -151,8 +155,8 @@ describe('ReleaseNotes', () => {
       });
       it('should handle bug links', async () => {
         const commits = [buildCommitFromFixture('bug-link')];
-        const releaseNotes = new ReleaseNotes();
-        const notes = await releaseNotes.buildNotes(
+        const changelogNotes = new DefaultChangelogNotes();
+        const notes = await changelogNotes.buildNotes(
           parseConventionalCommits(commits),
           notesOptions
         );
@@ -161,8 +165,8 @@ describe('ReleaseNotes', () => {
       });
       it('should handle git trailers', async () => {
         const commits = [buildCommitFromFixture('git-trailers-with-breaking')];
-        const releaseNotes = new ReleaseNotes();
-        const notes = await releaseNotes.buildNotes(
+        const changelogNotes = new DefaultChangelogNotes();
+        const notes = await changelogNotes.buildNotes(
           parseConventionalCommits(commits),
           notesOptions
         );
@@ -171,8 +175,8 @@ describe('ReleaseNotes', () => {
       });
       it('should handle meta commits', async () => {
         const commits = [buildCommitFromFixture('meta')];
-        const releaseNotes = new ReleaseNotes();
-        const notes = await releaseNotes.buildNotes(
+        const changelogNotes = new DefaultChangelogNotes();
+        const notes = await changelogNotes.buildNotes(
           parseConventionalCommits(commits),
           notesOptions
         );
@@ -181,8 +185,8 @@ describe('ReleaseNotes', () => {
       });
       it('should handle multi-line breaking changes', async () => {
         const commits = [buildCommitFromFixture('multi-line-breaking-body')];
-        const releaseNotes = new ReleaseNotes();
-        const notes = await releaseNotes.buildNotes(
+        const changelogNotes = new DefaultChangelogNotes();
+        const notes = await changelogNotes.buildNotes(
           parseConventionalCommits(commits),
           notesOptions
         );
@@ -193,8 +197,8 @@ describe('ReleaseNotes', () => {
         const commits = [
           buildCommitFromFixture('multi-line-breaking-body-list'),
         ];
-        const releaseNotes = new ReleaseNotes();
-        const notes = await releaseNotes.buildNotes(
+        const changelogNotes = new DefaultChangelogNotes();
+        const notes = await changelogNotes.buildNotes(
           parseConventionalCommits(commits),
           notesOptions
         );
@@ -203,8 +207,8 @@ describe('ReleaseNotes', () => {
       });
       it('should not include content two newlines after BREAKING CHANGE', async () => {
         const commits = [buildCommitFromFixture('breaking-body-content-after')];
-        const releaseNotes = new ReleaseNotes();
-        const notes = await releaseNotes.buildNotes(
+        const changelogNotes = new DefaultChangelogNotes();
+        const notes = await changelogNotes.buildNotes(
           parseConventionalCommits(commits),
           notesOptions
         );
@@ -213,8 +217,8 @@ describe('ReleaseNotes', () => {
       });
       it('handles Release-As footers', async () => {
         const commits = [buildCommitFromFixture('release-as')];
-        const releaseNotes = new ReleaseNotes();
-        const notes = await releaseNotes.buildNotes(
+        const changelogNotes = new DefaultChangelogNotes();
+        const notes = await changelogNotes.buildNotes(
           parseConventionalCommits(commits),
           notesOptions
         );
@@ -223,8 +227,8 @@ describe('ReleaseNotes', () => {
       });
       // it('ignores reverted commits', async () => {
       //   const commits = [buildCommitFromFixture('multiple-messages')];
-      //   const releaseNotes = new ReleaseNotes();
-      //   const notes = await releaseNotes.buildNotes(parseConventionalCommits(commits), notesOptions);
+      //   const changelogNotes = new DefaultChangelogNotes();
+      //   const notes = await changelogNotes.buildNotes(parseConventionalCommits(commits), notesOptions);
       //   expect(notes).to.is.string;
       //   safeSnapshot(notes);
       // });


### PR DESCRIPTION
ReleaseNotes is renamed to ChangelogNotes and turned into an interface with a default implementation. You can now inject a custom ChangelogNotes implementation to customize the content added to the changelog (and pull request/release notes).

This is in preparation to support adding content to the release notes outside of the changelog contents as well as #1106