### PR TITLE
feat: return path along with created release

### DIFF
--- a/src/manifest.ts
+++ b/src/manifest.ts
@@ -692,7 +692,7 @@ export class Manifest {
    *
    * @returns {GitHubRelease[]} List of created GitHub releases
    */
-  async createReleases(): Promise<(GitHubRelease | undefined)[]> {
+  async createReleases(): Promise<(CreatedRelease | undefined)[]> {
     const releasesByPullRequest: Record<number, CandidateRelease[]> = {};
     const pullRequestsByNumber: Record<number, PullRequest> = {};
     for (const release of await this.buildReleases()) {
@@ -704,7 +704,7 @@ export class Manifest {
       }
     }
 
-    const promises: Promise<GitHubRelease[]>[] = [];
+    const promises: Promise<CreatedRelease[]>[] = [];
     for (const pullNumber in releasesByPullRequest) {
       promises.push(
         this.createReleasesForPullRequest(

--- a/test/cli.ts
+++ b/test/cli.ts
@@ -292,6 +292,7 @@ describe('CLI', () => {
             sha: 'abc123',
             notes: 'some release notes',
             url: 'url-of-release',
+            path: '.',
           },
         ]);
     });
@@ -926,6 +927,7 @@ describe('CLI', () => {
               sha: 'abc123',
               notes: 'some release notes',
               url: 'url-of-release',
+              path: '.',
             },
           ]);
       });
@@ -1076,6 +1078,7 @@ describe('CLI', () => {
               sha: 'abc123',
               notes: 'some release notes',
               url: 'url-of-release',
+              path: '.',
             },
           ]);
       });

--- a/test/cli.ts
+++ b/test/cli.ts
@@ -98,7 +98,17 @@ describe('CLI', () => {
         .resolves(fakeManifest);
       createPullRequestsStub = sandbox
         .stub(fakeManifest, 'createPullRequests')
-        .resolves([123]);
+        .resolves([
+          {
+            title: 'fake title',
+            body: 'fake body',
+            headBranchName: 'head-branch-name',
+            baseBranchName: 'base-branch-name',
+            number: 123,
+            files: [],
+            labels: [],
+          },
+        ]);
     });
     it('instantiates a basic Manifest', async () => {
       await await parser.parseAsync(
@@ -435,16 +445,26 @@ describe('CLI', () => {
   describe('release-pr', () => {
     describe('with manifest options', () => {
       let fromManifestStub: sinon.SinonStub;
+      let createPullRequestsStub: sinon.SinonStub;
       beforeEach(() => {
         fromManifestStub = sandbox
           .stub(Manifest, 'fromManifest')
           .resolves(fakeManifest);
+        createPullRequestsStub = sandbox
+          .stub(fakeManifest, 'createPullRequests')
+          .resolves([
+            {
+              title: 'fake title',
+              body: 'fake body',
+              headBranchName: 'head-branch-name',
+              baseBranchName: 'base-branch-name',
+              number: 123,
+              files: [],
+              labels: [],
+            },
+          ]);
       });
       it('instantiates a basic Manifest', async () => {
-        const createPullRequestsStub = sandbox
-          .stub(fakeManifest, 'createPullRequests')
-          .resolves([123]);
-
         await parser.parseAsync(
           'release-pr --repo-url=googleapis/release-please-cli'
         );
@@ -465,10 +485,6 @@ describe('CLI', () => {
         sinon.assert.calledOnce(createPullRequestsStub);
       });
       it('instantiates Manifest with custom config/manifest', async () => {
-        const createPullRequestsStub = sandbox
-          .stub(fakeManifest, 'createPullRequests')
-          .resolves([123]);
-
         await parser.parseAsync(
           'release-pr --repo-url=googleapis/release-please-cli --config-file=foo.json --manifest-file=.bar.json'
         );
@@ -490,10 +506,6 @@ describe('CLI', () => {
       });
       for (const flag of ['--target-branch', '--default-branch']) {
         it(`handles ${flag}`, async () => {
-          const createPullRequestsStub = sandbox
-            .stub(fakeManifest, 'createPullRequests')
-            .resolves([123]);
-
           await parser.parseAsync(
             `release-pr --repo-url=googleapis/release-please-cli ${flag}=1.x`
           );
@@ -548,7 +560,17 @@ describe('CLI', () => {
           .resolves(fakeManifest);
         createPullRequestsStub = sandbox
           .stub(fakeManifest, 'createPullRequests')
-          .resolves([123]);
+          .resolves([
+            {
+              title: 'fake title',
+              body: 'fake body',
+              headBranchName: 'head-branch-name',
+              baseBranchName: 'base-branch-name',
+              number: 123,
+              files: [],
+              labels: [],
+            },
+          ]);
       });
       it('instantiates a basic Manifest', async () => {
         await parser.parseAsync(

--- a/test/manifest.ts
+++ b/test/manifest.ts
@@ -1533,6 +1533,7 @@ describe('Manifest', () => {
       expect(releases[0].notes)
         .to.be.a('string')
         .and.satisfy((msg: string) => msg.startsWith('### Bug Fixes'));
+      expect(releases[0].path).to.eql('.');
     });
 
     it('should handle a multiple manifest release', async () => {
@@ -1617,21 +1618,25 @@ describe('Manifest', () => {
       expect(releases[0].notes)
         .to.be.a('string')
         .and.satisfy((msg: string) => msg.startsWith('### Features'));
+      expect(releases[0].path).to.eql('packages/bot-config-utils');
       expect(releases[1].tag.toString()).to.eql('label-utils-v1.1.0');
       expect(releases[1].sha).to.eql('abc123');
       expect(releases[1].notes)
         .to.be.a('string')
         .and.satisfy((msg: string) => msg.startsWith('### Features'));
+      expect(releases[1].path).to.eql('packages/label-utils');
       expect(releases[2].tag.toString()).to.eql('object-selector-v1.1.0');
       expect(releases[2].sha).to.eql('abc123');
       expect(releases[2].notes)
         .to.be.a('string')
         .and.satisfy((msg: string) => msg.startsWith('### Features'));
+      expect(releases[2].path).to.eql('packages/object-selector');
       expect(releases[3].tag.toString()).to.eql('datastore-lock-v2.1.0');
       expect(releases[3].sha).to.eql('abc123');
       expect(releases[3].notes)
         .to.be.a('string')
         .and.satisfy((msg: string) => msg.startsWith('### Features'));
+      expect(releases[3].path).to.eql('packages/datastore-lock');
     });
 
     it('should handle a single standalone release', async () => {
@@ -1670,6 +1675,7 @@ describe('Manifest', () => {
       expect(releases[0].notes)
         .to.be.a('string')
         .and.satisfy((msg: string) => msg.startsWith('### [3.2.7]'));
+      expect(releases[0].path).to.eql('.');
     });
 
     it('should allow skipping releases', async () => {
@@ -1916,6 +1922,7 @@ describe('Manifest', () => {
       expect(releases[0]!.tagName).to.eql('release-brancher-v1.3.1');
       expect(releases[0]!.sha).to.eql('abc123');
       expect(releases[0]!.notes).to.eql('some release notes');
+      expect(releases[0]!.path).to.eql('.');
       sinon.assert.calledOnce(commentStub);
       sinon.assert.calledOnceWithExactly(
         addLabelsStub,
@@ -2020,15 +2027,19 @@ describe('Manifest', () => {
       expect(releases[0]!.tagName).to.eql('bot-config-utils-v3.2.0');
       expect(releases[0]!.sha).to.eql('abc123');
       expect(releases[0]!.notes).to.be.string;
+      expect(releases[0]!.path).to.eql('packages/bot-config-utils');
       expect(releases[1]!.tagName).to.eql('label-utils-v1.1.0');
       expect(releases[1]!.sha).to.eql('abc123');
       expect(releases[1]!.notes).to.be.string;
+      expect(releases[1]!.path).to.eql('packages/label-utils');
       expect(releases[2]!.tagName).to.eql('object-selector-v1.1.0');
       expect(releases[2]!.sha).to.eql('abc123');
       expect(releases[2]!.notes).to.be.string;
+      expect(releases[2]!.path).to.eql('packages/object-selector');
       expect(releases[3]!.tagName).to.eql('datastore-lock-v2.1.0');
       expect(releases[3]!.sha).to.eql('abc123');
       expect(releases[3]!.notes).to.be.string;
+      expect(releases[3]!.path).to.eql('packages/datastore-lock');
       sinon.assert.callCount(commentStub, 4);
       sinon.assert.calledOnceWithExactly(
         addLabelsStub,
@@ -2081,6 +2092,7 @@ describe('Manifest', () => {
       expect(releases[0]!.tagName).to.eql('v3.2.7');
       expect(releases[0]!.sha).to.eql('abc123');
       expect(releases[0]!.notes).to.be.string;
+      expect(releases[0]!.path).to.eql('.');
       sinon.assert.calledOnce(commentStub);
       sinon.assert.calledOnceWithExactly(
         addLabelsStub,

--- a/test/manifest.ts
+++ b/test/manifest.ts
@@ -1023,8 +1023,8 @@ describe('Manifest', () => {
         }
       );
       sandbox.stub(manifest, 'buildPullRequests').resolves([]);
-      const pullRequestNumbers = await manifest.createPullRequests();
-      expect(pullRequestNumbers).to.be.empty;
+      const pullRequests = await manifest.createPullRequests();
+      expect(pullRequests).to.be.empty;
     });
 
     it('handles a single pull request', async function () {
@@ -1085,8 +1085,8 @@ describe('Manifest', () => {
           draft: false,
         },
       ]);
-      const pullRequestNumbers = await manifest.createPullRequests();
-      expect(pullRequestNumbers).lengthOf(1);
+      const pullRequests = await manifest.createPullRequests();
+      expect(pullRequests).lengthOf(1);
     });
 
     it('handles a multiple pull requests', async () => {
@@ -1207,8 +1207,10 @@ describe('Manifest', () => {
           draft: false,
         },
       ]);
-      const pullRequestNumbers = await manifest.createPullRequests();
-      expect(pullRequestNumbers).to.eql([123, 124]);
+      const pullRequests = await manifest.createPullRequests();
+      expect(pullRequests.map(pullRequest => pullRequest!.number)).to.eql([
+        123, 124,
+      ]);
     });
 
     it('handles signoff users', async function () {


### PR DESCRIPTION
fix: return created pull request rather than just the pull request number

This returns the path of the component releases along with the release tag information when building/creating a GitHub release.