### PR TITLE
fix: add back version/major/minor/patch

### DIFF
--- a/src/manifest.ts
+++ b/src/manifest.ts
@@ -143,6 +143,10 @@ export const MANIFEST_PULL_REQUEST_TITLE_PATTERN = 'chore: release ${branch}';
 
 interface CreatedRelease extends GitHubRelease {
   path: string;
+  version: string;
+  major: number;
+  minor: number;
+  patch: number;
 }
 
 export class Manifest {
@@ -751,6 +755,10 @@ export class Manifest {
     return {
       ...githubRelease,
       path: release.path,
+      version: release.tag.version.toString(),
+      major: release.tag.version.major,
+      minor: release.tag.version.minor,
+      patch: release.tag.version.patch,
     };
   }
 

--- a/test/cli.ts
+++ b/test/cli.ts
@@ -293,6 +293,10 @@ describe('CLI', () => {
             notes: 'some release notes',
             url: 'url-of-release',
             path: '.',
+            version: 'v1.2.3',
+            major: 1,
+            minor: 2,
+            patch: 3,
           },
         ]);
     });
@@ -928,6 +932,10 @@ describe('CLI', () => {
               notes: 'some release notes',
               url: 'url-of-release',
               path: '.',
+              version: 'v1.2.3',
+              major: 1,
+              minor: 2,
+              patch: 3,
             },
           ]);
       });
@@ -1079,6 +1087,10 @@ describe('CLI', () => {
               notes: 'some release notes',
               url: 'url-of-release',
               path: '.',
+              version: 'v1.2.3',
+              major: 1,
+              minor: 2,
+              patch: 3,
             },
           ]);
       });


### PR DESCRIPTION
Adds back outputting version, along with `major`/`minor`/`patch`, these outputs are used during GitHub action releases to tag both the version itself, along with a moving `v1`, `v1.2` tag.
