### PR TITLE
feat: add `includeComponentInTag` option for strategies and hook up to `--monorepo-tags`

### DIFF
--- a/__snapshots__/cli.js
+++ b/__snapshots__/cli.js
@@ -21,6 +21,8 @@ Options:
                                                                         [string]
   --repo-url        GitHub URL to generate release for                [required]
   --dry-run         Prepare but do not take action    [boolean] [default: false]
+  --monorepo-tags   include library name in tags and release branches
+                                                      [boolean] [default: false]
   --path            release from path other than root directory         [string]
   --component       name of component release is being minted for       [string]
   --package-name    name of package release is being minted for         [string]
@@ -151,8 +153,6 @@ Options:
                                     the minor for non-breaking changes prior to
                                     the first major release
                                                       [boolean] [default: false]
-  --monorepo-tags                   include library name in tags and release
-                                    branches          [boolean] [default: false]
   --extra-files                     extra files for the strategy to consider
                                                                         [string]
   --version-file                    path to version file to update, e.g.,
@@ -182,6 +182,8 @@ Options:
                                     commit log message using the user and email
                                     provided. (format "Name
                                     <email@example.com>").              [string]
+  --monorepo-tags                   include library name in tags and release
+                                    branches          [boolean] [default: false]
   --path                            release from path other than root directory
                                                                         [string]
   --component                       name of component release is being minted

--- a/src/factory.ts
+++ b/src/factory.ts
@@ -111,7 +111,7 @@ export async function buildStrategy(
     bumpMinorPreMajor: options.bumpMinorPreMajor,
     bumpPatchForMinorPreMajor: options.bumpPatchForMinorPreMajor,
   });
-  const strategyOptions = {
+  const strategyOptions: StrategyOptions = {
     github: options.github,
     targetBranch,
     path: options.path,
@@ -124,6 +124,7 @@ export async function buildStrategy(
     versioningStrategy,
     skipGitHubRelease: options.skipGithubRelease,
     releaseAs: options.releaseAs,
+    includeComponentInTag: options.includeComponentInTag,
   };
   switch (options.releaseType) {
     case 'ruby': {

--- a/src/manifest.ts
+++ b/src/manifest.ts
@@ -56,6 +56,7 @@ export interface ReleaserConfig {
   draftPullRequest?: boolean;
   component?: string;
   packageName?: string;
+  includeComponentInTag?: boolean;
 
   // Ruby-only
   versionFile?: string;
@@ -86,6 +87,7 @@ interface ReleaserConfigJson {
   'draft-pull-request'?: boolean;
   label?: string;
   'release-label'?: string;
+  'include-component-in-tag'?: boolean;
 
   // Ruby-only
   'version-file'?: string;
@@ -823,6 +825,7 @@ function extractReleaserConfig(config: ReleaserPackageConfig): ReleaserConfig {
     packageName: config['package-name'],
     versionFile: config['version-file'],
     extraFiles: config['extra-files'],
+    includeComponentInTag: config['include-component-in-tag'],
   };
 }
 

--- a/src/strategy.ts
+++ b/src/strategy.ts
@@ -200,7 +200,11 @@ export abstract class Strategy {
     const component = await this.getComponent();
     logger.debug('component:', component);
 
-    const newVersionTag = new TagName(newVersion, component);
+    const newVersionTag = new TagName(
+      newVersion,
+      this.includeComponentInTag ? component : undefined,
+      this.tagSeparator
+    );
     const pullRequestTitle = PullRequestTitle.ofComponentTargetBranchVersion(
       component || '',
       this.targetBranch,

--- a/src/strategy.ts
+++ b/src/strategy.ts
@@ -60,6 +60,7 @@ export interface StrategyOptions {
   skipGitHubRelease?: boolean;
   releaseAs?: string;
   changelogNotes?: ChangelogNotes;
+  includeComponentInTag?: boolean;
 }
 
 /**
@@ -78,6 +79,7 @@ export abstract class Strategy {
   protected tagSeparator?: string;
   private skipGitHubRelease: boolean;
   private releaseAs?: string;
+  private includeComponentInTag: boolean;
 
   protected changelogNotes: ChangelogNotes;
 
@@ -101,6 +103,7 @@ export abstract class Strategy {
     this.releaseAs = options.releaseAs;
     this.changelogNotes =
       options.changelogNotes || new DefaultChangelogNotes(options);
+    this.includeComponentInTag = options.includeComponentInTag ?? true;
   }
 
   /**
@@ -327,8 +330,13 @@ export abstract class Strategy {
       throw new Error('Pull request should have included version');
     }
 
+    const tag = new TagName(
+      version,
+      this.includeComponentInTag ? component : undefined,
+      this.tagSeparator
+    );
     return {
-      tag: new TagName(version, component, this.tagSeparator),
+      tag,
       notes: notes || '',
       sha: mergedPullRequest.sha,
     };

--- a/test/cli.ts
+++ b/test/cli.ts
@@ -913,6 +913,27 @@ describe('CLI', () => {
         );
         sinon.assert.calledOnce(createPullRequestsStub);
       });
+
+      it('handles --monorepo-tags', async () => {
+        await parser.parseAsync(
+          'release-pr --repo-url=googleapis/release-please-cli --release-type=java-yoshi --monorepo-tags'
+        );
+
+        sinon.assert.calledOnceWithExactly(gitHubCreateStub, {
+          owner: 'googleapis',
+          repo: 'release-please-cli',
+          token: undefined,
+        });
+        sinon.assert.calledOnceWithExactly(
+          fromConfigStub,
+          fakeGitHub,
+          'main',
+          sinon.match({releaseType: 'java-yoshi', includeComponentInTag: true}),
+          sinon.match.any,
+          undefined
+        );
+        sinon.assert.calledOnce(createPullRequestsStub);
+      });
     });
   });
   describe('github-release', () => {
@@ -1237,6 +1258,27 @@ describe('CLI', () => {
           fakeGitHub,
           'main',
           sinon.match({releaseType: 'java-yoshi', packageName: '@foo/bar'}),
+          sinon.match.any,
+          undefined
+        );
+        sinon.assert.calledOnce(createReleasesStub);
+      });
+
+      it('handles --monorepo-tags', async () => {
+        await parser.parseAsync(
+          'github-release --repo-url=googleapis/release-please-cli --release-type=java-yoshi --monorepo-tags'
+        );
+
+        sinon.assert.calledOnceWithExactly(gitHubCreateStub, {
+          owner: 'googleapis',
+          repo: 'release-please-cli',
+          token: undefined,
+        });
+        sinon.assert.calledOnceWithExactly(
+          fromConfigStub,
+          fakeGitHub,
+          'main',
+          sinon.match({releaseType: 'java-yoshi', includeComponentInTag: true}),
           sinon.match.any,
           undefined
         );

--- a/test/manifest.ts
+++ b/test/manifest.ts
@@ -1866,6 +1866,52 @@ describe('Manifest', () => {
       expect(releases).lengthOf(1);
       expect(releases[0].draft).to.be.true;
     });
+
+    it('should skip component in tag', async () => {
+      mockPullRequests(
+        github,
+        [],
+        [
+          {
+            headBranchName: 'release-please/branches/main',
+            baseBranchName: 'main',
+            number: 1234,
+            title: 'chore: release main',
+            body: pullRequestBody('release-notes/single-manifest.txt'),
+            labels: ['autorelease: pending'],
+            files: [],
+            sha: 'abc123',
+          },
+        ]
+      );
+      const getFileContentsStub = sandbox.stub(
+        github,
+        'getFileContentsOnBranch'
+      );
+      getFileContentsStub
+        .withArgs('package.json', 'main')
+        .resolves(
+          buildGitHubFileRaw(
+            JSON.stringify({name: '@google-cloud/release-brancher'})
+          )
+        );
+      const manifest = new Manifest(
+        github,
+        'main',
+        {
+          '.': {
+            releaseType: 'node',
+            includeComponentInTag: false,
+          },
+        },
+        {
+          '.': Version.parse('1.3.0'),
+        }
+      );
+      const releases = await manifest.buildReleases();
+      expect(releases).lengthOf(1);
+      expect(releases[0].tag.toString()).to.eql('v1.3.1');
+    });
   });
 
   describe('createReleases', () => {

--- a/test/strategies/base.ts
+++ b/test/strategies/base.ts
@@ -50,6 +50,27 @@ describe('Strategy', () => {
       const pullRequest = await strategy.buildReleasePullRequest([]);
       expect(pullRequest).to.be.undefined;
     });
+  });
+  describe('buildRelease', () => {
+    it('builds a release tag', async () => {
+      const strategy = new TestStrategy({
+        targetBranch: 'main',
+        github,
+        component: 'google-cloud-automl',
+      });
+      const release = await strategy.buildRelease({
+        title: 'chore(main): release v1.2.3',
+        headBranchName: 'release-please/branches/main',
+        baseBranchName: 'main',
+        number: 1234,
+        body: new PullRequestBody([]).toString(),
+        labels: [],
+        files: [],
+        sha: 'abc123',
+      });
+      expect(release, 'Release').to.not.be.undefined;
+      expect(release!.tag.toString()).to.eql('google-cloud-automl-v1.2.3');
+    });
     it('overrides the tag separator', async () => {
       const strategy = new TestStrategy({
         targetBranch: 'main',
@@ -68,7 +89,27 @@ describe('Strategy', () => {
         sha: 'abc123',
       });
       expect(release, 'Release').to.not.be.undefined;
-      expect(release!.tag.separator).to.eql('/');
+      expect(release!.tag.toString()).to.eql('google-cloud-automl/v1.2.3');
+    });
+    it('skips component in release tag', async () => {
+      const strategy = new TestStrategy({
+        targetBranch: 'main',
+        github,
+        component: 'google-cloud-automl',
+        includeComponentInTag: false,
+      });
+      const release = await strategy.buildRelease({
+        title: 'chore(main): release v1.2.3',
+        headBranchName: 'release-please/branches/main',
+        baseBranchName: 'main',
+        number: 1234,
+        body: new PullRequestBody([]).toString(),
+        labels: [],
+        files: [],
+        sha: 'abc123',
+      });
+      expect(release, 'Release').to.not.be.undefined;
+      expect(release!.tag.toString()).to.eql('v1.2.3');
     });
   });
 });


### PR DESCRIPTION
`--monorepo-tags` option was available to `release-pr` and `github-release` CL commands. It forced adding the component to the release tag (like `component-v1.2.3` vs `v1.2.3`). Manifest commands always set this option by default.

Fixes #1116 
