### PR TITLE
feat: reimplement custom pull request title

### DIFF
--- a/__snapshots__/cli.js
+++ b/__snapshots__/cli.js
@@ -4,44 +4,54 @@ release-please github-release
 create a GitHub release from a release PR
 
 Options:
-  --help            Show help                                          [boolean]
-  --version         Show version number                                [boolean]
-  --debug           print verbose errors (use only for local debugging).
-                                                      [boolean] [default: false]
-  --trace           print extra verbose errors (use only for local debugging).
-                                                      [boolean] [default: false]
-  --token           GitHub token with repo write permissions
-  --api-url         URL to use when making API requests
+  --help                        Show help                              [boolean]
+  --version                     Show version number                    [boolean]
+  --debug                       print verbose errors (use only for local
+                                debugging).           [boolean] [default: false]
+  --trace                       print extra verbose errors (use only for local
+                                debugging).           [boolean] [default: false]
+  --token                       GitHub token with repo write permissions
+  --api-url                     URL to use when making API requests
                                     [string] [default: "https://api.github.com"]
-  --graphql-url     URL to use when making GraphQL requests
+  --graphql-url                 URL to use when making GraphQL requests
                                     [string] [default: "https://api.github.com"]
-  --default-branch  The branch to open release PRs against and tag releases on
+  --default-branch              The branch to open release PRs against and tag
+                                releases on
                               [deprecated: use --target-branch instead] [string]
-  --target-branch   The branch to open release PRs against and tag releases on
-                                                                        [string]
-  --repo-url        GitHub URL to generate release for                [required]
-  --dry-run         Prepare but do not take action    [boolean] [default: false]
-  --monorepo-tags   include library name in tags and release branches
+  --target-branch               The branch to open release PRs against and tag
+                                releases on                             [string]
+  --repo-url                    GitHub URL to generate release for    [required]
+  --dry-run                     Prepare but do not take action
                                                       [boolean] [default: false]
-  --path            release from path other than root directory         [string]
-  --component       name of component release is being minted for       [string]
-  --package-name    name of package release is being minted for         [string]
-  --release-type    what type of repo is a release being created for?
+  --monorepo-tags               include library name in tags and release
+                                branches              [boolean] [default: false]
+  --pull-request-title-pattern  Title pattern to make release PR        [string]
+  --path                        release from path other than root directory
+                                                                        [string]
+  --component                   name of component release is being minted for
+                                                                        [string]
+  --package-name                name of package release is being minted for
+                                                                        [string]
+  --release-type                what type of repo is a release being created
+                                for?
           [choices: "dart", "elixir", "go", "go-yoshi", "helm", "java-backport",
   "java-bom", "java-lts", "java-yoshi", "krm-blueprint", "node", "ocaml", "php",
                   "php-yoshi", "python", "ruby", "ruby-yoshi", "rust", "simple",
                                                              "terraform-module"]
-  --config-file     where can the config file be found in the project?
-                                         [default: "release-please-config.json"]
-  --manifest-file   where can the manifest file be found in the project?
+  --config-file                 where can the config file be found in the
+                                project? [default: "release-please-config.json"]
+  --manifest-file               where can the manifest file be found in the
+                                project?
                                       [default: ".release-please-manifest.json"]
-  --draft           mark release as a draft. no tag is created but tag_name and
-                    target_commitish are associated with the release for future
-                    tag creation upon "un-drafting" the release.
+  --draft                       mark release as a draft. no tag is created but
+                                tag_name and target_commitish are associated
+                                with the release for future tag creation upon
+                                "un-drafting" the release.
                                                       [boolean] [default: false]
-  --label           comma-separated list of labels to remove to from release PR
-                                               [default: "autorelease: pending"]
-  --release-label   set a pull request label other than "autorelease: tagged"
+  --label                       comma-separated list of labels to remove to from
+                                release PR     [default: "autorelease: pending"]
+  --release-label               set a pull request label other than
+                                "autorelease: tagged"
                                        [string] [default: "autorelease: tagged"]
 `
 
@@ -161,7 +171,6 @@ Options:
                                     generated?        [boolean] [default: false]
   --versioning-strategy             strategy used for bumping versions
   [choices: "default", "always-bump-patch", "service-pack"] [default: "default"]
-  --pull-request-title-pattern      Title pattern to make release PR    [string]
   --changelog-path                  where can the CHANGELOG be found in the
                                     project?  [string] [default: "CHANGELOG.md"]
   --last-package-version            last version # that package was released as
@@ -184,6 +193,7 @@ Options:
                                     <email@example.com>").              [string]
   --monorepo-tags                   include library name in tags and release
                                     branches          [boolean] [default: false]
+  --pull-request-title-pattern      Title pattern to make release PR    [string]
   --path                            release from path other than root directory
                                                                         [string]
   --component                       name of component release is being minted

--- a/src/bin/release-please.ts
+++ b/src/bin/release-please.ts
@@ -98,12 +98,12 @@ interface PullRequestStrategyArgs {
   // for Ruby: TODO refactor to find version.rb like Python finds version.py
   // and then remove this property
   versionFile?: string;
-  pullRequestTitlePattern?: string;
   extraFiles?: string[];
 }
 
 interface TaggingArgs {
   monorepoTags?: boolean;
+  pullRequestTitlePattern?: string;
 }
 
 interface CreatePullRequestArgs
@@ -268,10 +268,6 @@ function pullRequestStrategyOptions(yargs: yargs.Argv): yargs.Argv {
       choices: getVersioningStrategyTypes(),
       default: 'default',
     })
-    .option('pull-request-title-pattern', {
-      describe: 'Title pattern to make release PR',
-      type: 'string',
-    })
     .option('changelog-path', {
       default: 'CHANGELOG.md',
       describe: 'where can the CHANGELOG be found in the project?',
@@ -351,11 +347,16 @@ function manifestOptions(yargs: yargs.Argv): yargs.Argv {
 }
 
 function taggingOptions(yargs: yargs.Argv): yargs.Argv {
-  return yargs.option('monorepo-tags', {
-    describe: 'include library name in tags and release branches',
-    type: 'boolean',
-    default: false,
-  });
+  return yargs
+    .option('monorepo-tags', {
+      describe: 'include library name in tags and release branches',
+      type: 'boolean',
+      default: false,
+    })
+    .option('pull-request-title-pattern', {
+      describe: 'Title pattern to make release PR',
+      type: 'string',
+    });
 }
 
 const createReleasePullRequestCommand: yargs.CommandModule<

--- a/src/factory.ts
+++ b/src/factory.ts
@@ -125,6 +125,7 @@ export async function buildStrategy(
     skipGitHubRelease: options.skipGithubRelease,
     releaseAs: options.releaseAs,
     includeComponentInTag: options.includeComponentInTag,
+    pullRequestTitlePattern: options.pullRequestTitlePattern,
   };
   switch (options.releaseType) {
     case 'ruby': {

--- a/src/manifest.ts
+++ b/src/manifest.ts
@@ -57,6 +57,7 @@ export interface ReleaserConfig {
   component?: string;
   packageName?: string;
   includeComponentInTag?: boolean;
+  pullRequestTitlePattern?: string;
 
   // Ruby-only
   versionFile?: string;
@@ -88,6 +89,7 @@ interface ReleaserConfigJson {
   label?: string;
   'release-label'?: string;
   'include-component-in-tag'?: boolean;
+  'pull-request-title-pattern'?: string;
 
   // Ruby-only
   'version-file'?: string;
@@ -298,7 +300,8 @@ export class Manifest {
     const latestVersion = await latestReleaseVersion(
       github,
       targetBranch,
-      component
+      component,
+      config.pullRequestTitlePattern
     );
     if (latestVersion) {
       releasedVersions[path] = latestVersion;
@@ -826,6 +829,7 @@ function extractReleaserConfig(config: ReleaserPackageConfig): ReleaserConfig {
     versionFile: config['version-file'],
     extraFiles: config['extra-files'],
     includeComponentInTag: config['include-component-in-tag'],
+    pullRequestTitlePattern: config['pull-request-title-pattern'],
   };
 }
 
@@ -895,7 +899,8 @@ async function parseReleasedVersions(
 async function latestReleaseVersion(
   github: GitHub,
   targetBranch: string,
-  prefix?: string
+  prefix?: string,
+  pullRequestTitlePattern?: string
 ): Promise<Version | undefined> {
   const branchPrefix = prefix
     ? prefix.endsWith('-')
@@ -928,7 +933,10 @@ async function latestReleaseVersion(
       continue;
     }
 
-    const pullRequestTitle = PullRequestTitle.parse(mergedPullRequest.title);
+    const pullRequestTitle = PullRequestTitle.parse(
+      mergedPullRequest.title,
+      pullRequestTitlePattern
+    );
     if (!pullRequestTitle) {
       continue;
     }


### PR DESCRIPTION
Can customize the release pull request title with `pull-request-title-pattern` in the releaser config or via the `--pull-request-title-pattern=<pattern>` in the CLI.

Fixes #1115 
