### PR TITLE
fix: switch branch delimiter to `--`

### DIFF
--- a/test/manifest.ts
+++ b/test/manifest.ts
@@ -322,6 +322,9 @@ describe('Manifest', () => {
         assertHasUpdate(pullRequest.updates, 'CHANGELOG.md');
         assertHasUpdate(pullRequest.updates, 'version.txt');
         assertHasUpdate(pullRequest.updates, '.release-please-manifest.json');
+        expect(pullRequest.headRefName).to.eql(
+          'release-please--branches--main'
+        );
       });
 
       it('should create a draft pull request', async () => {
@@ -467,6 +470,9 @@ describe('Manifest', () => {
       expect(pullRequests).lengthOf(1);
       const pullRequest = pullRequests[0];
       expect(pullRequest.version?.toString()).to.eql('1.0.1');
+      expect(pullRequest.headRefName).to.eql(
+        'release-please--branches--main--components--pkg1'
+      );
     });
 
     it('should handle multiple package repository', async () => {

--- a/test/util/branch-name.ts
+++ b/test/util/branch-name.ts
@@ -39,8 +39,30 @@ describe('BranchName', () => {
         expect(branchName?.toString()).to.eql(name);
       });
     });
+    describe('v12 format', () => {
+      it('parses a target branch', () => {
+        const name = 'release-please/branches/main';
+        const branchName = BranchName.parse(name);
+        expect(branchName).to.not.be.undefined;
+        expect(branchName?.getTargetBranch()).to.eql('main');
+        expect(branchName?.getComponent()).to.be.undefined;
+        expect(branchName?.getVersion()).to.be.undefined;
+        expect(branchName?.toString()).to.eql(name);
+      });
+
+      it('parses a target branch and component', () => {
+        const name = 'release-please/branches/main/components/storage';
+        const branchName = BranchName.parse(name);
+        expect(branchName).to.not.be.undefined;
+        expect(branchName?.getTargetBranch()).to.eql('main');
+        expect(branchName?.getComponent()).to.eql('storage');
+        expect(branchName?.getVersion()).to.be.undefined;
+        expect(branchName?.toString()).to.eql(name);
+      });
+    });
+
     it('parses a target branch', () => {
-      const name = 'release-please/branches/main';
+      const name = 'release-please--branches--main';
       const branchName = BranchName.parse(name);
       expect(branchName).to.not.be.undefined;
       expect(branchName?.getTargetBranch()).to.eql('main');
@@ -50,7 +72,7 @@ describe('BranchName', () => {
     });
 
     it('parses a target branch and component', () => {
-      const name = 'release-please/branches/main/components/storage';
+      const name = 'release-please--branches--main--components--storage';
       const branchName = BranchName.parse(name);
       expect(branchName).to.not.be.undefined;
       expect(branchName?.getTargetBranch()).to.eql('main');
@@ -82,14 +104,14 @@ describe('BranchName', () => {
   describe('ofTargetBranch', () => {
     it('builds branchname with only target branch', () => {
       const branchName = BranchName.ofTargetBranch('main');
-      expect(branchName.toString()).to.eql('release-please/branches/main');
+      expect(branchName.toString()).to.eql('release-please--branches--main');
     });
   });
   describe('ofComponentTargetBranch', () => {
     it('builds branchname with target branch and component', () => {
       const branchName = BranchName.ofComponentTargetBranch('foo', 'main');
       expect(branchName.toString()).to.eql(
-        'release-please/branches/main/components/foo'
+        'release-please--branches--main--components--foo'
       );
     });
   });


### PR DESCRIPTION
With slashes in the branch name, we can get weird behavior. If a branch already exists named `release-please`, we cannot create any branches that are prefixed with `release-please/` due to git's storage mechanism.

To go along with this, we should re-implement the closing of other release PRs that match component/target branch that do not adhere to the correct branch name.

Fixes #1024 
Fixes #1125 
