### PR TITLE
fix: merge manifest release PRs unless separatePullRequests is configured

### DIFF
--- a/src/manifest.ts
+++ b/src/manifest.ts
@@ -217,7 +217,9 @@ export class Manifest {
     this.releasedVersions = releasedVersions;
     this.manifestPath =
       manifestOptions?.manifestPath || DEFAULT_RELEASE_PLEASE_MANIFEST;
-    this.separatePullRequests = manifestOptions?.separatePullRequests || false;
+    this.separatePullRequests =
+      manifestOptions?.separatePullRequests ??
+      Object.keys(repositoryConfig).length === 1;
     this.plugins = manifestOptions?.plugins || [];
     this.fork = manifestOptions?.fork || false;
     this.signoffUser = manifestOptions?.signoff;
@@ -316,7 +318,10 @@ export class Manifest {
       targetBranch,
       repositoryConfig,
       releasedVersions,
-      manifestOptions
+      {
+        separatePullRequests: true,
+        ...manifestOptions,
+      }
     );
   }
 

--- a/src/plugins/merge.ts
+++ b/src/plugins/merge.ts
@@ -34,7 +34,7 @@ export class Merge extends ManifestPlugin {
   async run(
     candidates: CandidateReleasePullRequest[]
   ): Promise<CandidateReleasePullRequest[]> {
-    if (candidates.length < 2) {
+    if (candidates.length < 1) {
       return candidates;
     }
 

--- a/src/util/pull-request-title.ts
+++ b/src/util/pull-request-title.ts
@@ -151,6 +151,7 @@ export class PullRequestTitle {
       .replace('${scope}', scope)
       .replace('${component}', component)
       .replace('${version}', version.toString())
+      .replace('${branch}', this.targetBranch || '')
       .trim();
   }
 }

--- a/test/manifest.ts
+++ b/test/manifest.ts
@@ -1010,7 +1010,9 @@ describe('Manifest', () => {
       const manifest = await Manifest.fromManifest(github, 'main');
       const pullRequests = await manifest.buildPullRequests();
       expect(pullRequests).lengthOf(1);
-      expect(pullRequests[0].version?.toString()).to.eql('1.2.4');
+      expect(pullRequests[0].body.releaseData).lengthOf(1);
+      expect(pullRequests[0].body.releaseData[0].component).to.eql('pkg1');
+      expect(pullRequests[0].body.releaseData[0].version?.toString()).to.eql('1.2.4');
     });
 
     describe('with plugins', () => {

--- a/test/manifest.ts
+++ b/test/manifest.ts
@@ -1012,7 +1012,9 @@ describe('Manifest', () => {
       expect(pullRequests).lengthOf(1);
       expect(pullRequests[0].body.releaseData).lengthOf(1);
       expect(pullRequests[0].body.releaseData[0].component).to.eql('pkg1');
-      expect(pullRequests[0].body.releaseData[0].version?.toString()).to.eql('1.2.4');
+      expect(pullRequests[0].body.releaseData[0].version?.toString()).to.eql(
+        '1.2.4'
+      );
     });
 
     describe('with plugins', () => {

--- a/test/plugins/merge.ts
+++ b/test/plugins/merge.ts
@@ -55,9 +55,9 @@ describe('Merge plugin', () => {
       const plugin = new Merge(github, 'main', {});
       const newCandidates = await plugin.run(candidates);
       expect(newCandidates).lengthOf(1);
-      console.log(newCandidates[0].pullRequest.title);
-      console.log(newCandidates[0].pullRequest.title.toString());
-      expect(newCandidates[0].pullRequest.title.toString()).to.eql('chore: release main');
+      expect(newCandidates[0].pullRequest.title.toString()).to.eql(
+        'chore: release main'
+      );
     });
 
     it('merges multiple pull requests into an aggregate', async () => {

--- a/test/plugins/merge.ts
+++ b/test/plugins/merge.ts
@@ -48,13 +48,16 @@ describe('Merge plugin', () => {
       expect(newCandidates).lengthOf(0);
     });
 
-    it('ignores a single pull request', async () => {
+    it('merges a single pull request', async () => {
       const candidates: CandidateReleasePullRequest[] = [
         buildMockCandidatePullRequest('python', 'python', '1.0.0'),
       ];
       const plugin = new Merge(github, 'main', {});
       const newCandidates = await plugin.run(candidates);
-      expect(newCandidates).to.eql(candidates);
+      expect(newCandidates).lengthOf(1);
+      console.log(newCandidates[0].pullRequest.title);
+      console.log(newCandidates[0].pullRequest.title.toString());
+      expect(newCandidates[0].pullRequest.title.toString()).to.eql('chore: release main');
     });
 
     it('merges multiple pull requests into an aggregate', async () => {


### PR DESCRIPTION
Also, skip merging if there is only a single configured package for the manifest.