### PR TITLE
fix: backfill latest release with version found in manifest

### DIFF
--- a/src/manifest.ts
+++ b/src/manifest.ts
@@ -479,7 +479,22 @@ export class Manifest {
       }
 
       const strategy = strategiesByPath[path];
-      const latestRelease = releasesByPath[path];
+      let latestRelease = releasesByPath[path];
+      if (
+        !latestRelease &&
+        this.releasedVersions[path].toString() !== '0.0.0'
+      ) {
+        const version = this.releasedVersions[path];
+        const component = await strategy.getComponent();
+        logger.info(
+          `No latest release found for path: ${path}, component: ${component}, but a previous version (${version.toString()}) was specified in the manifest.`
+        );
+        latestRelease = {
+          tag: new TagName(version, component),
+          sha: '',
+          notes: '',
+        };
+      }
       const releasePullRequest = await strategy.buildReleasePullRequest(
         pathCommits,
         latestRelease,


### PR DESCRIPTION
Sometimes, a repository may not have a previous release tagged in the expected format and release-please cannot find it in the history. In those cases, we will use the version specified in the manifest (if there is one) as the previous release.

Fixes #1130 