### PR TITLE
fix(rust): Don't update dev-dependencies lacking a version key (#1095)

### DIFF
--- a/__snapshots__/cargo-toml.js
+++ b/__snapshots__/cargo-toml.js
@@ -10,6 +10,7 @@ normal-dep = "1.2.3"
 
 [dev-dependencies]
 dev-dep = { version = "1.2.3" }
+dev-dep-2 = { path = "../dev-dep-2" }
 
 [build-dependencies]
 # this is using a private registry
@@ -44,6 +45,7 @@ normal-dep = "1.2.3"
 
 [dev-dependencies]
 dev-dep = { version = "1.2.3" }
+dev-dep-2 = { path = "../dev-dep-2" }
 
 [build-dependencies]
 # this is using a private registry

--- a/src/updaters/rust/cargo-toml.ts
+++ b/src/updaters/rust/cargo-toml.ts
@@ -68,7 +68,16 @@ export class CargoToml extends DefaultUpdater {
         const dep = deps[pkgName];
 
         if (typeof dep === 'string' || typeof dep.path === 'undefined') {
-          logger.info(`skipping ${depKind}.${pkgName} in`);
+          logger.info(
+            `skipping ${depKind}.${pkgName} (no path set)`
+          );
+          continue; // to next depKind
+        }
+
+        if (typeof dep.version === 'undefined') {
+          logger.info(
+            `skipping ${depKind}.${pkgName} (no version set)`
+          );
           continue; // to next depKind
         }
 

--- a/src/updaters/rust/cargo-toml.ts
+++ b/src/updaters/rust/cargo-toml.ts
@@ -68,16 +68,12 @@ export class CargoToml extends DefaultUpdater {
         const dep = deps[pkgName];
 
         if (typeof dep === 'string' || typeof dep.path === 'undefined') {
-          logger.info(
-            `skipping ${depKind}.${pkgName} (no path set)`
-          );
+          logger.info(`skipping ${depKind}.${pkgName} (no path set)`);
           continue; // to next depKind
         }
 
         if (typeof dep.version === 'undefined') {
-          logger.info(
-            `skipping ${depKind}.${pkgName} (no version set)`
-          );
+          logger.info(`skipping ${depKind}.${pkgName} (no version set)`);
           continue; // to next depKind
         }
 

--- a/test/fixtures/strategies/rust/Cargo-crate2.toml
+++ b/test/fixtures/strategies/rust/Cargo-crate2.toml
@@ -3,5 +3,5 @@ name = "crate2"
 version = "0.4.321"
 
 [dependencies]
-crate1 = { version = "0.123.4", path = "../crate2" }
+crate1 = { version = "0.123.4", path = "../crate1" }
 

--- a/test/fixtures/strategies/rust/Cargo-workspace.toml
+++ b/test/fixtures/strategies/rust/Cargo-workspace.toml
@@ -1,6 +1,6 @@
 [workspace]
 members = [
     "crates/crate1",
-    "crates/crate2",
+    "crates/crate2"
 ]
 

--- a/test/updaters/cargo-toml.ts
+++ b/test/updaters/cargo-toml.ts
@@ -76,6 +76,7 @@ describe('CargoToml', () => {
       const versions = new Map();
       versions.set('normal-dep', '2.0.0');
       versions.set('dev-dep', '2.0.0');
+      versions.set('dev-dep-2', '2.0.0');
       versions.set('build-dep', '2.0.0');
       versions.set('windows-dep', '2.0.0');
       versions.set('unix-dep', '2.0.0');

--- a/test/updaters/fixtures/Cargo-workspace.toml
+++ b/test/updaters/fixtures/Cargo-workspace.toml
@@ -1,7 +1,7 @@
 [workspace]
 members = [
     "crates/crate1",
-    "crates/crate2",
+    "crates/crate2"
 ]
 
 

--- a/test/updaters/fixtures/Cargo.toml
+++ b/test/updaters/fixtures/Cargo.toml
@@ -9,6 +9,7 @@ normal-dep = "1.2.3"
 
 [dev-dependencies]
 dev-dep = { version = "1.2.3" }
+dev-dep-2 = { path = "../dev-dep-2" }
 
 [build-dependencies]
 # this is using a private registry


### PR DESCRIPTION
Cherry pick #1095 into v13 and resolve conflicts

Fixes #1094