### PR TITLE
fix: allow setting release-type at root of manifest config

### DIFF
--- a/src/manifest.ts
+++ b/src/manifest.ts
@@ -840,9 +840,11 @@ export class Manifest {
  * @param {ReleaserPackageConfig} config Parsed configuration from JSON file.
  * @returns {ReleaserConfig}
  */
-function extractReleaserConfig(config: ReleaserPackageConfig): ReleaserConfig {
+function extractReleaserConfig(
+  config: ReleaserPackageConfig
+): Partial<ReleaserConfig> {
   return {
-    releaseType: config['release-type'] || 'node', // for backwards-compatibility
+    releaseType: config['release-type'],
     bumpMinorPreMajor: config['bump-minor-pre-major'],
     bumpPatchForMinorPreMajor: config['bump-patch-for-minor-pre-major'],
     changelogSections: config['changelog-sections'],
@@ -1014,11 +1016,11 @@ async function latestReleaseVersion(
 }
 
 function mergeReleaserConfig(
-  defaultConfig: ReleaserConfig,
-  pathConfig: ReleaserConfig
-) {
+  defaultConfig: Partial<ReleaserConfig>,
+  pathConfig: Partial<ReleaserConfig>
+): ReleaserConfig {
   return {
-    releaseType: pathConfig.releaseType ?? defaultConfig.releaseType,
+    releaseType: pathConfig.releaseType ?? defaultConfig.releaseType ?? 'node',
     bumpMinorPreMajor:
       pathConfig.bumpMinorPreMajor ?? defaultConfig.bumpMinorPreMajor,
     bumpPatchForMinorPreMajor:

--- a/test/fixtures/manifest/config/root-release-type.json
+++ b/test/fixtures/manifest/config/root-release-type.json
@@ -1,0 +1,11 @@
+{
+  "release-type": "java-yoshi",
+  "packages": {
+    ".": {
+      "package-name": "foo"
+    },
+    "node-package": {
+      "release-type": "node"
+    }
+  }
+}

--- a/test/manifest.ts
+++ b/test/manifest.ts
@@ -127,7 +127,7 @@ describe('Manifest', () => {
   });
 
   describe('fromManifest', () => {
-    it('it should parse config and manifest from repostiory', async () => {
+    it('should parse config and manifest from repostiory', async () => {
       const getFileContentsStub = sandbox.stub(
         github,
         'getFileContentsOnBranch'
@@ -150,6 +150,35 @@ describe('Manifest', () => {
       );
       expect(Object.keys(manifest.repositoryConfig)).lengthOf(8);
       expect(Object.keys(manifest.releasedVersions)).lengthOf(8);
+    });
+    it('should read the default release-type from manifest', async () => {
+      const getFileContentsStub = sandbox.stub(
+        github,
+        'getFileContentsOnBranch'
+      );
+      getFileContentsStub
+        .withArgs('release-please-config.json', 'main')
+        .resolves(
+          buildGitHubFileContent(
+            fixturesPath,
+            'manifest/config/root-release-type.json'
+          )
+        )
+        .withArgs('.release-please-manifest.json', 'main')
+        .resolves(
+          buildGitHubFileContent(
+            fixturesPath,
+            'manifest/versions/versions.json'
+          )
+        );
+      const manifest = await Manifest.fromManifest(
+        github,
+        github.repository.defaultBranch
+      );
+      expect(manifest.repositoryConfig['.'].releaseType).to.eql('java-yoshi');
+      expect(manifest.repositoryConfig['node-package'].releaseType).to.eql(
+        'node'
+      );
     });
   });
 


### PR DESCRIPTION
We were setting the default too early - if you specified a release-type at the root of the config but left the per-path config empty, the per-path's default would take precedence over the configured root value.

Discovered while investigating #1141 
