### PR TITLE
fix: fallback to look at tags when looking for latest release

### DIFF
--- a/src/manifest.ts
+++ b/src/manifest.ts
@@ -993,7 +993,7 @@ async function latestReleaseVersion(
       continue;
     }
 
-    if (tagName.component === prefix) {
+    if (tagName.component === branchPrefix) {
       logger.debug(`found release for ${prefix}`, tagName.version);
       if (!commitShas.has(release.sha)) {
         logger.debug(
@@ -1009,8 +1009,38 @@ async function latestReleaseVersion(
     candidateReleaseVersions
   );
 
+  if (candidateReleaseVersions.length > 0) {
+    // Find largest release number (sort descending then return first)
+    return candidateReleaseVersions.sort((a, b) => b.compare(a))[0];
+  }
+
+  // If not found from recent pull requests or releases, look at tags. Iterate
+  // through tags and cross reference against SHAs in this branch
+  const tagGenerator = github.tagIterator();
+  const candidateTagVersion: Version[] = [];
+  for await (const tag of tagGenerator) {
+    const tagName = TagName.parse(tag.name);
+    if (!tagName) {
+      continue;
+    }
+
+    if (tagName.component === branchPrefix) {
+      if (!commitShas.has(tag.sha)) {
+        logger.debug(
+          `SHA not found in recent commits to branch ${targetBranch}, skipping`
+        );
+        continue;
+      }
+      candidateTagVersion.push(tagName.version);
+    }
+  }
+  logger.debug(
+    `found ${candidateTagVersion.length} possible tags.`,
+    candidateTagVersion
+  );
+
   // Find largest release number (sort descending then return first)
-  return candidateReleaseVersions.sort((a, b) => b.compare(a))[0];
+  return candidateTagVersion.sort((a, b) => b.compare(a))[0];
 }
 
 function mergeReleaserConfig(

--- a/test/manifest.ts
+++ b/test/manifest.ts
@@ -14,7 +14,7 @@
 
 import {describe, it, beforeEach, afterEach} from 'mocha';
 import {Manifest} from '../src/manifest';
-import {GitHub, GitHubRelease} from '../src/github';
+import {GitHub, GitHubRelease, GitHubTag} from '../src/github';
 import * as sinon from 'sinon';
 import {Commit} from '../src/commit';
 import {
@@ -57,6 +57,15 @@ function mockReleases(github: GitHub, releases: GitHubRelease[]) {
     }
   }
   sandbox.stub(github, 'releaseIterator').returns(fakeGenerator());
+}
+
+function mockTags(github: GitHub, tags: GitHubTag[]) {
+  async function* fakeGenerator() {
+    for (const tag of tags) {
+      yield tag;
+    }
+  }
+  sandbox.stub(github, 'tagIterator').returns(fakeGenerator());
 }
 
 function mockPullRequests(
@@ -306,6 +315,47 @@ describe('Manifest', () => {
         '3.3.3'
       );
     });
+    it('finds legacy tags', async () => {
+      mockCommits(github, [
+        {
+          sha: 'abc123',
+          message: 'some commit message',
+          files: [],
+          pullRequest: {
+            headBranchName: 'release-please/branches/main/components/foobar',
+            baseBranchName: 'main',
+            number: 123,
+            title: 'chore: release foobar 1.2.3',
+            body: '',
+            labels: [],
+            files: [],
+          },
+        },
+      ]);
+      mockReleases(github, []);
+      mockTags(github, [
+        {
+          name: 'other-v3.3.3',
+          sha: 'abc123',
+        },
+      ]);
+
+      const manifest = await Manifest.fromConfig(github, 'target-branch', {
+        releaseType: 'simple',
+        bumpMinorPreMajor: true,
+        bumpPatchForMinorPreMajor: true,
+        component: 'other',
+        includeComponentInTag: true,
+      });
+      expect(Object.keys(manifest.repositoryConfig)).lengthOf(1);
+      expect(
+        Object.keys(manifest.releasedVersions),
+        'found release versions'
+      ).lengthOf(1);
+      expect(Object.values(manifest.releasedVersions)[0].toString()).to.eql(
+        '3.3.3'
+      );
+    });
     it('ignores manually tagged release if commit not found', async () => {
       mockCommits(github, [
         {
@@ -330,6 +380,7 @@ describe('Manifest', () => {
           url: 'http://path/to/release',
         },
       ]);
+      mockTags(github, []);
 
       const manifest = await Manifest.fromConfig(github, 'target-branch', {
         releaseType: 'simple',
@@ -383,6 +434,65 @@ describe('Manifest', () => {
           tagName: 'other-v3.3.2',
           sha: 'def234',
           url: 'http://path/to/release',
+        },
+      ]);
+
+      const manifest = await Manifest.fromConfig(github, 'target-branch', {
+        releaseType: 'simple',
+        bumpMinorPreMajor: true,
+        bumpPatchForMinorPreMajor: true,
+        component: 'other',
+        includeComponentInTag: true,
+      });
+      expect(Object.keys(manifest.repositoryConfig)).lengthOf(1);
+      expect(
+        Object.keys(manifest.releasedVersions),
+        'found release versions'
+      ).lengthOf(1);
+      expect(Object.values(manifest.releasedVersions)[0].toString()).to.eql(
+        '3.3.3'
+      );
+    });
+    it('finds largest found tagged', async () => {
+      mockCommits(github, [
+        {
+          sha: 'abc123',
+          message: 'some commit message',
+          files: [],
+          pullRequest: {
+            headBranchName: 'release-please/branches/main/components/foobar',
+            baseBranchName: 'main',
+            number: 123,
+            title: 'chore: release foobar 1.2.3',
+            body: '',
+            labels: [],
+            files: [],
+          },
+        },
+        {
+          sha: 'def234',
+          message: 'some commit message',
+          files: [],
+          pullRequest: {
+            headBranchName: 'release-please/branches/main/components/foobar',
+            baseBranchName: 'main',
+            number: 123,
+            title: 'chore: release foobar 1.2.3',
+            body: '',
+            labels: [],
+            files: [],
+          },
+        },
+      ]);
+      mockReleases(github, []);
+      mockTags(github, [
+        {
+          name: 'other-v3.3.3',
+          sha: 'abc123',
+        },
+        {
+          name: 'other-v3.3.2',
+          sha: 'def234',
         },
       ]);
 


### PR DESCRIPTION
Similar to #1146

If we don't find a recent release PR or release, fallback to parsing tags. This should only be necessary for non-manifest releases that are being bootstrapped to release-please.
