### PR TITLE
feat: add ability to override merged commit message

### DIFF
--- a/src/commit.ts
+++ b/src/commit.ts
@@ -347,8 +347,9 @@ export function parseConventionalCommits(
   const conventionalCommits: ConventionalCommit[] = [];
 
   for (const commit of commits) {
+    const commitMessage = preprocessCommitMessage(commit);
     try {
-      for (const parsedCommit of parseCommits(commit.message)) {
+      for (const parsedCommit of parseCommits(commitMessage)) {
         const breaking =
           parsedCommit.notes.filter(note => note.title === 'BREAKING CHANGE')
             .length > 0;
@@ -375,4 +376,19 @@ export function parseConventionalCommits(
   }
 
   return conventionalCommits;
+}
+
+function preprocessCommitMessage(commit: Commit): string {
+  // look for 'BEGIN_COMMIT_OVERRIDE' section of pull request body
+  if (commit.pullRequest) {
+    const overrideMessage = (
+      commit.pullRequest.body.split('BEGIN_COMMIT_OVERRIDE')[1] || ''
+    )
+      .split('END_COMMIT_OVERRIDE')[0]
+      .trim();
+    if (overrideMessage) {
+      return overrideMessage;
+    }
+  }
+  return commit.message;
 }

--- a/test/commits.ts
+++ b/test/commits.ts
@@ -167,6 +167,46 @@ describe('parseConventionalCommits', () => {
     expect(metaCommit!.notes[0].text).to.eql('v3.0.0');
   });
 
+  it('can override the commit message from BEGIN_COMMIT_OVERRIDE body', async () => {
+    const commit = buildMockCommit('chore: some commit');
+    const body = 'BEGIN_COMMIT_OVERRIDE\nfix: some fix\nEND_COMMIT_OVERRIDE';
+    commit.pullRequest = {
+      headBranchName: 'fix-something',
+      baseBranchName: 'main',
+      number: 123,
+      title: 'chore: some commit',
+      labels: [],
+      files: [],
+      body,
+    };
+
+    const conventionalCommits = parseConventionalCommits([commit]);
+    expect(conventionalCommits).lengthOf(1);
+    expect(conventionalCommits[0].type).to.eql('fix');
+    expect(conventionalCommits[0].bareMessage).to.eql('some fix');
+  });
+  it('can override the commit message from BEGIN_COMMIT_OVERRIDE body with a meta commit', async () => {
+    const commit = buildMockCommit('chore: some commit');
+    const body =
+      'BEGIN_COMMIT_OVERRIDE\nfix: some fix\n\nfeat: another feature\nEND_COMMIT_OVERRIDE';
+    commit.pullRequest = {
+      headBranchName: 'fix-something',
+      baseBranchName: 'main',
+      number: 123,
+      title: 'chore: some commit',
+      labels: [],
+      files: [],
+      body,
+    };
+
+    const conventionalCommits = parseConventionalCommits([commit]);
+    expect(conventionalCommits).lengthOf(2);
+    expect(conventionalCommits[0].type).to.eql('feat');
+    expect(conventionalCommits[0].bareMessage).to.eql('another feature');
+    expect(conventionalCommits[1].type).to.eql('fix');
+    expect(conventionalCommits[1].bareMessage).to.eql('some fix');
+  });
+
   // it('ignores reverted commits', async () => {
   //   const commits = [
   //     {sha: 'sha1', message: 'feat: some feature', files: ['path1/file1.txt']},


### PR DESCRIPTION
This allows you to retroactively "fix" a merged commit's message by updating the associated merged pull request with a section like:

```
BEGIN_COMMIT_OVERRIDE
feat: add ability to override merged commit message

chore: another message
chore: a third message
END_COMMIT_OVERRIDE
```

Fixes #967
