### PR TITLE
fix: GitHub#findFilesByExtension should treat prefix as a directory

### DIFF
--- a/src/github.ts
+++ b/src/github.ts
@@ -845,7 +845,7 @@ export class GitHub {
             // match the filename
             path.endsWith(filename) &&
             // match the prefix if provided
-            (!prefix || path.startsWith(prefix))
+            (!prefix || path.startsWith(`${prefix}/`))
           );
         })
         .map(file => {
@@ -1111,7 +1111,7 @@ export class GitHub {
             // match the file extension
             path.endsWith(`.${extension}`) &&
             // match the prefix if provided
-            (!prefix || path.startsWith(prefix))
+            (!prefix || path.startsWith(`${prefix}/`))
           );
         })
         .map(file => {

--- a/src/strategies/krm-blueprint.ts
+++ b/src/strategies/krm-blueprint.ts
@@ -48,7 +48,11 @@ export class KRMBlueprint extends BaseStrategy {
     }
 
     // Update version in all yaml files with attribution annotation
-    const yamlPaths = await this.github.findFilesByExtension('yaml', this.path);
+    const yamlPaths = await this.github.findFilesByExtensionAndRef(
+      'yaml',
+      this.targetBranch,
+      this.path
+    );
     for (const yamlPath of yamlPaths) {
       const contents: GitHubFileContents = await this.github.getFileContents(
         this.addPath(yamlPath)

--- a/test/fixtures/pom-file-search-with-prefix.json
+++ b/test/fixtures/pom-file-search-with-prefix.json
@@ -16,6 +16,13 @@
         "type": "tree",
         "sha": "f484d249c660418515fb01c2b9662073663c242e",
         "url": "https://api.github.com/repos/octocat/Hello-World/git/blobs/f484d249c660418515fb01c2b9662073663c242e"
+      },
+      {
+        "path": "appengine-other/pom.xml",
+        "mode": "040000",
+        "type": "tree",
+        "sha": "418515fb01c2b9662073663c242ef484d249c660",
+        "url": "https://api.github.com/repos/octocat/Hello-World/git/blobs/418515fb01c2b9662073663c242ef484d249c660"
       }
     ],
     "truncated": false

--- a/test/github.ts
+++ b/test/github.ts
@@ -162,6 +162,20 @@ describe('GitHub', () => {
         expect(pomFiles).to.deep.equal(['pom.xml', 'foo/pom.xml']);
       });
     });
+    it('ensures the prefix is a directory', async () => {
+      const fileSearchResponse = JSON.parse(
+        readFileSync(
+          resolve(fixturesPath, 'pom-file-search-with-prefix.json'),
+          'utf8'
+        )
+      );
+      req
+        .get('/repos/fake/fake/git/trees/main?recursive=true')
+        .reply(200, fileSearchResponse);
+      const pomFiles = await github.findFilesByExtension('xml', 'appengine');
+      req.done();
+      expect(pomFiles).to.deep.equal(['pom.xml', 'foo/pom.xml']);
+    });
   });
 
   describe('getFileContents', () => {

--- a/test/strategies/krm-blueprint.ts
+++ b/test/strategies/krm-blueprint.ts
@@ -58,7 +58,7 @@ describe('KRMBlueprint', () => {
         github,
         component: 'google-cloud-automl',
       });
-      sandbox.stub(github, 'findFilesByExtension').resolves([]);
+      sandbox.stub(github, 'findFilesByExtensionAndRef').resolves([]);
       const latestRelease = undefined;
       const release = await strategy.buildReleasePullRequest(
         commits,
@@ -73,7 +73,7 @@ describe('KRMBlueprint', () => {
         github,
         component: 'some-krm-blueprint-package',
       });
-      sandbox.stub(github, 'findFilesByExtension').resolves([]);
+      sandbox.stub(github, 'findFilesByExtensionAndRef').resolves([]);
       const latestRelease = {
         tag: new TagName(
           Version.parse('0.123.4'),
@@ -96,7 +96,7 @@ describe('KRMBlueprint', () => {
         github,
         component: 'google-cloud-automl',
       });
-      sandbox.stub(github, 'findFilesByExtension').resolves([]);
+      sandbox.stub(github, 'findFilesByExtensionAndRef').resolves([]);
       const latestRelease = undefined;
       const release = await strategy.buildReleasePullRequest(
         commits,
@@ -113,8 +113,8 @@ describe('KRMBlueprint', () => {
         component: 'google-cloud-automl',
       });
       sandbox
-        .stub(github, 'findFilesByExtension')
-        .withArgs('yaml', '.')
+        .stub(github, 'findFilesByExtensionAndRef')
+        .withArgs('yaml', 'main', '.')
         .resolves(['project.yaml', 'no-attrib-bucket.yaml']);
       stubFilesFromFixtures({
         github,


### PR DESCRIPTION
This fixes 1164 in the v13 branch, but we will need to backport the fix for 12.x as well

See #1164
