### PR TITLE
fix: export public interface types from index.ts

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1,0 +1,26 @@
+// Copyright 2021 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+export * as Errors from './errors';
+export {Manifest, ReleaserConfig, ManifestOptions} from './manifest';
+export {
+  ReleaseType,
+  getReleaserTypes,
+  VersioningStrategyType,
+  getVersioningStrategyTypes,
+  ChangelogNotesType,
+  getChangelogTypes,
+} from './factory';
+export {Logger, setLogger} from './util/logger';
+export {GitHub} from './github';


### PR DESCRIPTION
This allows other libraries to:

```ts
import {Manifest, ReleaseType} from 'release-please';
```
