### PR TITLE
fix(rust): Rust strategy should update root Cargo files in a workspace

### DIFF
--- a/src/updaters/rust/cargo-toml.ts
+++ b/src/updaters/rust/cargo-toml.ts
@@ -39,21 +39,13 @@ export class CargoToml extends DefaultUpdater {
       logger.error(msg);
       throw new Error(msg);
     }
+    payload = replaceTomlValue(
+      payload,
+      ['package', 'version'],
+      this.version.toString()
+    );
 
     for (const [pkgName, pkgVersion] of this.versionsMap) {
-      if (parsed.package.name === pkgName) {
-        logger.info(
-          `updating own version from ${parsed.package?.version} to ${pkgVersion}`
-        );
-        payload = replaceTomlValue(
-          payload,
-          ['package', 'version'],
-          pkgVersion.toString()
-        );
-
-        continue; // to next [pkgName, pkgVersion] pair
-      }
-
       for (const depKind of DEP_KINDS) {
         const deps = parsed[depKind];
 

--- a/test/strategies/rust.ts
+++ b/test/strategies/rust.ts
@@ -140,7 +140,11 @@ describe('Rust', () => {
       sandbox
         .stub(github, 'getFileContentsOnBranch')
         .withArgs('Cargo.toml', 'main')
-        .resolves(buildGitHubFileContent(fixturesPath, 'Cargo-workspace.toml'));
+        .resolves(buildGitHubFileContent(fixturesPath, 'Cargo-workspace.toml'))
+        .withArgs('crates/crate1/Cargo.toml', 'main')
+        .resolves(buildGitHubFileContent(fixturesPath, 'Cargo-crate1.toml'))
+        .withArgs('crates/crate2/Cargo.toml', 'main')
+        .resolves(buildGitHubFileContent(fixturesPath, 'Cargo-crate2.toml'));
       const latestRelease = undefined;
       const release = await strategy.buildReleasePullRequest(
         COMMITS,

--- a/test/strategies/rust.ts
+++ b/test/strategies/rust.ts
@@ -66,6 +66,7 @@ describe('Rust', () => {
       );
       expect(release!.version?.toString()).to.eql(expectedVersion);
     });
+
     it('returns release PR changes with semver patch bump', async () => {
       const expectedVersion = '0.123.5';
       const strategy = new Rust({
@@ -111,6 +112,7 @@ describe('Rust', () => {
       snapshot(dateSafe(pullRequest!.body.toString()));
     });
   });
+
   describe('buildUpdates', () => {
     it('builds common files', async () => {
       const strategy = new Rust({
@@ -147,6 +149,7 @@ describe('Rust', () => {
       const updates = release!.updates;
       assertHasUpdate(updates, 'crates/crate1/Cargo.toml', CargoToml);
       assertHasUpdate(updates, 'crates/crate2/Cargo.toml', CargoToml);
+      assertHasUpdate(updates, 'Cargo.toml', CargoToml);
       assertHasUpdate(updates, 'Cargo.lock', CargoLock);
     });
   });

--- a/test/updaters/cargo-toml.ts
+++ b/test/updaters/cargo-toml.ts
@@ -58,10 +58,11 @@ describe('CargoToml', () => {
         resolve(fixturesPath, './Cargo.toml'),
         'utf8'
       ).replace(/\r\n/g, '\n');
+      const newVersion = Version.parse('14.0.0');
       const versions = new Map();
-      versions.set('rust-test-repo', '14.0.0');
+      versions.set('rust-test-repo', newVersion);
       const cargoToml = new CargoToml({
-        version: FAKE_VERSION,
+        version: newVersion,
         versionsMap: versions,
       });
       const newContent = cargoToml.updateContent(oldContent);
@@ -73,6 +74,7 @@ describe('CargoToml', () => {
         resolve(fixturesPath, './Cargo.toml'),
         'utf8'
       ).replace(/\r\n/g, '\n');
+      const newVersion = Version.parse('12.0.0');
       const versions = new Map();
       versions.set('normal-dep', '2.0.0');
       versions.set('dev-dep', '2.0.0');
@@ -84,7 +86,7 @@ describe('CargoToml', () => {
       versions.set('x86-64-dep', '2.0.0');
       versions.set('foobar-dep', '2.0.0');
       const cargoToml = new CargoToml({
-        version: FAKE_VERSION,
+        version: newVersion,
         versionsMap: versions,
       });
       const newContent = cargoToml.updateContent(oldContent);


### PR DESCRIPTION
* Cargo.toml updater now updates the main package version from the updater's version
* cargo-workspace merges the root component's updates
* rust strategy now updates all workspace members versions in sync (overridden by cargo-workspace plugin if configured)

Fixes #1170
Fixes #1096 