### PR TITLE
fix: java snapshots should update all files with :current annotations

### DIFF
--- a/__snapshots__/java-update.js
+++ b/__snapshots__/java-update.js
@@ -1,3 +1,45 @@
+exports['JavaUpdate updateContent only updates current versions for snapshots 1'] = `
+# this is an inline current entry and should always be replaced
+3.3.3 # {x-version-update:module-name:current}
+
+# this is a block current entry and should always be replaced
+# {x-version-update-start:module-name:current}
+3.3.3
+3.3.3
+# {x-version-update-end}
+
+# this is an inline released entry and should be replaced for non-snapshot releases
+1.2.3 # {x-version-update:module-name:released}
+
+# this is a block released entry and should be replaced for non-snapshot releases
+# {x-version-update-start:module-name:released}
+2.3.4
+3.4.5
+# {x-version-update-end}
+
+`
+
+exports['JavaUpdate updateContent updates all versions for non snapshots 1'] = `
+# this is an inline current entry and should always be replaced
+3.3.3 # {x-version-update:module-name:current}
+
+# this is a block current entry and should always be replaced
+# {x-version-update-start:module-name:current}
+3.3.3
+3.3.3
+# {x-version-update-end}
+
+# this is an inline released entry and should be replaced for non-snapshot releases
+3.3.3 # {x-version-update:module-name:released}
+
+# this is a block released entry and should be replaced for non-snapshot releases
+# {x-version-update-start:module-name:released}
+3.3.3
+3.3.3
+# {x-version-update-end}
+
+`
+
 exports['JavaUpdate updateContent updates an LTS snapshot version 1'] = `
 <?xml version="1.0" encoding="UTF-8"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">

--- a/src/strategies/java-yoshi.ts
+++ b/src/strategies/java-yoshi.ts
@@ -47,6 +47,10 @@ const CHANGELOG_SECTIONS = [
   {type: 'ci', section: 'Continuous Integration', hidden: true},
 ];
 
+interface JavaBuildUpdatesOption extends BuildUpdatesOptions {
+  isSnapshot?: boolean;
+}
+
 export class JavaYoshi extends BaseStrategy {
   private versionsContent?: GitHubFileContents;
   private snapshotVersioning: VersioningStrategy;
@@ -105,27 +109,25 @@ export class JavaYoshi extends BaseStrategy {
     const branchName = component
       ? BranchName.ofComponentTargetBranch(component, this.targetBranch)
       : BranchName.ofTargetBranch(this.targetBranch);
+    const notes =
+      '### Updating meta-information for bleeding-edge SNAPSHOT release.';
     const pullRequestBody = new PullRequestBody([
       {
         component,
         version: newVersion,
-        notes:
-          '### Updating meta-information for bleeding-edge SNAPSHOT release.',
+        notes,
       },
     ]);
+    const updates = await this.buildUpdates({
+      newVersion,
+      versionsMap,
+      changelogEntry: notes,
+      isSnapshot: true,
+    });
     return {
       title: pullRequestTitle,
       body: pullRequestBody,
-      updates: [
-        {
-          path: this.addPath('versions.txt'),
-          createIfMissing: false,
-          updater: new VersionsManifest({
-            version: newVersion,
-            versionsMap,
-          }),
-        },
-      ],
+      updates,
       labels: [],
       headRefName: branchName.toString(),
       version: newVersion,
@@ -166,7 +168,7 @@ export class JavaYoshi extends BaseStrategy {
   }
 
   protected async buildUpdates(
-    options: BuildUpdatesOptions
+    options: JavaBuildUpdatesOption
   ): Promise<Update[]> {
     const updates: Update[] = [];
     const version = options.newVersion;
@@ -203,6 +205,7 @@ export class JavaYoshi extends BaseStrategy {
         updater: new JavaUpdate({
           version,
           versionsMap,
+          isSnapshot: options.isSnapshot,
         }),
       });
     });
@@ -215,6 +218,7 @@ export class JavaYoshi extends BaseStrategy {
         updater: new JavaUpdate({
           version,
           versionsMap,
+          isSnapshot: options.isSnapshot,
         }),
       });
     });
@@ -227,6 +231,7 @@ export class JavaYoshi extends BaseStrategy {
         updater: new JavaUpdate({
           version,
           versionsMap,
+          isSnapshot: options.isSnapshot,
         }),
       });
     });
@@ -238,18 +243,21 @@ export class JavaYoshi extends BaseStrategy {
         updater: new JavaUpdate({
           version,
           versionsMap,
+          isSnapshot: options.isSnapshot,
         }),
       });
     });
 
-    updates.push({
-      path: this.addPath(this.changelogPath),
-      createIfMissing: true,
-      updater: new Changelog({
-        version,
-        changelogEntry: options.changelogEntry,
-      }),
-    });
+    if (!options.isSnapshot) {
+      updates.push({
+        path: this.addPath(this.changelogPath),
+        createIfMissing: true,
+        updater: new Changelog({
+          version,
+          changelogEntry: options.changelogEntry,
+        }),
+      });
+    }
 
     return updates;
   }

--- a/test/strategies/java-yoshi.ts
+++ b/test/strategies/java-yoshi.ts
@@ -17,7 +17,11 @@ import {expect} from 'chai';
 import {GitHub} from '../../src/github';
 import {JavaYoshi} from '../../src/strategies/java-yoshi';
 import * as sinon from 'sinon';
-import {buildGitHubFileContent, assertHasUpdate} from '../helpers';
+import {
+  buildGitHubFileContent,
+  assertHasUpdate,
+  assertNoHasUpdate,
+} from '../helpers';
 import {buildMockCommit} from '../helpers';
 import {TagName} from '../../src/util/tag-name';
 import {Version} from '../../src/version';
@@ -230,7 +234,8 @@ describe('JavaYoshi', () => {
       );
       const updates = release!.updates;
       assertHasUpdate(updates, 'CHANGELOG.md', Changelog);
-      assertHasUpdate(updates, 'path1/pom.xml', JavaUpdate);
+      const {updater} = assertHasUpdate(updates, 'path1/pom.xml', JavaUpdate);
+      expect((updater as JavaUpdate).isSnapshot).to.be.false;
       assertHasUpdate(updates, 'path2/pom.xml', JavaUpdate);
       assertHasUpdate(updates, 'path1/build.gradle', JavaUpdate);
       assertHasUpdate(updates, 'path1/build.gradle', JavaUpdate);
@@ -262,6 +267,47 @@ describe('JavaYoshi', () => {
       assertHasUpdate(updates, 'CHANGELOG.md', Changelog);
       assertHasUpdate(updates, 'foo/bar.java', CompositeUpdater);
       assertHasUpdate(updates, 'src/version.java', CompositeUpdater);
+      assertHasUpdate(updates, 'versions.txt', VersionsManifest);
+    });
+
+    it('updates all files for snapshots', async () => {
+      const strategy = new JavaYoshi({
+        targetBranch: 'main',
+        github,
+        component: 'google-cloud-automl',
+      });
+      const findFilesStub = sandbox.stub(github, 'findFilesByFilename');
+      findFilesStub
+        .withArgs('pom.xml', '.')
+        .resolves(['path1/pom.xml', 'path2/pom.xml']);
+      findFilesStub
+        .withArgs('build.gradle', '.')
+        .resolves(['path1/build.gradle', 'path2/build.gradle']);
+      findFilesStub
+        .withArgs('dependencies.properties', '.')
+        .resolves(['dependencies.properties']);
+      const getFileContentsStub = sandbox.stub(
+        github,
+        'getFileContentsOnBranch'
+      );
+      getFileContentsStub
+        .withArgs('versions.txt', 'main')
+        .resolves(
+          buildGitHubFileContent(fixturesPath, 'versions-released.txt')
+        );
+      const latestRelease = undefined;
+      const release = await strategy.buildReleasePullRequest(
+        COMMITS,
+        latestRelease
+      );
+      const updates = release!.updates;
+      assertNoHasUpdate(updates, 'CHANGELOG.md');
+      const {updater} = assertHasUpdate(updates, 'path1/pom.xml', JavaUpdate);
+      expect((updater as JavaUpdate).isSnapshot).to.be.true;
+      assertHasUpdate(updates, 'path2/pom.xml', JavaUpdate);
+      assertHasUpdate(updates, 'path1/build.gradle', JavaUpdate);
+      assertHasUpdate(updates, 'path1/build.gradle', JavaUpdate);
+      assertHasUpdate(updates, 'dependencies.properties', JavaUpdate);
       assertHasUpdate(updates, 'versions.txt', VersionsManifest);
     });
   });

--- a/test/updaters/fixtures/java-replacements-test.txt
+++ b/test/updaters/fixtures/java-replacements-test.txt
@@ -1,0 +1,17 @@
+# this is an inline current entry and should always be replaced
+1.2.3 # {x-version-update:module-name:current}
+
+# this is a block current entry and should always be replaced
+# {x-version-update-start:module-name:current}
+2.3.4
+3.4.5
+# {x-version-update-end}
+
+# this is an inline released entry and should be replaced for non-snapshot releases
+1.2.3 # {x-version-update:module-name:released}
+
+# this is a block released entry and should be replaced for non-snapshot releases
+# {x-version-update-start:module-name:released}
+2.3.4
+3.4.5
+# {x-version-update-end}

--- a/test/updaters/java-update.ts
+++ b/test/updaters/java-update.ts
@@ -30,11 +30,40 @@ describe('JavaUpdate', () => {
       ).replace(/\r\n/g, '\n');
       const versions = new Map<string, Version>();
       versions.set('google-auth-library-parent', Version.parse('v0.16.2-sp.1'));
-      const pom = new JavaUpdate({
+      const updater = new JavaUpdate({
         versionsMap: versions,
         version: Version.parse('v0.16.2-sp.1'),
       });
-      const newContent = pom.updateContent(oldContent);
+      const newContent = updater.updateContent(oldContent);
+      snapshot(newContent);
+    });
+    it('only updates current versions for snapshots', async () => {
+      const oldContent = readFileSync(
+        resolve(fixturesPath, './java-replacements-test.txt'),
+        'utf8'
+      ).replace(/\r\n/g, '\n');
+      const versions = new Map<string, Version>();
+      versions.set('module-name', Version.parse('3.3.3'));
+      const updater = new JavaUpdate({
+        versionsMap: versions,
+        version: Version.parse('3.3.3'),
+        isSnapshot: true,
+      });
+      const newContent = updater.updateContent(oldContent);
+      snapshot(newContent);
+    });
+    it('updates all versions for non snapshots', async () => {
+      const oldContent = readFileSync(
+        resolve(fixturesPath, './java-replacements-test.txt'),
+        'utf8'
+      ).replace(/\r\n/g, '\n');
+      const versions = new Map<string, Version>();
+      versions.set('module-name', Version.parse('3.3.3'));
+      const updater = new JavaUpdate({
+        versionsMap: versions,
+        version: Version.parse('3.3.3'),
+      });
+      const newContent = updater.updateContent(oldContent);
       snapshot(newContent);
     });
   });


### PR DESCRIPTION
Updates JavaUpdater to allow only updating `:current` vs `:released` annotated versions.
Fix files updated for snapshot releases (same as normal releases, but skip Changelog).

Fixes #1203
