### PR TITLE
fix(php-yoshi): fix parsing of pull request body

### DIFF
--- a/__snapshots__/php-yoshi.js
+++ b/__snapshots__/php-yoshi.js
@@ -1,3 +1,739 @@
+exports['PHPYoshi buildRelease parses the release notes 1'] = `
+<details><summary>google/cloud-access-approval: 0.3.0</summary>
+
+### Features
+
+* update client libraries to support Database operations ([#4977](https://github.com/googleapis/google-cloud-php/issues/4977)) ([731b051](https://github.com/googleapis/google-cloud-php/commit/731b051d9cd8c2ddea077fdd2719885bdf6a8925))
+</details>
+
+<details><summary>google/access-context-manager: 0.2.0</summary>
+
+### Features
+
+* update client libraries to support Database operations ([#4976](https://github.com/googleapis/google-cloud-php/issues/4976)) ([3ce2080](https://github.com/googleapis/google-cloud-php/commit/3ce2080e1293f6c6b07bb03c9f816cbcd032ae3b))
+</details>
+
+<details><summary>google/analytics-admin: 0.4.2</summary>
+
+
+</details>
+
+<details><summary>google/analytics-data: 0.8.0</summary>
+
+### Features
+
+* [AnalyticsData] Updates from OwlBot ([#4974](https://github.com/googleapis/google-cloud-php/issues/4974)) ([841628c](https://github.com/googleapis/google-cloud-php/commit/841628c1e83a36f5671e1d1ef8c99d6f1f9e2d67))
+
+
+### Bug Fixes
+
+* owlbot copy excludes ([#4987](https://github.com/googleapis/google-cloud-php/issues/4987)) ([49e2a11](https://github.com/googleapis/google-cloud-php/commit/49e2a11239a30d9c11743a0ca7693f3cc51fce03))
+* remove deprecated aliases in double-nested protos ([#4997](https://github.com/googleapis/google-cloud-php/issues/4997)) ([c4c790c](https://github.com/googleapis/google-cloud-php/commit/c4c790cc33266848c8851c5ae557d326ad27fcf5))
+</details>
+
+<details><summary>google/cloud-api-gateway: 0.2.0</summary>
+
+### Features
+
+* [ApiGateway] service update ([#5013](https://github.com/googleapis/google-cloud-php/issues/5013)) ([2cdda28](https://github.com/googleapis/google-cloud-php/commit/2cdda2871320b5c56eff7523fbe15aece1f6dbf3))
+</details>
+
+<details><summary>google/cloud-apigee-connect: 0.2.3</summary>
+
+
+</details>
+
+<details><summary>google/cloud-appengine-admin: 0.2.3</summary>
+
+
+</details>
+
+<details><summary>google/cloud-artifact-registry: 0.1.3</summary>
+
+
+</details>
+
+<details><summary>google/cloud-asset: 1.6.3</summary>
+
+
+</details>
+
+<details><summary>google/cloud-assured-workloads: 0.5.0</summary>
+
+### Features
+
+* [AssuredWorkloads] service updates ([#5004](https://github.com/googleapis/google-cloud-php/issues/5004)) ([881b79e](https://github.com/googleapis/google-cloud-php/commit/881b79e72fd6d11075775d5ce16231a363baafe2))
+</details>
+
+<details><summary>google/cloud-automl: 1.4.2</summary>
+
+
+</details>
+
+<details><summary>google/cloud-bigquery-connection: 0.5.3</summary>
+
+
+</details>
+
+<details><summary>google/cloud-bigquerydatatransfer: 1.2.6</summary>
+
+
+</details>
+
+<details><summary>google/cloud-bigquery-reservation: 0.5.0</summary>
+
+### Features
+
+* increase the logical timeout (retry deadline) to 5 minutes ([#4864](https://github.com/googleapis/google-cloud-php/issues/4864)) ([52130ee](https://github.com/googleapis/google-cloud-php/commit/52130ee60f03c61ef0ada04c31b1268af87bacb6))
+</details>
+
+<details><summary>google/cloud-bigquery-storage: 1.2.2</summary>
+
+
+</details>
+
+<details><summary>google/cloud-bigtable: 1.11.3</summary>
+
+### Bug Fixes
+
+* make partial veneer client excludes explicit ([#4995](https://github.com/googleapis/google-cloud-php/issues/4995)) ([8819eaa](https://github.com/googleapis/google-cloud-php/commit/8819eaa01e146ba40576750b47a22cbb8cb1407b))
+</details>
+
+<details><summary>google/cloud-billing: 1.3.3</summary>
+
+
+</details>
+
+<details><summary>google/cloud-billing-budgets: 0.2.3</summary>
+
+
+</details>
+
+<details><summary>google/cloud-binary-authorization: 0.4.0</summary>
+
+### Features
+
+* [BinaryAuthorization] update client libraries to support Database operations ([#4959](https://github.com/googleapis/google-cloud-php/issues/4959)) ([a76716a](https://github.com/googleapis/google-cloud-php/commit/a76716ad8d333204bad2c8ac9cc6672b068242c7))
+</details>
+
+<details><summary>google/cloud-build: 0.2.0</summary>
+
+### Features
+
+* [Build] update client libraries to support Database operations ([#4958](https://github.com/googleapis/google-cloud-php/issues/4958)) ([bd76f9e](https://github.com/googleapis/google-cloud-php/commit/bd76f9e8ca0a5035f66d419d7ad61c5ec57b49ae))
+
+
+### Bug Fixes
+
+* [Build] autoload for metadata classes ([#4991](https://github.com/googleapis/google-cloud-php/issues/4991)) ([7dad428](https://github.com/googleapis/google-cloud-php/commit/7dad428f26771c98adc45a72d4ff66c40f2d8208))
+</details>
+
+<details><summary>google/cloud-channel: 0.6.0</summary>
+
+### Features
+
+* [Channel] update client libraries to support Database operations ([#4957](https://github.com/googleapis/google-cloud-php/issues/4957)) ([5a43585](https://github.com/googleapis/google-cloud-php/commit/5a43585ce3a0281b50dc78b7a403673443f95838))
+</details>
+
+<details><summary>google/cloud-common-protos: 0.3.0</summary>
+
+### Features
+
+* update common-protos and add common/operation_metadata.proto ([#4837](https://github.com/googleapis/google-cloud-php/issues/4837)) ([8eea01c](https://github.com/googleapis/google-cloud-php/commit/8eea01c549613ea391a0fa043d717f4e14891894))
+</details>
+
+<details><summary>google/cloud-compute: 0.6.0</summary>
+
+### Features
+
+* Update gapic-generator-php to v1.3.0 ([#4978](https://github.com/googleapis/google-cloud-php/issues/4978)) ([96d6c1e](https://github.com/googleapis/google-cloud-php/commit/96d6c1e4a32357a6e7afc8a9329349e9ba4f69f1))
+
+
+### Bug Fixes
+
+* remove deprecated aliases in double-nested protos ([#4997](https://github.com/googleapis/google-cloud-php/issues/4997)) ([c4c790c](https://github.com/googleapis/google-cloud-php/commit/c4c790cc33266848c8851c5ae557d326ad27fcf5))
+</details>
+
+<details><summary>google/cloud-contact-center-insights: 0.2.0</summary>
+
+### Features
+
+* [ContactCenterInsights] new API for the View resource ([#4984](https://github.com/googleapis/google-cloud-php/issues/4984)) ([54a9de3](https://github.com/googleapis/google-cloud-php/commit/54a9de35279b872fc09c995576f8e90296e571b4))
+
+
+### Bug Fixes
+
+* owlbot copy excludes ([#4987](https://github.com/googleapis/google-cloud-php/issues/4987)) ([49e2a11](https://github.com/googleapis/google-cloud-php/commit/49e2a11239a30d9c11743a0ca7693f3cc51fce03))
+* remove deprecated aliases in double-nested protos ([#4997](https://github.com/googleapis/google-cloud-php/issues/4997)) ([c4c790c](https://github.com/googleapis/google-cloud-php/commit/c4c790cc33266848c8851c5ae557d326ad27fcf5))
+</details>
+
+<details><summary>google/cloud-container: 1.5.3</summary>
+
+
+</details>
+
+<details><summary>google/cloud-container-analysis: 0.1.3</summary>
+
+### Bug Fixes
+
+* [ContainerAnalysis] Modify the bazel.BUILD file by hand to include the compliance protos which are not autogenerated ([#4989](https://github.com/googleapis/google-cloud-php/issues/4989)) ([76cf4bb](https://github.com/googleapis/google-cloud-php/commit/76cf4bb19d5a431ff05e61fefba74a34a155d1ba))
+* owlbot copy excludes ([#4987](https://github.com/googleapis/google-cloud-php/issues/4987)) ([49e2a11](https://github.com/googleapis/google-cloud-php/commit/49e2a11239a30d9c11743a0ca7693f3cc51fce03))
+* remove deprecated aliases in double-nested protos ([#4997](https://github.com/googleapis/google-cloud-php/issues/4997)) ([c4c790c](https://github.com/googleapis/google-cloud-php/commit/c4c790cc33266848c8851c5ae557d326ad27fcf5))
+</details>
+
+<details><summary>google/cloud-core: 1.43.2</summary>
+
+### Bug Fixes
+
+* step ordering for component release ([#4813](https://github.com/googleapis/google-cloud-php/issues/4813)) ([b5109cf](https://github.com/googleapis/google-cloud-php/commit/b5109cfdc8e2b6032b96f1a99a50dd13dfcae356))
+</details>
+
+<details><summary>google/cloud-data-catalog: 1.0.6</summary>
+
+
+</details>
+
+<details><summary>google/cloud-data-fusion: 0.1.3</summary>
+
+
+</details>
+
+<details><summary>google/cloud-datalabeling: 0.1.2</summary>
+
+
+</details>
+
+<details><summary>google/cloud-dataflow: 0.1.3</summary>
+
+
+</details>
+
+<details><summary>google/cloud-dataproc: 2.4.1</summary>
+
+
+</details>
+
+<details><summary>google/cloud-dataproc-metastore: 0.2.3</summary>
+
+
+</details>
+
+<details><summary>google/cloud-datastore: 1.13.2</summary>
+
+
+</details>
+
+<details><summary>google/cloud-datastore-admin: 0.4.0</summary>
+
+### Features
+
+* [DatastoreAdmin] define Datastore -> Firestore in Datastore mode migration long running operation metadata ([#4979](https://github.com/googleapis/google-cloud-php/issues/4979)) ([7774f2b](https://github.com/googleapis/google-cloud-php/commit/7774f2bc8294c33b2c9961fdb813871a94155871))
+</details>
+
+<details><summary>google/cloud-debugger: 1.4.3</summary>
+
+
+</details>
+
+<details><summary>google/cloud-deploy: 0.1.3</summary>
+
+### Bug Fixes
+
+* owlbot copy excludes ([#4987](https://github.com/googleapis/google-cloud-php/issues/4987)) ([49e2a11](https://github.com/googleapis/google-cloud-php/commit/49e2a11239a30d9c11743a0ca7693f3cc51fce03))
+* remove deprecated aliases in double-nested protos ([#4997](https://github.com/googleapis/google-cloud-php/issues/4997)) ([c4c790c](https://github.com/googleapis/google-cloud-php/commit/c4c790cc33266848c8851c5ae557d326ad27fcf5))
+</details>
+
+<details><summary>google/cloud-dialogflow: 0.24.0</summary>
+
+### Features
+
+* added export documentation method feat: added filter in list documentations request feat: added option to import custom metadata from Google Cloud Storage in reload document request feat: added option to apply partial update to the smart messagin... ([#4853](https://github.com/googleapis/google-cloud-php/issues/4853)) ([6c3343d](https://github.com/googleapis/google-cloud-php/commit/6c3343d500a84cee5a2f13ce5c4ef4fa7920d1c1))
+</details>
+
+<details><summary>google/cloud-dlp: 1.3.1</summary>
+
+
+</details>
+
+<details><summary>google/cloud-dms: 0.2.4</summary>
+
+
+</details>
+
+<details><summary>google/cloud-document-ai: 0.1.2</summary>
+
+### Bug Fixes
+
+* owlbot copy excludes ([#4987](https://github.com/googleapis/google-cloud-php/issues/4987)) ([49e2a11](https://github.com/googleapis/google-cloud-php/commit/49e2a11239a30d9c11743a0ca7693f3cc51fce03))
+* remove deprecated aliases in double-nested protos ([#4997](https://github.com/googleapis/google-cloud-php/issues/4997)) ([c4c790c](https://github.com/googleapis/google-cloud-php/commit/c4c790cc33266848c8851c5ae557d326ad27fcf5))
+</details>
+
+<details><summary>google/cloud-domains: 0.1.2</summary>
+
+### Bug Fixes
+
+* owlbot copy excludes ([#4987](https://github.com/googleapis/google-cloud-php/issues/4987)) ([49e2a11](https://github.com/googleapis/google-cloud-php/commit/49e2a11239a30d9c11743a0ca7693f3cc51fce03))
+* remove deprecated aliases in double-nested protos ([#4997](https://github.com/googleapis/google-cloud-php/issues/4997)) ([c4c790c](https://github.com/googleapis/google-cloud-php/commit/c4c790cc33266848c8851c5ae557d326ad27fcf5))
+</details>
+
+<details><summary>google/cloud-error-reporting: 0.19.0</summary>
+
+### Features
+
+* [ErrorReporting] Updates from OwlBot ([#4937](https://github.com/googleapis/google-cloud-php/issues/4937)) ([f6f47fa](https://github.com/googleapis/google-cloud-php/commit/f6f47fa516fc40ea0014263266534da0540d9e72))
+</details>
+
+<details><summary>google/cloud-essential-contacts: 0.2.3</summary>
+
+
+</details>
+
+<details><summary>google/cloud-eventarc: 0.1.3</summary>
+
+
+</details>
+
+<details><summary>google/cloud-filestore: 0.1.2</summary>
+
+
+</details>
+
+<details><summary>google/cloud-firestore: 1.20.3</summary>
+
+### Bug Fixes
+
+* make partial veneer client excludes explicit ([#4995](https://github.com/googleapis/google-cloud-php/issues/4995)) ([8819eaa](https://github.com/googleapis/google-cloud-php/commit/8819eaa01e146ba40576750b47a22cbb8cb1407b))
+</details>
+
+<details><summary>google/cloud-functions: 0.2.0</summary>
+
+### Features
+
+* [Functions] Updates from OwlBot ([#4932](https://github.com/googleapis/google-cloud-php/issues/4932)) ([6abbb28](https://github.com/googleapis/google-cloud-php/commit/6abbb2858aacc44b45ffe3f1060f488566721509))
+
+
+### Bug Fixes
+
+* [Functions] service update ([#5010](https://github.com/googleapis/google-cloud-php/issues/5010)) ([e2efd54](https://github.com/googleapis/google-cloud-php/commit/e2efd54ae6aa92ed73a5107a59039249f30baca5))
+* owlbot copy excludes ([#4987](https://github.com/googleapis/google-cloud-php/issues/4987)) ([49e2a11](https://github.com/googleapis/google-cloud-php/commit/49e2a11239a30d9c11743a0ca7693f3cc51fce03))
+* remove deprecated aliases in double-nested protos ([#4997](https://github.com/googleapis/google-cloud-php/issues/4997)) ([c4c790c](https://github.com/googleapis/google-cloud-php/commit/c4c790cc33266848c8851c5ae557d326ad27fcf5))
+</details>
+
+<details><summary>google/cloud-game-servers: 0.4.0</summary>
+
+### Features
+
+* [Gaming] service update ([#5009](https://github.com/googleapis/google-cloud-php/issues/5009)) ([1b5756b](https://github.com/googleapis/google-cloud-php/commit/1b5756bfc66001e1e058bd915f1f147b60df180d))
+
+
+### Bug Fixes
+
+* owlbot copy excludes ([#4987](https://github.com/googleapis/google-cloud-php/issues/4987)) ([49e2a11](https://github.com/googleapis/google-cloud-php/commit/49e2a11239a30d9c11743a0ca7693f3cc51fce03))
+* remove deprecated aliases in double-nested protos ([#4997](https://github.com/googleapis/google-cloud-php/issues/4997)) ([c4c790c](https://github.com/googleapis/google-cloud-php/commit/c4c790cc33266848c8851c5ae557d326ad27fcf5))
+</details>
+
+<details><summary>google/cloud-gke-connect-gateway: 0.1.3</summary>
+
+
+</details>
+
+<details><summary>google/cloud-gke-hub: 0.2.3</summary>
+
+
+</details>
+
+<details><summary>google/grafeas: 0.2.1</summary>
+
+### Bug Fixes
+
+* [Grafeas] Modify the bazel.BUILD file by hand to include the compliance protos which are not autogenerated ([#4988](https://github.com/googleapis/google-cloud-php/issues/4988)) ([2da5f2b](https://github.com/googleapis/google-cloud-php/commit/2da5f2b35912bfbc6f6c6157882d11ac105140f3))
+* owlbot copy excludes ([#4987](https://github.com/googleapis/google-cloud-php/issues/4987)) ([49e2a11](https://github.com/googleapis/google-cloud-php/commit/49e2a11239a30d9c11743a0ca7693f3cc51fce03))
+* remove deprecated aliases in double-nested protos ([#4997](https://github.com/googleapis/google-cloud-php/issues/4997)) ([c4c790c](https://github.com/googleapis/google-cloud-php/commit/c4c790cc33266848c8851c5ae557d326ad27fcf5))
+</details>
+
+<details><summary>google/cloud-iam-credentials: 0.1.2</summary>
+
+### Bug Fixes
+
+* owlbot copy excludes ([#4987](https://github.com/googleapis/google-cloud-php/issues/4987)) ([49e2a11](https://github.com/googleapis/google-cloud-php/commit/49e2a11239a30d9c11743a0ca7693f3cc51fce03))
+* remove deprecated aliases in double-nested protos ([#4997](https://github.com/googleapis/google-cloud-php/issues/4997)) ([c4c790c](https://github.com/googleapis/google-cloud-php/commit/c4c790cc33266848c8851c5ae557d326ad27fcf5))
+</details>
+
+<details><summary>google/cloud-iap: 0.1.3</summary>
+
+
+</details>
+
+<details><summary>google/cloud-iot: 1.4.3</summary>
+
+
+</details>
+
+<details><summary>google/cloud-kms: 1.12.2</summary>
+
+
+</details>
+
+<details><summary>google/cloud-language: 0.26.3</summary>
+
+
+</details>
+
+<details><summary>google/cloud-life-sciences: 0.2.3</summary>
+
+
+</details>
+
+<details><summary>google/cloud-logging: 1.22.3</summary>
+
+
+</details>
+
+<details><summary>google/cloud-managed-identities: 0.1.2</summary>
+
+
+</details>
+
+<details><summary>google/cloud-media-translation: 0.2.3</summary>
+
+
+</details>
+
+<details><summary>google/cloud-memcache: 0.5.3</summary>
+
+
+</details>
+
+<details><summary>google/cloud-monitoring: 1.0.3</summary>
+
+
+</details>
+
+<details><summary>google/cloud-network-connectivity: 0.1.3</summary>
+
+
+</details>
+
+<details><summary>google/cloud-network-management: 0.1.3</summary>
+
+
+</details>
+
+<details><summary>google/cloud-network-security: 0.2.0</summary>
+
+### ⚠ BREAKING CHANGES
+
+* updating metadata messages for all long running operations (#4981)
+
+### Bug Fixes
+
+* owlbot copy excludes ([#4987](https://github.com/googleapis/google-cloud-php/issues/4987)) ([49e2a11](https://github.com/googleapis/google-cloud-php/commit/49e2a11239a30d9c11743a0ca7693f3cc51fce03))
+* remove deprecated aliases in double-nested protos ([#4997](https://github.com/googleapis/google-cloud-php/issues/4997)) ([c4c790c](https://github.com/googleapis/google-cloud-php/commit/c4c790cc33266848c8851c5ae557d326ad27fcf5))
+* updating metadata messages for all long running operations ([#4981](https://github.com/googleapis/google-cloud-php/issues/4981)) ([5a25584](https://github.com/googleapis/google-cloud-php/commit/5a25584349798e3604fea469c35a696594d8502e))
+</details>
+
+<details><summary>google/cloud-notebooks: 0.2.3</summary>
+
+
+</details>
+
+<details><summary>google/cloud-orchestration-airflow: 0.1.3</summary>
+
+
+</details>
+
+<details><summary>google/cloud-org-policy: 0.2.3</summary>
+
+
+</details>
+
+<details><summary>google/cloud-osconfig: 0.4.0</summary>
+
+### Features
+
+* [OsConfig] service update ([#5001](https://github.com/googleapis/google-cloud-php/issues/5001)) ([d726f30](https://github.com/googleapis/google-cloud-php/commit/d726f306729a5286931dae4ee7cd058bf2d07e4c))
+
+
+### Bug Fixes
+
+* owlbot copy excludes ([#4987](https://github.com/googleapis/google-cloud-php/issues/4987)) ([49e2a11](https://github.com/googleapis/google-cloud-php/commit/49e2a11239a30d9c11743a0ca7693f3cc51fce03))
+* remove deprecated aliases in double-nested protos ([#4997](https://github.com/googleapis/google-cloud-php/issues/4997)) ([c4c790c](https://github.com/googleapis/google-cloud-php/commit/c4c790cc33266848c8851c5ae557d326ad27fcf5))
+</details>
+
+<details><summary>google/cloud-oslogin: 1.3.3</summary>
+
+
+</details>
+
+<details><summary>google/cloud-policy-troubleshooter: 0.2.3</summary>
+
+
+</details>
+
+<details><summary>google/cloud-private-catalog: 0.2.3</summary>
+
+
+</details>
+
+<details><summary>google/cloud-profiler: 0.2.3</summary>
+
+
+</details>
+
+<details><summary>google/cloud-pubsub: 1.34.3</summary>
+
+
+</details>
+
+<details><summary>google/cloud-recaptcha-enterprise: 1.1.2</summary>
+
+
+</details>
+
+<details><summary>google/cloud-recommendations-ai: 0.4.0</summary>
+
+### Features
+
+* [RecommendationEngine] Updates from OwlBot ([#4903](https://github.com/googleapis/google-cloud-php/issues/4903)) ([f7fa368](https://github.com/googleapis/google-cloud-php/commit/f7fa368483ff8c8de60856a99aa174b6f591e5d2))
+
+
+### Bug Fixes
+
+* owlbot copy excludes ([#4987](https://github.com/googleapis/google-cloud-php/issues/4987)) ([49e2a11](https://github.com/googleapis/google-cloud-php/commit/49e2a11239a30d9c11743a0ca7693f3cc51fce03))
+* remove deprecated aliases in double-nested protos ([#4997](https://github.com/googleapis/google-cloud-php/issues/4997)) ([c4c790c](https://github.com/googleapis/google-cloud-php/commit/c4c790cc33266848c8851c5ae557d326ad27fcf5))
+</details>
+
+<details><summary>google/cloud-recommender: 1.5.3</summary>
+
+
+</details>
+
+<details><summary>google/cloud-redis: 1.4.1</summary>
+
+### Bug Fixes
+
+* make partial veneer client excludes explicit ([#4995](https://github.com/googleapis/google-cloud-php/issues/4995)) ([8819eaa](https://github.com/googleapis/google-cloud-php/commit/8819eaa01e146ba40576750b47a22cbb8cb1407b))
+</details>
+
+<details><summary>google/cloud-resource-manager: 0.2.3</summary>
+
+### Bug Fixes
+
+* owlbot copy excludes ([#4987](https://github.com/googleapis/google-cloud-php/issues/4987)) ([49e2a11](https://github.com/googleapis/google-cloud-php/commit/49e2a11239a30d9c11743a0ca7693f3cc51fce03))
+* remove deprecated aliases in double-nested protos ([#4997](https://github.com/googleapis/google-cloud-php/issues/4997)) ([c4c790c](https://github.com/googleapis/google-cloud-php/commit/c4c790cc33266848c8851c5ae557d326ad27fcf5))
+</details>
+
+<details><summary>google/cloud-resource-settings: 0.1.3</summary>
+
+### Bug Fixes
+
+* owlbot copy excludes ([#4987](https://github.com/googleapis/google-cloud-php/issues/4987)) ([49e2a11](https://github.com/googleapis/google-cloud-php/commit/49e2a11239a30d9c11743a0ca7693f3cc51fce03))
+* remove deprecated aliases in double-nested protos ([#4997](https://github.com/googleapis/google-cloud-php/issues/4997)) ([c4c790c](https://github.com/googleapis/google-cloud-php/commit/c4c790cc33266848c8851c5ae557d326ad27fcf5))
+</details>
+
+<details><summary>google/cloud-retail: 0.3.0</summary>
+
+### Features
+
+* [Retail] service update ([#5000](https://github.com/googleapis/google-cloud-php/issues/5000)) ([19dfe3b](https://github.com/googleapis/google-cloud-php/commit/19dfe3b81dd0a8c12044b02914b6ebbab0ec4e03))
+
+
+### Bug Fixes
+
+* owlbot copy excludes ([#4987](https://github.com/googleapis/google-cloud-php/issues/4987)) ([49e2a11](https://github.com/googleapis/google-cloud-php/commit/49e2a11239a30d9c11743a0ca7693f3cc51fce03))
+* remove deprecated aliases in double-nested protos ([#4997](https://github.com/googleapis/google-cloud-php/issues/4997)) ([c4c790c](https://github.com/googleapis/google-cloud-php/commit/c4c790cc33266848c8851c5ae557d326ad27fcf5))
+</details>
+
+<details><summary>google/cloud-scheduler: 1.6.0</summary>
+
+### Features
+
+* [Scheduler] Updates from OwlBot ([#4897](https://github.com/googleapis/google-cloud-php/issues/4897)) ([95de7e0](https://github.com/googleapis/google-cloud-php/commit/95de7e0f1bfb3e08a13af37d4c58550f4d7db874))
+</details>
+
+<details><summary>google/cloud-secret-manager: 1.7.3</summary>
+
+
+</details>
+
+<details><summary>google/cloud-security-center: 1.5.1</summary>
+
+
+</details>
+
+<details><summary>google/cloud-security-private-ca: 0.3.2</summary>
+
+### Bug Fixes
+
+* owlbot copy excludes ([#4987](https://github.com/googleapis/google-cloud-php/issues/4987)) ([49e2a11](https://github.com/googleapis/google-cloud-php/commit/49e2a11239a30d9c11743a0ca7693f3cc51fce03))
+* remove deprecated aliases in double-nested protos ([#4997](https://github.com/googleapis/google-cloud-php/issues/4997)) ([c4c790c](https://github.com/googleapis/google-cloud-php/commit/c4c790cc33266848c8851c5ae557d326ad27fcf5))
+</details>
+
+<details><summary>google/cloud-service-control: 0.3.3</summary>
+
+### Bug Fixes
+
+* owlbot copy excludes ([#4987](https://github.com/googleapis/google-cloud-php/issues/4987)) ([49e2a11](https://github.com/googleapis/google-cloud-php/commit/49e2a11239a30d9c11743a0ca7693f3cc51fce03))
+* remove deprecated aliases in double-nested protos ([#4997](https://github.com/googleapis/google-cloud-php/issues/4997)) ([c4c790c](https://github.com/googleapis/google-cloud-php/commit/c4c790cc33266848c8851c5ae557d326ad27fcf5))
+</details>
+
+<details><summary>google/cloud-service-directory: 0.6.3</summary>
+
+### Bug Fixes
+
+* owlbot copy excludes ([#4987](https://github.com/googleapis/google-cloud-php/issues/4987)) ([49e2a11](https://github.com/googleapis/google-cloud-php/commit/49e2a11239a30d9c11743a0ca7693f3cc51fce03))
+* remove deprecated aliases in double-nested protos ([#4997](https://github.com/googleapis/google-cloud-php/issues/4997)) ([c4c790c](https://github.com/googleapis/google-cloud-php/commit/c4c790cc33266848c8851c5ae557d326ad27fcf5))
+</details>
+
+<details><summary>google/cloud-service-management: 0.2.3</summary>
+
+### Bug Fixes
+
+* owlbot copy excludes ([#4987](https://github.com/googleapis/google-cloud-php/issues/4987)) ([49e2a11](https://github.com/googleapis/google-cloud-php/commit/49e2a11239a30d9c11743a0ca7693f3cc51fce03))
+* remove deprecated aliases in double-nested protos ([#4997](https://github.com/googleapis/google-cloud-php/issues/4997)) ([c4c790c](https://github.com/googleapis/google-cloud-php/commit/c4c790cc33266848c8851c5ae557d326ad27fcf5))
+</details>
+
+<details><summary>google/cloud-service-usage: 0.2.2</summary>
+
+### Bug Fixes
+
+* owlbot copy excludes ([#4987](https://github.com/googleapis/google-cloud-php/issues/4987)) ([49e2a11](https://github.com/googleapis/google-cloud-php/commit/49e2a11239a30d9c11743a0ca7693f3cc51fce03))
+* remove deprecated aliases in double-nested protos ([#4997](https://github.com/googleapis/google-cloud-php/issues/4997)) ([c4c790c](https://github.com/googleapis/google-cloud-php/commit/c4c790cc33266848c8851c5ae557d326ad27fcf5))
+</details>
+
+<details><summary>google/cloud-shell: 0.1.2</summary>
+
+### Bug Fixes
+
+* owlbot copy excludes ([#4987](https://github.com/googleapis/google-cloud-php/issues/4987)) ([49e2a11](https://github.com/googleapis/google-cloud-php/commit/49e2a11239a30d9c11743a0ca7693f3cc51fce03))
+* remove deprecated aliases in double-nested protos ([#4997](https://github.com/googleapis/google-cloud-php/issues/4997)) ([c4c790c](https://github.com/googleapis/google-cloud-php/commit/c4c790cc33266848c8851c5ae557d326ad27fcf5))
+</details>
+
+<details><summary>google/cloud-spanner: 1.46.3</summary>
+
+### Bug Fixes
+
+* [Spanner] exclude partial veneer SpannerClient from owlbot ([#4994](https://github.com/googleapis/google-cloud-php/issues/4994)) ([0f59589](https://github.com/googleapis/google-cloud-php/commit/0f5958976d944d868508e2b84b734010de03bfa6))
+</details>
+
+<details><summary>google/cloud-speech: 1.4.2</summary>
+
+### Bug Fixes
+
+* make partial veneer client excludes explicit ([#4995](https://github.com/googleapis/google-cloud-php/issues/4995)) ([8819eaa](https://github.com/googleapis/google-cloud-php/commit/8819eaa01e146ba40576750b47a22cbb8cb1407b))
+</details>
+
+<details><summary>google/cloud-sql-admin: 0.1.3</summary>
+
+### Bug Fixes
+
+* owlbot copy excludes ([#4987](https://github.com/googleapis/google-cloud-php/issues/4987)) ([49e2a11](https://github.com/googleapis/google-cloud-php/commit/49e2a11239a30d9c11743a0ca7693f3cc51fce03))
+* remove deprecated aliases in double-nested protos ([#4997](https://github.com/googleapis/google-cloud-php/issues/4997)) ([c4c790c](https://github.com/googleapis/google-cloud-php/commit/c4c790cc33266848c8851c5ae557d326ad27fcf5))
+</details>
+
+<details><summary>google/cloud-storage: 1.26.0</summary>
+
+### Features
+
+* added methods/tests for enabling Turbo Replication. ([#4543](https://github.com/googleapis/google-cloud-php/issues/4543)) ([d621cff](https://github.com/googleapis/google-cloud-php/commit/d621cffaf6a58ad0f8106cc4dadc068163db5d15))
+</details>
+
+<details><summary>google/cloud-storage-transfer: 0.1.3</summary>
+
+### Bug Fixes
+
+* owlbot copy excludes ([#4987](https://github.com/googleapis/google-cloud-php/issues/4987)) ([49e2a11](https://github.com/googleapis/google-cloud-php/commit/49e2a11239a30d9c11743a0ca7693f3cc51fce03))
+* remove deprecated aliases in double-nested protos ([#4997](https://github.com/googleapis/google-cloud-php/issues/4997)) ([c4c790c](https://github.com/googleapis/google-cloud-php/commit/c4c790cc33266848c8851c5ae557d326ad27fcf5))
+</details>
+
+<details><summary>google/cloud-talent: 0.16.2</summary>
+
+### Bug Fixes
+
+* owlbot copy excludes ([#4987](https://github.com/googleapis/google-cloud-php/issues/4987)) ([49e2a11](https://github.com/googleapis/google-cloud-php/commit/49e2a11239a30d9c11743a0ca7693f3cc51fce03))
+* remove deprecated aliases in double-nested protos ([#4997](https://github.com/googleapis/google-cloud-php/issues/4997)) ([c4c790c](https://github.com/googleapis/google-cloud-php/commit/c4c790cc33266848c8851c5ae557d326ad27fcf5))
+</details>
+
+<details><summary>google/cloud-tasks: 1.10.0</summary>
+
+### Features
+
+* [Tasks] Updates from OwlBot ([#4883](https://github.com/googleapis/google-cloud-php/issues/4883)) ([3296dd1](https://github.com/googleapis/google-cloud-php/commit/3296dd13e3b49276c1a45edc1d8d88703f0d9a9a))
+</details>
+
+<details><summary>google/cloud-text-to-speech: 1.3.3</summary>
+
+
+</details>
+
+<details><summary>google/cloud-tpu: 0.2.3</summary>
+
+### Bug Fixes
+
+* owlbot copy excludes ([#4987](https://github.com/googleapis/google-cloud-php/issues/4987)) ([49e2a11](https://github.com/googleapis/google-cloud-php/commit/49e2a11239a30d9c11743a0ca7693f3cc51fce03))
+* remove deprecated aliases in double-nested protos ([#4997](https://github.com/googleapis/google-cloud-php/issues/4997)) ([c4c790c](https://github.com/googleapis/google-cloud-php/commit/c4c790cc33266848c8851c5ae557d326ad27fcf5))
+</details>
+
+<details><summary>google/cloud-trace: 1.4.3</summary>
+
+
+</details>
+
+<details><summary>google/cloud-translate: 1.12.3</summary>
+
+### Bug Fixes
+
+* make partial veneer client excludes explicit ([#4995](https://github.com/googleapis/google-cloud-php/issues/4995)) ([8819eaa](https://github.com/googleapis/google-cloud-php/commit/8819eaa01e146ba40576750b47a22cbb8cb1407b))
+</details>
+
+<details><summary>google/cloud-videointelligence: 1.12.5</summary>
+
+
+</details>
+
+<details><summary>google/cloud-video-transcoder: 0.3.2</summary>
+
+### Bug Fixes
+
+* owlbot copy excludes ([#4987](https://github.com/googleapis/google-cloud-php/issues/4987)) ([49e2a11](https://github.com/googleapis/google-cloud-php/commit/49e2a11239a30d9c11743a0ca7693f3cc51fce03))
+* remove deprecated aliases in double-nested protos ([#4997](https://github.com/googleapis/google-cloud-php/issues/4997)) ([c4c790c](https://github.com/googleapis/google-cloud-php/commit/c4c790cc33266848c8851c5ae557d326ad27fcf5))
+</details>
+
+<details><summary>google/cloud-vision: 1.5.3</summary>
+
+
+</details>
+
+<details><summary>google/cloud-vpc-access: 0.2.3</summary>
+
+### Bug Fixes
+
+* owlbot copy excludes ([#4987](https://github.com/googleapis/google-cloud-php/issues/4987)) ([49e2a11](https://github.com/googleapis/google-cloud-php/commit/49e2a11239a30d9c11743a0ca7693f3cc51fce03))
+* remove deprecated aliases in double-nested protos ([#4997](https://github.com/googleapis/google-cloud-php/issues/4997)) ([c4c790c](https://github.com/googleapis/google-cloud-php/commit/c4c790cc33266848c8851c5ae557d326ad27fcf5))
+</details>
+
+<details><summary>google/cloud-web-risk: 1.1.3</summary>
+
+
+</details>
+
+<details><summary>google/cloud-web-security-scanner: 0.7.3</summary>
+
+### Bug Fixes
+
+* owlbot copy excludes ([#4987](https://github.com/googleapis/google-cloud-php/issues/4987)) ([49e2a11](https://github.com/googleapis/google-cloud-php/commit/49e2a11239a30d9c11743a0ca7693f3cc51fce03))
+* remove deprecated aliases in double-nested protos ([#4997](https://github.com/googleapis/google-cloud-php/issues/4997)) ([c4c790c](https://github.com/googleapis/google-cloud-php/commit/c4c790cc33266848c8851c5ae557d326ad27fcf5))
+</details>
+
+<details><summary>google/cloud-workflows: 0.2.3</summary>
+
+### Bug Fixes
+
+* owlbot copy excludes ([#4987](https://github.com/googleapis/google-cloud-php/issues/4987)) ([49e2a11](https://github.com/googleapis/google-cloud-php/commit/49e2a11239a30d9c11743a0ca7693f3cc51fce03))
+* remove deprecated aliases in double-nested protos ([#4997](https://github.com/googleapis/google-cloud-php/issues/4997)) ([c4c790c](https://github.com/googleapis/google-cloud-php/commit/c4c790cc33266848c8851c5ae557d326ad27fcf5))
+</details>
+`
+
 exports['PHPYoshi buildReleasePullRequest returns release PR changes with defaultInitialVersion 1'] = `
 :robot: I have created a release *beep* *boop*
 ---

--- a/src/strategies/base.ts
+++ b/src/strategies/base.ts
@@ -325,6 +325,12 @@ export abstract class BaseStrategy implements Strategy {
     return new Map();
   }
 
+  protected async parsePullRequestBody(
+    pullRequestBody: string
+  ): Promise<PullRequestBody | undefined> {
+    return PullRequestBody.parse(pullRequestBody);
+  }
+
   /**
    * Given a merged pull request, build the candidate release.
    * @param {PullRequest} mergedPullRequest The merged release pull request.
@@ -360,7 +366,9 @@ export abstract class BaseStrategy implements Strategy {
       logger.error(`Bad branch name: ${mergedPullRequest.headBranchName}`);
       return;
     }
-    const pullRequestBody = PullRequestBody.parse(mergedPullRequest.body);
+    const pullRequestBody = await this.parsePullRequestBody(
+      mergedPullRequest.body
+    );
     if (!pullRequestBody) {
       logger.error('Could not parse pull request body as a release PR');
       return;

--- a/src/strategies/php-yoshi.ts
+++ b/src/strategies/php-yoshi.ts
@@ -120,7 +120,7 @@ export class PHPYoshi extends BaseStrategy {
           }
         );
         releaseNotesBody = updatePHPChangelogEntry(
-          `${composer.name}: ${newVersion.toString()}`,
+          `${composer.name} ${newVersion.toString()}`,
           releaseNotesBody,
           partialReleaseNotes
         );
@@ -192,6 +192,29 @@ export class PHPYoshi extends BaseStrategy {
       version: newVersion,
       draft: draft ?? false,
     };
+  }
+
+  protected async parsePullRequestBody(
+    pullRequestBody: string
+  ): Promise<PullRequestBody | undefined> {
+    const body = PullRequestBody.parse(pullRequestBody);
+    if (!body) {
+      return undefined;
+    }
+    const component = await this.getComponent();
+    const notes = body.releaseData
+      .map(release => {
+        return `<details><summary>${
+          release.component
+        }: ${release.version?.toString()}</summary>\n\n${
+          release.notes
+        }\n</details>`;
+      })
+      .join('\n\n');
+    return new PullRequestBody([{component, notes}], {
+      footer: body.footer,
+      header: body.header,
+    });
   }
 
   protected async buildUpdates(

--- a/src/strategies/php-yoshi.ts
+++ b/src/strategies/php-yoshi.ts
@@ -120,7 +120,7 @@ export class PHPYoshi extends BaseStrategy {
           }
         );
         releaseNotesBody = updatePHPChangelogEntry(
-          `${composer.name} ${newVersion.toString()}`,
+          `${composer.name}: ${newVersion.toString()}`,
           releaseNotesBody,
           partialReleaseNotes
         );

--- a/src/util/pull-request-body.ts
+++ b/src/util/pull-request-body.ts
@@ -102,7 +102,7 @@ function splitBody(
   };
 }
 
-const SUMMARY_PATTERN = /^(?<component>.*): (?<version>\d+\.\d+\.\d+.*)$/;
+const SUMMARY_PATTERN = /^(?<component>.*[^:]):? (?<version>\d+\.\d+\.\d+.*)$/;
 export interface ReleaseData {
   component?: string;
   version?: Version;

--- a/test/fixtures/release-notes/legacy-php-yoshi.txt
+++ b/test/fixtures/release-notes/legacy-php-yoshi.txt
@@ -1,0 +1,957 @@
+:robot: I have created a release *beep* *boop*
+---
+
+
+## 0.173.0
+
+<details><summary>google/cloud-access-approval 0.3.0</summary>
+
+
+
+### Features
+
+* update client libraries to support Database operations ([#4977](https://github.com/googleapis/google-cloud-php/issues/4977)) ([731b051](https://github.com/googleapis/google-cloud-php/commit/731b051d9cd8c2ddea077fdd2719885bdf6a8925))
+
+</details>
+
+<details><summary>google/access-context-manager 0.2.0</summary>
+
+
+
+### Features
+
+* update client libraries to support Database operations ([#4976](https://github.com/googleapis/google-cloud-php/issues/4976)) ([3ce2080](https://github.com/googleapis/google-cloud-php/commit/3ce2080e1293f6c6b07bb03c9f816cbcd032ae3b))
+
+</details>
+
+<details><summary>google/analytics-admin 0.4.2</summary>
+
+
+
+</details>
+
+<details><summary>google/analytics-data 0.8.0</summary>
+
+
+
+### Features
+
+* [AnalyticsData] Updates from OwlBot ([#4974](https://github.com/googleapis/google-cloud-php/issues/4974)) ([841628c](https://github.com/googleapis/google-cloud-php/commit/841628c1e83a36f5671e1d1ef8c99d6f1f9e2d67))
+
+
+### Bug Fixes
+
+* owlbot copy excludes ([#4987](https://github.com/googleapis/google-cloud-php/issues/4987)) ([49e2a11](https://github.com/googleapis/google-cloud-php/commit/49e2a11239a30d9c11743a0ca7693f3cc51fce03))
+* remove deprecated aliases in double-nested protos ([#4997](https://github.com/googleapis/google-cloud-php/issues/4997)) ([c4c790c](https://github.com/googleapis/google-cloud-php/commit/c4c790cc33266848c8851c5ae557d326ad27fcf5))
+
+</details>
+
+<details><summary>google/cloud-api-gateway 0.2.0</summary>
+
+
+
+### Features
+
+* [ApiGateway] service update ([#5013](https://github.com/googleapis/google-cloud-php/issues/5013)) ([2cdda28](https://github.com/googleapis/google-cloud-php/commit/2cdda2871320b5c56eff7523fbe15aece1f6dbf3))
+
+</details>
+
+<details><summary>google/cloud-apigee-connect 0.2.3</summary>
+
+
+
+</details>
+
+<details><summary>google/cloud-appengine-admin 0.2.3</summary>
+
+
+
+</details>
+
+<details><summary>google/cloud-artifact-registry 0.1.3</summary>
+
+
+
+</details>
+
+<details><summary>google/cloud-asset 1.6.3</summary>
+
+
+
+</details>
+
+<details><summary>google/cloud-assured-workloads 0.5.0</summary>
+
+
+
+### Features
+
+* [AssuredWorkloads] service updates ([#5004](https://github.com/googleapis/google-cloud-php/issues/5004)) ([881b79e](https://github.com/googleapis/google-cloud-php/commit/881b79e72fd6d11075775d5ce16231a363baafe2))
+
+</details>
+
+<details><summary>google/cloud-automl 1.4.2</summary>
+
+
+
+</details>
+
+<details><summary>google/cloud-bigquery-connection 0.5.3</summary>
+
+
+
+</details>
+
+<details><summary>google/cloud-bigquerydatatransfer 1.2.6</summary>
+
+
+
+</details>
+
+<details><summary>google/cloud-bigquery-reservation 0.5.0</summary>
+
+
+
+### Features
+
+* increase the logical timeout (retry deadline) to 5 minutes ([#4864](https://github.com/googleapis/google-cloud-php/issues/4864)) ([52130ee](https://github.com/googleapis/google-cloud-php/commit/52130ee60f03c61ef0ada04c31b1268af87bacb6))
+
+</details>
+
+<details><summary>google/cloud-bigquery-storage 1.2.2</summary>
+
+
+
+</details>
+
+<details><summary>google/cloud-bigtable 1.11.3</summary>
+
+
+
+### Bug Fixes
+
+* make partial veneer client excludes explicit ([#4995](https://github.com/googleapis/google-cloud-php/issues/4995)) ([8819eaa](https://github.com/googleapis/google-cloud-php/commit/8819eaa01e146ba40576750b47a22cbb8cb1407b))
+
+</details>
+
+<details><summary>google/cloud-billing 1.3.3</summary>
+
+
+
+</details>
+
+<details><summary>google/cloud-billing-budgets 0.2.3</summary>
+
+
+
+</details>
+
+<details><summary>google/cloud-binary-authorization 0.4.0</summary>
+
+
+
+### Features
+
+* [BinaryAuthorization] update client libraries to support Database operations ([#4959](https://github.com/googleapis/google-cloud-php/issues/4959)) ([a76716a](https://github.com/googleapis/google-cloud-php/commit/a76716ad8d333204bad2c8ac9cc6672b068242c7))
+
+</details>
+
+<details><summary>google/cloud-build 0.2.0</summary>
+
+
+
+### Features
+
+* [Build] update client libraries to support Database operations ([#4958](https://github.com/googleapis/google-cloud-php/issues/4958)) ([bd76f9e](https://github.com/googleapis/google-cloud-php/commit/bd76f9e8ca0a5035f66d419d7ad61c5ec57b49ae))
+
+
+### Bug Fixes
+
+* [Build] autoload for metadata classes ([#4991](https://github.com/googleapis/google-cloud-php/issues/4991)) ([7dad428](https://github.com/googleapis/google-cloud-php/commit/7dad428f26771c98adc45a72d4ff66c40f2d8208))
+
+</details>
+
+<details><summary>google/cloud-channel 0.6.0</summary>
+
+
+
+### Features
+
+* [Channel] update client libraries to support Database operations ([#4957](https://github.com/googleapis/google-cloud-php/issues/4957)) ([5a43585](https://github.com/googleapis/google-cloud-php/commit/5a43585ce3a0281b50dc78b7a403673443f95838))
+
+</details>
+
+<details><summary>google/cloud-common-protos 0.3.0</summary>
+
+
+
+### Features
+
+* update common-protos and add common/operation_metadata.proto ([#4837](https://github.com/googleapis/google-cloud-php/issues/4837)) ([8eea01c](https://github.com/googleapis/google-cloud-php/commit/8eea01c549613ea391a0fa043d717f4e14891894))
+
+</details>
+
+<details><summary>google/cloud-compute 0.6.0</summary>
+
+
+
+### Features
+
+* Update gapic-generator-php to v1.3.0 ([#4978](https://github.com/googleapis/google-cloud-php/issues/4978)) ([96d6c1e](https://github.com/googleapis/google-cloud-php/commit/96d6c1e4a32357a6e7afc8a9329349e9ba4f69f1))
+
+
+### Bug Fixes
+
+* remove deprecated aliases in double-nested protos ([#4997](https://github.com/googleapis/google-cloud-php/issues/4997)) ([c4c790c](https://github.com/googleapis/google-cloud-php/commit/c4c790cc33266848c8851c5ae557d326ad27fcf5))
+
+</details>
+
+<details><summary>google/cloud-contact-center-insights 0.2.0</summary>
+
+
+
+### Features
+
+* [ContactCenterInsights] new API for the View resource ([#4984](https://github.com/googleapis/google-cloud-php/issues/4984)) ([54a9de3](https://github.com/googleapis/google-cloud-php/commit/54a9de35279b872fc09c995576f8e90296e571b4))
+
+
+### Bug Fixes
+
+* owlbot copy excludes ([#4987](https://github.com/googleapis/google-cloud-php/issues/4987)) ([49e2a11](https://github.com/googleapis/google-cloud-php/commit/49e2a11239a30d9c11743a0ca7693f3cc51fce03))
+* remove deprecated aliases in double-nested protos ([#4997](https://github.com/googleapis/google-cloud-php/issues/4997)) ([c4c790c](https://github.com/googleapis/google-cloud-php/commit/c4c790cc33266848c8851c5ae557d326ad27fcf5))
+
+</details>
+
+<details><summary>google/cloud-container 1.5.3</summary>
+
+
+
+</details>
+
+<details><summary>google/cloud-container-analysis 0.1.3</summary>
+
+
+
+### Bug Fixes
+
+* [ContainerAnalysis] Modify the bazel.BUILD file by hand to include the compliance protos which are not autogenerated ([#4989](https://github.com/googleapis/google-cloud-php/issues/4989)) ([76cf4bb](https://github.com/googleapis/google-cloud-php/commit/76cf4bb19d5a431ff05e61fefba74a34a155d1ba))
+* owlbot copy excludes ([#4987](https://github.com/googleapis/google-cloud-php/issues/4987)) ([49e2a11](https://github.com/googleapis/google-cloud-php/commit/49e2a11239a30d9c11743a0ca7693f3cc51fce03))
+* remove deprecated aliases in double-nested protos ([#4997](https://github.com/googleapis/google-cloud-php/issues/4997)) ([c4c790c](https://github.com/googleapis/google-cloud-php/commit/c4c790cc33266848c8851c5ae557d326ad27fcf5))
+
+</details>
+
+<details><summary>google/cloud-core 1.43.2</summary>
+
+
+
+### Bug Fixes
+
+* step ordering for component release ([#4813](https://github.com/googleapis/google-cloud-php/issues/4813)) ([b5109cf](https://github.com/googleapis/google-cloud-php/commit/b5109cfdc8e2b6032b96f1a99a50dd13dfcae356))
+
+</details>
+
+<details><summary>google/cloud-data-catalog 1.0.6</summary>
+
+
+
+</details>
+
+<details><summary>google/cloud-data-fusion 0.1.3</summary>
+
+
+
+</details>
+
+<details><summary>google/cloud-datalabeling 0.1.2</summary>
+
+
+
+</details>
+
+<details><summary>google/cloud-dataflow 0.1.3</summary>
+
+
+
+</details>
+
+<details><summary>google/cloud-dataproc 2.4.1</summary>
+
+
+
+</details>
+
+<details><summary>google/cloud-dataproc-metastore 0.2.3</summary>
+
+
+
+</details>
+
+<details><summary>google/cloud-datastore 1.13.2</summary>
+
+
+
+</details>
+
+<details><summary>google/cloud-datastore-admin 0.4.0</summary>
+
+
+
+### Features
+
+* [DatastoreAdmin] define Datastore -> Firestore in Datastore mode migration long running operation metadata ([#4979](https://github.com/googleapis/google-cloud-php/issues/4979)) ([7774f2b](https://github.com/googleapis/google-cloud-php/commit/7774f2bc8294c33b2c9961fdb813871a94155871))
+
+</details>
+
+<details><summary>google/cloud-debugger 1.4.3</summary>
+
+
+
+</details>
+
+<details><summary>google/cloud-deploy 0.1.3</summary>
+
+
+
+### Bug Fixes
+
+* owlbot copy excludes ([#4987](https://github.com/googleapis/google-cloud-php/issues/4987)) ([49e2a11](https://github.com/googleapis/google-cloud-php/commit/49e2a11239a30d9c11743a0ca7693f3cc51fce03))
+* remove deprecated aliases in double-nested protos ([#4997](https://github.com/googleapis/google-cloud-php/issues/4997)) ([c4c790c](https://github.com/googleapis/google-cloud-php/commit/c4c790cc33266848c8851c5ae557d326ad27fcf5))
+
+</details>
+
+<details><summary>google/cloud-dialogflow 0.24.0</summary>
+
+
+
+### Features
+
+* added export documentation method feat: added filter in list documentations request feat: added option to import custom metadata from Google Cloud Storage in reload document request feat: added option to apply partial update to the smart messagin... ([#4853](https://github.com/googleapis/google-cloud-php/issues/4853)) ([6c3343d](https://github.com/googleapis/google-cloud-php/commit/6c3343d500a84cee5a2f13ce5c4ef4fa7920d1c1))
+
+</details>
+
+<details><summary>google/cloud-dlp 1.3.1</summary>
+
+
+
+</details>
+
+<details><summary>google/cloud-dms 0.2.4</summary>
+
+
+
+</details>
+
+<details><summary>google/cloud-document-ai 0.1.2</summary>
+
+
+
+### Bug Fixes
+
+* owlbot copy excludes ([#4987](https://github.com/googleapis/google-cloud-php/issues/4987)) ([49e2a11](https://github.com/googleapis/google-cloud-php/commit/49e2a11239a30d9c11743a0ca7693f3cc51fce03))
+* remove deprecated aliases in double-nested protos ([#4997](https://github.com/googleapis/google-cloud-php/issues/4997)) ([c4c790c](https://github.com/googleapis/google-cloud-php/commit/c4c790cc33266848c8851c5ae557d326ad27fcf5))
+
+</details>
+
+<details><summary>google/cloud-domains 0.1.2</summary>
+
+
+
+### Bug Fixes
+
+* owlbot copy excludes ([#4987](https://github.com/googleapis/google-cloud-php/issues/4987)) ([49e2a11](https://github.com/googleapis/google-cloud-php/commit/49e2a11239a30d9c11743a0ca7693f3cc51fce03))
+* remove deprecated aliases in double-nested protos ([#4997](https://github.com/googleapis/google-cloud-php/issues/4997)) ([c4c790c](https://github.com/googleapis/google-cloud-php/commit/c4c790cc33266848c8851c5ae557d326ad27fcf5))
+
+</details>
+
+<details><summary>google/cloud-error-reporting 0.19.0</summary>
+
+
+
+### Features
+
+* [ErrorReporting] Updates from OwlBot ([#4937](https://github.com/googleapis/google-cloud-php/issues/4937)) ([f6f47fa](https://github.com/googleapis/google-cloud-php/commit/f6f47fa516fc40ea0014263266534da0540d9e72))
+
+</details>
+
+<details><summary>google/cloud-essential-contacts 0.2.3</summary>
+
+
+
+</details>
+
+<details><summary>google/cloud-eventarc 0.1.3</summary>
+
+
+
+</details>
+
+<details><summary>google/cloud-filestore 0.1.2</summary>
+
+
+
+</details>
+
+<details><summary>google/cloud-firestore 1.20.3</summary>
+
+
+
+### Bug Fixes
+
+* make partial veneer client excludes explicit ([#4995](https://github.com/googleapis/google-cloud-php/issues/4995)) ([8819eaa](https://github.com/googleapis/google-cloud-php/commit/8819eaa01e146ba40576750b47a22cbb8cb1407b))
+
+</details>
+
+<details><summary>google/cloud-functions 0.2.0</summary>
+
+
+
+### Features
+
+* [Functions] Updates from OwlBot ([#4932](https://github.com/googleapis/google-cloud-php/issues/4932)) ([6abbb28](https://github.com/googleapis/google-cloud-php/commit/6abbb2858aacc44b45ffe3f1060f488566721509))
+
+
+### Bug Fixes
+
+* [Functions] service update ([#5010](https://github.com/googleapis/google-cloud-php/issues/5010)) ([e2efd54](https://github.com/googleapis/google-cloud-php/commit/e2efd54ae6aa92ed73a5107a59039249f30baca5))
+* owlbot copy excludes ([#4987](https://github.com/googleapis/google-cloud-php/issues/4987)) ([49e2a11](https://github.com/googleapis/google-cloud-php/commit/49e2a11239a30d9c11743a0ca7693f3cc51fce03))
+* remove deprecated aliases in double-nested protos ([#4997](https://github.com/googleapis/google-cloud-php/issues/4997)) ([c4c790c](https://github.com/googleapis/google-cloud-php/commit/c4c790cc33266848c8851c5ae557d326ad27fcf5))
+
+</details>
+
+<details><summary>google/cloud-game-servers 0.4.0</summary>
+
+
+
+### Features
+
+* [Gaming] service update ([#5009](https://github.com/googleapis/google-cloud-php/issues/5009)) ([1b5756b](https://github.com/googleapis/google-cloud-php/commit/1b5756bfc66001e1e058bd915f1f147b60df180d))
+
+
+### Bug Fixes
+
+* owlbot copy excludes ([#4987](https://github.com/googleapis/google-cloud-php/issues/4987)) ([49e2a11](https://github.com/googleapis/google-cloud-php/commit/49e2a11239a30d9c11743a0ca7693f3cc51fce03))
+* remove deprecated aliases in double-nested protos ([#4997](https://github.com/googleapis/google-cloud-php/issues/4997)) ([c4c790c](https://github.com/googleapis/google-cloud-php/commit/c4c790cc33266848c8851c5ae557d326ad27fcf5))
+
+</details>
+
+<details><summary>google/cloud-gke-connect-gateway 0.1.3</summary>
+
+
+
+</details>
+
+<details><summary>google/cloud-gke-hub 0.2.3</summary>
+
+
+
+</details>
+
+<details><summary>google/grafeas 0.2.1</summary>
+
+
+
+### Bug Fixes
+
+* [Grafeas] Modify the bazel.BUILD file by hand to include the compliance protos which are not autogenerated ([#4988](https://github.com/googleapis/google-cloud-php/issues/4988)) ([2da5f2b](https://github.com/googleapis/google-cloud-php/commit/2da5f2b35912bfbc6f6c6157882d11ac105140f3))
+* owlbot copy excludes ([#4987](https://github.com/googleapis/google-cloud-php/issues/4987)) ([49e2a11](https://github.com/googleapis/google-cloud-php/commit/49e2a11239a30d9c11743a0ca7693f3cc51fce03))
+* remove deprecated aliases in double-nested protos ([#4997](https://github.com/googleapis/google-cloud-php/issues/4997)) ([c4c790c](https://github.com/googleapis/google-cloud-php/commit/c4c790cc33266848c8851c5ae557d326ad27fcf5))
+
+</details>
+
+<details><summary>google/cloud-iam-credentials 0.1.2</summary>
+
+
+
+### Bug Fixes
+
+* owlbot copy excludes ([#4987](https://github.com/googleapis/google-cloud-php/issues/4987)) ([49e2a11](https://github.com/googleapis/google-cloud-php/commit/49e2a11239a30d9c11743a0ca7693f3cc51fce03))
+* remove deprecated aliases in double-nested protos ([#4997](https://github.com/googleapis/google-cloud-php/issues/4997)) ([c4c790c](https://github.com/googleapis/google-cloud-php/commit/c4c790cc33266848c8851c5ae557d326ad27fcf5))
+
+</details>
+
+<details><summary>google/cloud-iap 0.1.3</summary>
+
+
+
+</details>
+
+<details><summary>google/cloud-iot 1.4.3</summary>
+
+
+
+</details>
+
+<details><summary>google/cloud-kms 1.12.2</summary>
+
+
+
+</details>
+
+<details><summary>google/cloud-language 0.26.3</summary>
+
+
+
+</details>
+
+<details><summary>google/cloud-life-sciences 0.2.3</summary>
+
+
+
+</details>
+
+<details><summary>google/cloud-logging 1.22.3</summary>
+
+
+
+</details>
+
+<details><summary>google/cloud-managed-identities 0.1.2</summary>
+
+
+
+</details>
+
+<details><summary>google/cloud-media-translation 0.2.3</summary>
+
+
+
+</details>
+
+<details><summary>google/cloud-memcache 0.5.3</summary>
+
+
+
+</details>
+
+<details><summary>google/cloud-monitoring 1.0.3</summary>
+
+
+
+</details>
+
+<details><summary>google/cloud-network-connectivity 0.1.3</summary>
+
+
+
+</details>
+
+<details><summary>google/cloud-network-management 0.1.3</summary>
+
+
+
+</details>
+
+<details><summary>google/cloud-network-security 0.2.0</summary>
+
+
+
+### ⚠ BREAKING CHANGES
+
+* updating metadata messages for all long running operations (#4981)
+
+### Bug Fixes
+
+* owlbot copy excludes ([#4987](https://github.com/googleapis/google-cloud-php/issues/4987)) ([49e2a11](https://github.com/googleapis/google-cloud-php/commit/49e2a11239a30d9c11743a0ca7693f3cc51fce03))
+* remove deprecated aliases in double-nested protos ([#4997](https://github.com/googleapis/google-cloud-php/issues/4997)) ([c4c790c](https://github.com/googleapis/google-cloud-php/commit/c4c790cc33266848c8851c5ae557d326ad27fcf5))
+* updating metadata messages for all long running operations ([#4981](https://github.com/googleapis/google-cloud-php/issues/4981)) ([5a25584](https://github.com/googleapis/google-cloud-php/commit/5a25584349798e3604fea469c35a696594d8502e))
+
+</details>
+
+<details><summary>google/cloud-notebooks 0.2.3</summary>
+
+
+
+</details>
+
+<details><summary>google/cloud-orchestration-airflow 0.1.3</summary>
+
+
+
+</details>
+
+<details><summary>google/cloud-org-policy 0.2.3</summary>
+
+
+
+</details>
+
+<details><summary>google/cloud-osconfig 0.4.0</summary>
+
+
+
+### Features
+
+* [OsConfig] service update ([#5001](https://github.com/googleapis/google-cloud-php/issues/5001)) ([d726f30](https://github.com/googleapis/google-cloud-php/commit/d726f306729a5286931dae4ee7cd058bf2d07e4c))
+
+
+### Bug Fixes
+
+* owlbot copy excludes ([#4987](https://github.com/googleapis/google-cloud-php/issues/4987)) ([49e2a11](https://github.com/googleapis/google-cloud-php/commit/49e2a11239a30d9c11743a0ca7693f3cc51fce03))
+* remove deprecated aliases in double-nested protos ([#4997](https://github.com/googleapis/google-cloud-php/issues/4997)) ([c4c790c](https://github.com/googleapis/google-cloud-php/commit/c4c790cc33266848c8851c5ae557d326ad27fcf5))
+
+</details>
+
+<details><summary>google/cloud-oslogin 1.3.3</summary>
+
+
+
+</details>
+
+<details><summary>google/cloud-policy-troubleshooter 0.2.3</summary>
+
+
+
+</details>
+
+<details><summary>google/cloud-private-catalog 0.2.3</summary>
+
+
+
+</details>
+
+<details><summary>google/cloud-profiler 0.2.3</summary>
+
+
+
+</details>
+
+<details><summary>google/cloud-pubsub 1.34.3</summary>
+
+
+
+</details>
+
+<details><summary>google/cloud-recaptcha-enterprise 1.1.2</summary>
+
+
+
+</details>
+
+<details><summary>google/cloud-recommendations-ai 0.4.0</summary>
+
+
+
+### Features
+
+* [RecommendationEngine] Updates from OwlBot ([#4903](https://github.com/googleapis/google-cloud-php/issues/4903)) ([f7fa368](https://github.com/googleapis/google-cloud-php/commit/f7fa368483ff8c8de60856a99aa174b6f591e5d2))
+
+
+### Bug Fixes
+
+* owlbot copy excludes ([#4987](https://github.com/googleapis/google-cloud-php/issues/4987)) ([49e2a11](https://github.com/googleapis/google-cloud-php/commit/49e2a11239a30d9c11743a0ca7693f3cc51fce03))
+* remove deprecated aliases in double-nested protos ([#4997](https://github.com/googleapis/google-cloud-php/issues/4997)) ([c4c790c](https://github.com/googleapis/google-cloud-php/commit/c4c790cc33266848c8851c5ae557d326ad27fcf5))
+
+</details>
+
+<details><summary>google/cloud-recommender 1.5.3</summary>
+
+
+
+</details>
+
+<details><summary>google/cloud-redis 1.4.1</summary>
+
+
+
+### Bug Fixes
+
+* make partial veneer client excludes explicit ([#4995](https://github.com/googleapis/google-cloud-php/issues/4995)) ([8819eaa](https://github.com/googleapis/google-cloud-php/commit/8819eaa01e146ba40576750b47a22cbb8cb1407b))
+
+</details>
+
+<details><summary>google/cloud-resource-manager 0.2.3</summary>
+
+
+
+### Bug Fixes
+
+* owlbot copy excludes ([#4987](https://github.com/googleapis/google-cloud-php/issues/4987)) ([49e2a11](https://github.com/googleapis/google-cloud-php/commit/49e2a11239a30d9c11743a0ca7693f3cc51fce03))
+* remove deprecated aliases in double-nested protos ([#4997](https://github.com/googleapis/google-cloud-php/issues/4997)) ([c4c790c](https://github.com/googleapis/google-cloud-php/commit/c4c790cc33266848c8851c5ae557d326ad27fcf5))
+
+</details>
+
+<details><summary>google/cloud-resource-settings 0.1.3</summary>
+
+
+
+### Bug Fixes
+
+* owlbot copy excludes ([#4987](https://github.com/googleapis/google-cloud-php/issues/4987)) ([49e2a11](https://github.com/googleapis/google-cloud-php/commit/49e2a11239a30d9c11743a0ca7693f3cc51fce03))
+* remove deprecated aliases in double-nested protos ([#4997](https://github.com/googleapis/google-cloud-php/issues/4997)) ([c4c790c](https://github.com/googleapis/google-cloud-php/commit/c4c790cc33266848c8851c5ae557d326ad27fcf5))
+
+</details>
+
+<details><summary>google/cloud-retail 0.3.0</summary>
+
+
+
+### Features
+
+* [Retail] service update ([#5000](https://github.com/googleapis/google-cloud-php/issues/5000)) ([19dfe3b](https://github.com/googleapis/google-cloud-php/commit/19dfe3b81dd0a8c12044b02914b6ebbab0ec4e03))
+
+
+### Bug Fixes
+
+* owlbot copy excludes ([#4987](https://github.com/googleapis/google-cloud-php/issues/4987)) ([49e2a11](https://github.com/googleapis/google-cloud-php/commit/49e2a11239a30d9c11743a0ca7693f3cc51fce03))
+* remove deprecated aliases in double-nested protos ([#4997](https://github.com/googleapis/google-cloud-php/issues/4997)) ([c4c790c](https://github.com/googleapis/google-cloud-php/commit/c4c790cc33266848c8851c5ae557d326ad27fcf5))
+
+</details>
+
+<details><summary>google/cloud-scheduler 1.6.0</summary>
+
+
+
+### Features
+
+* [Scheduler] Updates from OwlBot ([#4897](https://github.com/googleapis/google-cloud-php/issues/4897)) ([95de7e0](https://github.com/googleapis/google-cloud-php/commit/95de7e0f1bfb3e08a13af37d4c58550f4d7db874))
+
+</details>
+
+<details><summary>google/cloud-secret-manager 1.7.3</summary>
+
+
+
+</details>
+
+<details><summary>google/cloud-security-center 1.5.1</summary>
+
+
+
+</details>
+
+<details><summary>google/cloud-security-private-ca 0.3.2</summary>
+
+
+
+### Bug Fixes
+
+* owlbot copy excludes ([#4987](https://github.com/googleapis/google-cloud-php/issues/4987)) ([49e2a11](https://github.com/googleapis/google-cloud-php/commit/49e2a11239a30d9c11743a0ca7693f3cc51fce03))
+* remove deprecated aliases in double-nested protos ([#4997](https://github.com/googleapis/google-cloud-php/issues/4997)) ([c4c790c](https://github.com/googleapis/google-cloud-php/commit/c4c790cc33266848c8851c5ae557d326ad27fcf5))
+
+</details>
+
+<details><summary>google/cloud-service-control 0.3.3</summary>
+
+
+
+### Bug Fixes
+
+* owlbot copy excludes ([#4987](https://github.com/googleapis/google-cloud-php/issues/4987)) ([49e2a11](https://github.com/googleapis/google-cloud-php/commit/49e2a11239a30d9c11743a0ca7693f3cc51fce03))
+* remove deprecated aliases in double-nested protos ([#4997](https://github.com/googleapis/google-cloud-php/issues/4997)) ([c4c790c](https://github.com/googleapis/google-cloud-php/commit/c4c790cc33266848c8851c5ae557d326ad27fcf5))
+
+</details>
+
+<details><summary>google/cloud-service-directory 0.6.3</summary>
+
+
+
+### Bug Fixes
+
+* owlbot copy excludes ([#4987](https://github.com/googleapis/google-cloud-php/issues/4987)) ([49e2a11](https://github.com/googleapis/google-cloud-php/commit/49e2a11239a30d9c11743a0ca7693f3cc51fce03))
+* remove deprecated aliases in double-nested protos ([#4997](https://github.com/googleapis/google-cloud-php/issues/4997)) ([c4c790c](https://github.com/googleapis/google-cloud-php/commit/c4c790cc33266848c8851c5ae557d326ad27fcf5))
+
+</details>
+
+<details><summary>google/cloud-service-management 0.2.3</summary>
+
+
+
+### Bug Fixes
+
+* owlbot copy excludes ([#4987](https://github.com/googleapis/google-cloud-php/issues/4987)) ([49e2a11](https://github.com/googleapis/google-cloud-php/commit/49e2a11239a30d9c11743a0ca7693f3cc51fce03))
+* remove deprecated aliases in double-nested protos ([#4997](https://github.com/googleapis/google-cloud-php/issues/4997)) ([c4c790c](https://github.com/googleapis/google-cloud-php/commit/c4c790cc33266848c8851c5ae557d326ad27fcf5))
+
+</details>
+
+<details><summary>google/cloud-service-usage 0.2.2</summary>
+
+
+
+### Bug Fixes
+
+* owlbot copy excludes ([#4987](https://github.com/googleapis/google-cloud-php/issues/4987)) ([49e2a11](https://github.com/googleapis/google-cloud-php/commit/49e2a11239a30d9c11743a0ca7693f3cc51fce03))
+* remove deprecated aliases in double-nested protos ([#4997](https://github.com/googleapis/google-cloud-php/issues/4997)) ([c4c790c](https://github.com/googleapis/google-cloud-php/commit/c4c790cc33266848c8851c5ae557d326ad27fcf5))
+
+</details>
+
+<details><summary>google/cloud-shell 0.1.2</summary>
+
+
+
+### Bug Fixes
+
+* owlbot copy excludes ([#4987](https://github.com/googleapis/google-cloud-php/issues/4987)) ([49e2a11](https://github.com/googleapis/google-cloud-php/commit/49e2a11239a30d9c11743a0ca7693f3cc51fce03))
+* remove deprecated aliases in double-nested protos ([#4997](https://github.com/googleapis/google-cloud-php/issues/4997)) ([c4c790c](https://github.com/googleapis/google-cloud-php/commit/c4c790cc33266848c8851c5ae557d326ad27fcf5))
+
+</details>
+
+<details><summary>google/cloud-spanner 1.46.3</summary>
+
+
+
+### Bug Fixes
+
+* [Spanner] exclude partial veneer SpannerClient from owlbot ([#4994](https://github.com/googleapis/google-cloud-php/issues/4994)) ([0f59589](https://github.com/googleapis/google-cloud-php/commit/0f5958976d944d868508e2b84b734010de03bfa6))
+
+</details>
+
+<details><summary>google/cloud-speech 1.4.2</summary>
+
+
+
+### Bug Fixes
+
+* make partial veneer client excludes explicit ([#4995](https://github.com/googleapis/google-cloud-php/issues/4995)) ([8819eaa](https://github.com/googleapis/google-cloud-php/commit/8819eaa01e146ba40576750b47a22cbb8cb1407b))
+
+</details>
+
+<details><summary>google/cloud-sql-admin 0.1.3</summary>
+
+
+
+### Bug Fixes
+
+* owlbot copy excludes ([#4987](https://github.com/googleapis/google-cloud-php/issues/4987)) ([49e2a11](https://github.com/googleapis/google-cloud-php/commit/49e2a11239a30d9c11743a0ca7693f3cc51fce03))
+* remove deprecated aliases in double-nested protos ([#4997](https://github.com/googleapis/google-cloud-php/issues/4997)) ([c4c790c](https://github.com/googleapis/google-cloud-php/commit/c4c790cc33266848c8851c5ae557d326ad27fcf5))
+
+</details>
+
+<details><summary>google/cloud-storage 1.26.0</summary>
+
+
+
+### Features
+
+* added methods/tests for enabling Turbo Replication. ([#4543](https://github.com/googleapis/google-cloud-php/issues/4543)) ([d621cff](https://github.com/googleapis/google-cloud-php/commit/d621cffaf6a58ad0f8106cc4dadc068163db5d15))
+
+</details>
+
+<details><summary>google/cloud-storage-transfer 0.1.3</summary>
+
+
+
+### Bug Fixes
+
+* owlbot copy excludes ([#4987](https://github.com/googleapis/google-cloud-php/issues/4987)) ([49e2a11](https://github.com/googleapis/google-cloud-php/commit/49e2a11239a30d9c11743a0ca7693f3cc51fce03))
+* remove deprecated aliases in double-nested protos ([#4997](https://github.com/googleapis/google-cloud-php/issues/4997)) ([c4c790c](https://github.com/googleapis/google-cloud-php/commit/c4c790cc33266848c8851c5ae557d326ad27fcf5))
+
+</details>
+
+<details><summary>google/cloud-talent 0.16.2</summary>
+
+
+
+### Bug Fixes
+
+* owlbot copy excludes ([#4987](https://github.com/googleapis/google-cloud-php/issues/4987)) ([49e2a11](https://github.com/googleapis/google-cloud-php/commit/49e2a11239a30d9c11743a0ca7693f3cc51fce03))
+* remove deprecated aliases in double-nested protos ([#4997](https://github.com/googleapis/google-cloud-php/issues/4997)) ([c4c790c](https://github.com/googleapis/google-cloud-php/commit/c4c790cc33266848c8851c5ae557d326ad27fcf5))
+
+</details>
+
+<details><summary>google/cloud-tasks 1.10.0</summary>
+
+
+
+### Features
+
+* [Tasks] Updates from OwlBot ([#4883](https://github.com/googleapis/google-cloud-php/issues/4883)) ([3296dd1](https://github.com/googleapis/google-cloud-php/commit/3296dd13e3b49276c1a45edc1d8d88703f0d9a9a))
+
+</details>
+
+<details><summary>google/cloud-text-to-speech 1.3.3</summary>
+
+
+
+</details>
+
+<details><summary>google/cloud-tpu 0.2.3</summary>
+
+
+
+### Bug Fixes
+
+* owlbot copy excludes ([#4987](https://github.com/googleapis/google-cloud-php/issues/4987)) ([49e2a11](https://github.com/googleapis/google-cloud-php/commit/49e2a11239a30d9c11743a0ca7693f3cc51fce03))
+* remove deprecated aliases in double-nested protos ([#4997](https://github.com/googleapis/google-cloud-php/issues/4997)) ([c4c790c](https://github.com/googleapis/google-cloud-php/commit/c4c790cc33266848c8851c5ae557d326ad27fcf5))
+
+</details>
+
+<details><summary>google/cloud-trace 1.4.3</summary>
+
+
+
+</details>
+
+<details><summary>google/cloud-translate 1.12.3</summary>
+
+
+
+### Bug Fixes
+
+* make partial veneer client excludes explicit ([#4995](https://github.com/googleapis/google-cloud-php/issues/4995)) ([8819eaa](https://github.com/googleapis/google-cloud-php/commit/8819eaa01e146ba40576750b47a22cbb8cb1407b))
+
+</details>
+
+<details><summary>google/cloud-videointelligence 1.12.5</summary>
+
+
+
+</details>
+
+<details><summary>google/cloud-video-transcoder 0.3.2</summary>
+
+
+
+### Bug Fixes
+
+* owlbot copy excludes ([#4987](https://github.com/googleapis/google-cloud-php/issues/4987)) ([49e2a11](https://github.com/googleapis/google-cloud-php/commit/49e2a11239a30d9c11743a0ca7693f3cc51fce03))
+* remove deprecated aliases in double-nested protos ([#4997](https://github.com/googleapis/google-cloud-php/issues/4997)) ([c4c790c](https://github.com/googleapis/google-cloud-php/commit/c4c790cc33266848c8851c5ae557d326ad27fcf5))
+
+</details>
+
+<details><summary>google/cloud-vision 1.5.3</summary>
+
+
+
+</details>
+
+<details><summary>google/cloud-vpc-access 0.2.3</summary>
+
+
+
+### Bug Fixes
+
+* owlbot copy excludes ([#4987](https://github.com/googleapis/google-cloud-php/issues/4987)) ([49e2a11](https://github.com/googleapis/google-cloud-php/commit/49e2a11239a30d9c11743a0ca7693f3cc51fce03))
+* remove deprecated aliases in double-nested protos ([#4997](https://github.com/googleapis/google-cloud-php/issues/4997)) ([c4c790c](https://github.com/googleapis/google-cloud-php/commit/c4c790cc33266848c8851c5ae557d326ad27fcf5))
+
+</details>
+
+<details><summary>google/cloud-web-risk 1.1.3</summary>
+
+
+
+</details>
+
+<details><summary>google/cloud-web-security-scanner 0.7.3</summary>
+
+
+
+### Bug Fixes
+
+* owlbot copy excludes ([#4987](https://github.com/googleapis/google-cloud-php/issues/4987)) ([49e2a11](https://github.com/googleapis/google-cloud-php/commit/49e2a11239a30d9c11743a0ca7693f3cc51fce03))
+* remove deprecated aliases in double-nested protos ([#4997](https://github.com/googleapis/google-cloud-php/issues/4997)) ([c4c790c](https://github.com/googleapis/google-cloud-php/commit/c4c790cc33266848c8851c5ae557d326ad27fcf5))
+
+</details>
+
+<details><summary>google/cloud-workflows 0.2.3</summary>
+
+
+
+### Bug Fixes
+
+* owlbot copy excludes ([#4987](https://github.com/googleapis/google-cloud-php/issues/4987)) ([49e2a11](https://github.com/googleapis/google-cloud-php/commit/49e2a11239a30d9c11743a0ca7693f3cc51fce03))
+* remove deprecated aliases in double-nested protos ([#4997](https://github.com/googleapis/google-cloud-php/issues/4997)) ([c4c790c](https://github.com/googleapis/google-cloud-php/commit/c4c790cc33266848c8851c5ae557d326ad27fcf5))
+
+</details>
+
+---
+This PR was generated with [Release Please](https://github.com/googleapis/release-please). See [documentation](https://github.com/googleapis/release-please#release-please).

--- a/test/util/pull-request-body.ts
+++ b/test/util/pull-request-body.ts
@@ -80,6 +80,19 @@ describe('PullRequestBody', () => {
       expect(releaseData[0].version?.toString()).to.eql('3.2.7');
       expect(releaseData[0].notes).matches(/^### \[3\.2\.7\]/);
     });
+    it('should parse legacy PHP body', () => {
+      const body = readFileSync(
+        resolve(fixturesPath, './legacy-php-yoshi.txt'),
+        'utf8'
+      ).replace(/\r\n/g, '\n');
+      const pullRequestBody = PullRequestBody.parse(body);
+      expect(pullRequestBody).to.not.be.undefined;
+      const releaseData = pullRequestBody!.releaseData;
+      expect(releaseData).lengthOf(109);
+      expect(releaseData[0].component).to.eql('google/cloud-access-approval');
+      expect(releaseData[0].version?.toString()).to.eql('0.3.0');
+      expect(releaseData[0].notes).matches(/Database operations/);
+    });
   });
   describe('toString', () => {
     it('can handle multiple entries', () => {


### PR DESCRIPTION
PHP Yoshi strategy was creating a manifest-like pull request body with `<summary>` sections however it was not adding the `:` between the component and the version. Moving forward we will make the section include the `:`.

We also adjust the parsing to handle the `<summary>` value without the `:` (which we can possibly remove at a later time). Added a test for parsing the legacy format.

Fixes #1212
