### PR TITLE
fix: BranchName.parse should not throw exceptions

### DIFF
--- a/src/util/branch-name.ts
+++ b/src/util/branch-name.ts
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 import {Version} from '../version';
+import {logger} from './logger';
 
 // cannot import from '..' - transpiled code references to RELEASE_PLEASE
 // at the script level are undefined, they are only defined inside function
@@ -39,13 +40,18 @@ export class BranchName {
   version?: Version;
 
   static parse(branchName: string): BranchName | undefined {
-    const branchNameClass = getAllResourceNames().find(clazz => {
-      return clazz.matches(branchName);
-    });
-    if (!branchNameClass) {
+    try {
+      const branchNameClass = getAllResourceNames().find(clazz => {
+        return clazz.matches(branchName);
+      });
+      if (!branchNameClass) {
+        return undefined;
+      }
+      return new branchNameClass(branchName);
+    } catch (e) {
+      logger.warn(`Error parsing branch name: ${branchName}`, e);
       return undefined;
     }
-    return new branchNameClass(branchName);
   }
   static ofComponentVersion(
     branchPrefix: string,

--- a/test/util/branch-name.ts
+++ b/test/util/branch-name.ts
@@ -38,6 +38,11 @@ describe('BranchName', () => {
         expect(branchName?.getVersion()?.toString()).to.eql('1.2.3');
         expect(branchName?.toString()).to.eql(name);
       });
+      it('should not crash on parsing', () => {
+        const name = 'release-storage-v1';
+        const branchName = BranchName.parse(name);
+        expect(branchName).to.be.undefined;
+      });
     });
     describe('v12 format', () => {
       it('parses a target branch', () => {


### PR DESCRIPTION
`BranchName.parse` is expected to return `undefined` if a branch name doesn't match one of our expected patterns, not throw exceptions

Fixes #1226 
