### PR TITLE
fix: handle windows newlines in pull request body

### DIFF
--- a/src/util/pull-request-body.ts
+++ b/src/util/pull-request-body.ts
@@ -86,7 +86,7 @@ ${this.footer}`;
 function splitBody(
   body: string
 ): {header: string; footer: string; content: string} | undefined {
-  const lines = body.trim().split('\n');
+  const lines = body.trim().replace(/\r\n/g, '\n').split('\n');
   const index = lines.indexOf(NOTES_DELIMITER);
   if (index === -1) {
     return undefined;

--- a/test/util/pull-request-body.ts
+++ b/test/util/pull-request-body.ts
@@ -28,7 +28,7 @@ describe('PullRequestBody', () => {
       const body = readFileSync(
         resolve(fixturesPath, './multiple.txt'),
         'utf8'
-      ).replace(/\r\n/g, '\n');
+      );
       const pullRequestBody = PullRequestBody.parse(body);
       expect(pullRequestBody).to.not.be.undefined;
       const releaseData = pullRequestBody!.releaseData;
@@ -58,7 +58,7 @@ describe('PullRequestBody', () => {
       const body = readFileSync(
         resolve(fixturesPath, './single-manifest.txt'),
         'utf8'
-      ).replace(/\r\n/g, '\n');
+      );
       const pullRequestBody = PullRequestBody.parse(body);
       expect(pullRequestBody).to.not.be.undefined;
       const releaseData = pullRequestBody!.releaseData;
@@ -68,10 +68,7 @@ describe('PullRequestBody', () => {
       expect(releaseData[0].notes).matches(/^### Bug Fixes/);
     });
     it('should parse standalone release', () => {
-      const body = readFileSync(
-        resolve(fixturesPath, './single.txt'),
-        'utf8'
-      ).replace(/\r\n/g, '\n');
+      const body = readFileSync(resolve(fixturesPath, './single.txt'), 'utf8');
       const pullRequestBody = PullRequestBody.parse(body);
       expect(pullRequestBody).to.not.be.undefined;
       const releaseData = pullRequestBody!.releaseData;
@@ -84,7 +81,7 @@ describe('PullRequestBody', () => {
       const body = readFileSync(
         resolve(fixturesPath, './legacy-php-yoshi.txt'),
         'utf8'
-      ).replace(/\r\n/g, '\n');
+      );
       const pullRequestBody = PullRequestBody.parse(body);
       expect(pullRequestBody).to.not.be.undefined;
       const releaseData = pullRequestBody!.releaseData;


### PR DESCRIPTION
If you modify the PR body in the GitHub UI, it seems to add windows newlines.

Fixes #1206
