### PR TITLE
fix: multi-component manifest release notes for single component release

### DIFF
--- a/__snapshots__/cargo-workspace.js
+++ b/__snapshots__/cargo-workspace.js
@@ -62,7 +62,10 @@ exports['CargoWorkspace plugin run handles a single rust package 1'] = `
 ---
 
 
+<details><summary>pkgA: 1.1.2</summary>
+
 Release notes for path: packages/rustA, releaseType: rust
+</details>
 
 ---
 This PR was generated with [Release Please](https://github.com/googleapis/release-please). See [documentation](https://github.com/googleapis/release-please#release-please).

--- a/__snapshots__/node-workspace.js
+++ b/__snapshots__/node-workspace.js
@@ -55,7 +55,10 @@ exports['NodeWorkspace plugin run handles a single node package 1'] = `
 ---
 
 
+<details><summary>@here/pkgA: 3.3.4</summary>
+
 Release notes for path: node1, releaseType: node
+</details>
 
 ---
 This PR was generated with [Release Please](https://github.com/googleapis/release-please). See [documentation](https://github.com/googleapis/release-please#release-please).

--- a/__snapshots__/pull-request-body.js
+++ b/__snapshots__/pull-request-body.js
@@ -28,6 +28,20 @@ some special notes go here
 This PR was generated with [Release Please](https://github.com/googleapis/release-please). See [documentation](https://github.com/googleapis/release-please#release-please).
 `
 
+exports['PullRequestBody toString can handle a single entries forced components 1'] = `
+:robot: I have created a release *beep* *boop*
+---
+
+
+<details><summary>pkg1: 1.2.3</summary>
+
+some special notes go here
+</details>
+
+---
+This PR was generated with [Release Please](https://github.com/googleapis/release-please). See [documentation](https://github.com/googleapis/release-please#release-please).
+`
+
 exports['PullRequestBody toString can handle multiple entries 1'] = `
 :robot: I have created a release *beep* *boop*
 ---

--- a/src/manifest.ts
+++ b/src/manifest.ts
@@ -555,6 +555,7 @@ export class Manifest {
       })
     );
 
+    logger.info(`separate pull requests: ${this.separatePullRequests}`);
     // Combine pull requests into 1 unless configured for separate
     // pull requests
     if (!this.separatePullRequests) {

--- a/src/plugins/merge.ts
+++ b/src/plugins/merge.ts
@@ -25,6 +25,7 @@ import {BranchName} from '../util/branch-name';
 import {Update} from '../update';
 import {mergeUpdates} from '../updaters/composite';
 import {GitHub} from '../github';
+import {logger} from '../util/logger';
 
 /**
  * This plugin merges multiple pull requests into a single
@@ -52,6 +53,7 @@ export class Merge extends ManifestPlugin {
     if (candidates.length < 1) {
       return candidates;
     }
+    logger.info(`Merging ${candidates.length} pull requests`);
 
     const releaseData: ReleaseData[] = [];
     const labels = new Set<string>();
@@ -77,7 +79,7 @@ export class Merge extends ManifestPlugin {
         rootRelease?.pullRequest.title.version,
         this.pullRequestTitlePattern
       ),
-      body: new PullRequestBody(releaseData),
+      body: new PullRequestBody(releaseData, {useComponents: true}),
       updates,
       labels: Array.from(labels),
       headRefName: BranchName.ofTargetBranch(this.targetBranch).toString(),

--- a/src/util/pull-request-body.ts
+++ b/src/util/pull-request-body.ts
@@ -25,6 +25,7 @@ interface PullRequestBodyOptions {
   header?: string;
   footer?: string;
   extra?: string;
+  useComponents?: boolean;
 }
 
 export class PullRequestBody {
@@ -32,11 +33,13 @@ export class PullRequestBody {
   footer: string;
   extra?: string;
   releaseData: ReleaseData[];
+  useComponents: boolean;
   constructor(releaseData: ReleaseData[], options?: PullRequestBodyOptions) {
     this.header = options?.header || DEFAULT_HEADER;
     this.footer = options?.footer || DEFAULT_FOOTER;
     this.extra = options?.extra;
     this.releaseData = releaseData;
+    this.useComponents = options?.useComponents ?? this.releaseData.length > 1;
   }
   static parse(body: string): PullRequestBody | undefined {
     const parts = splitBody(body);
@@ -57,7 +60,7 @@ export class PullRequestBody {
     });
   }
   notes(): string {
-    if (this.releaseData.length > 1) {
+    if (this.useComponents) {
       return this.releaseData
         .map(release => {
           return `<details><summary>${

--- a/test/util/pull-request-body.ts
+++ b/test/util/pull-request-body.ts
@@ -121,6 +121,18 @@ describe('PullRequestBody', () => {
       snapshot(pullRequestBody.toString());
     });
 
+    it('can handle a single entries forced components', () => {
+      const data = [
+        {
+          component: 'pkg1',
+          version: Version.parse('1.2.3'),
+          notes: 'some special notes go here',
+        },
+      ];
+      const pullRequestBody = new PullRequestBody(data, {useComponents: true});
+      snapshot(pullRequestBody.toString());
+    });
+
     it('can handle a custom header and footer', () => {
       const data = [
         {


### PR DESCRIPTION
When merging pull requests for multi-component manifests, always use the component-separate pull request body style.

Fixes #1245 
