### PR TITLE
fix: delegate empty commit handling to strategies

### DIFF
--- a/src/manifest.ts
+++ b/src/manifest.ts
@@ -489,10 +489,6 @@ export class Manifest {
         path === ROOT_PROJECT_PATH ? commits : commitsPerPath[path],
         releaseShasByPath[path]
       );
-      if (!pathCommits || pathCommits.length === 0) {
-        logger.info(`No commits for path: ${path}, skipping`);
-        continue;
-      }
       logger.debug(`commits: ${pathCommits.length}`);
       const latestReleasePullRequest =
         releasePullRequestsBySha[releaseShasByPath[path]];
@@ -555,7 +551,6 @@ export class Manifest {
       })
     );
 
-    logger.info(`separate pull requests: ${this.separatePullRequests}`);
     // Combine pull requests into 1 unless configured for separate
     // pull requests
     if (!this.separatePullRequests) {

--- a/src/strategies/base.ts
+++ b/src/strategies/base.ts
@@ -214,6 +214,10 @@ export abstract class BaseStrategy implements Strategy {
       parseConventionalCommits(commits)
     );
     logger.info(`Considering: ${conventionalCommits.length} commits`);
+    if (conventionalCommits.length === 0) {
+      logger.info(`No commits for path: ${this.path}, skipping`);
+      return undefined;
+    }
 
     const newVersion = await this.buildNewVersion(
       conventionalCommits,

--- a/src/strategies/java-yoshi.ts
+++ b/src/strategies/java-yoshi.ts
@@ -135,6 +135,32 @@ export class JavaYoshi extends BaseStrategy {
     };
   }
 
+  /**
+   * Override this method to post process commits
+   * @param {ConventionalCommit[]} commits parsed commits
+   * @returns {ConventionalCommit[]} modified commits
+   */
+  protected async postProcessCommits(
+    commits: ConventionalCommit[]
+  ): Promise<ConventionalCommit[]> {
+    if (commits.length === 0) {
+      // For Java commits, push a fake commit so we force a
+      // SNAPSHOT release
+      commits.push({
+        type: 'fake',
+        bareMessage: 'fake commit',
+        message: 'fake commit',
+        breaking: false,
+        scope: null,
+        notes: [],
+        files: [],
+        references: [],
+        sha: 'fake',
+      });
+    }
+    return commits;
+  }
+
   private async needsSnapshot(): Promise<boolean> {
     return VersionsManifest.needsSnapshot(
       (await this.getVersionsContent()).parsedContent

--- a/src/strategies/php-yoshi.ts
+++ b/src/strategies/php-yoshi.ts
@@ -69,10 +69,14 @@ export class PHPYoshi extends BaseStrategy {
     latestRelease?: Release,
     draft?: boolean,
     labels: string[] = []
-  ): Promise<ReleasePullRequest> {
+  ): Promise<ReleasePullRequest | undefined> {
     const conventionalCommits = await this.postProcessCommits(
       parseConventionalCommits(commits)
     );
+    if (conventionalCommits.length === 0) {
+      logger.info(`No commits for path: ${this.path}, skipping`);
+      return undefined;
+    }
 
     const newVersion = latestRelease
       ? await this.versioningStrategy.bump(


### PR DESCRIPTION
Previously the manifest would just short-circuit and ignore creating pull requests if there are no commits. Now, it's the responsibility of the strategy to decide to skip proposing a pull request or not.

The java-yoshi strategy now forces itself to consider an empty commit set in order to create the -SNAPSHOT pull request

Fixes #1253
