### PR TITLE
fix: check recent commits and latest releases for latest version

### DIFF
--- a/src/manifest.ts
+++ b/src/manifest.ts
@@ -969,6 +969,7 @@ async function latestReleaseVersion(
   // is in the current branch
   const commitShas = new Set<string>();
 
+  const candidateReleaseVersions: Version[] = [];
   // only look at the last 250 or so commits to find the latest tag - we
   // don't want to scan the entire repository history if this repo has never
   // been released
@@ -1005,13 +1006,18 @@ async function latestReleaseVersion(
       continue;
     }
 
-    return version;
+    if (version) {
+      logger.debug(
+        `Found latest release pull request: ${mergedPullRequest.number} version: ${version}`
+      );
+      candidateReleaseVersions.push(version);
+      break;
+    }
   }
 
   // If not found from recent pull requests, look at releases. Iterate
   // through releases finding valid tags, then cross reference
   const releaseGenerator = github.releaseIterator();
-  const candidateReleaseVersions: Version[] = [];
   for await (const release of releaseGenerator) {
     const tagName = TagName.parse(release.tagName);
     if (!tagName) {

--- a/test/manifest.ts
+++ b/test/manifest.ts
@@ -246,6 +246,13 @@ describe('Manifest', () => {
           },
         },
       ]);
+      mockReleases(github, [
+        {
+          tagName: 'v1.2.3',
+          sha: 'abc123',
+          url: 'http://path/to/release',
+        },
+      ]);
 
       const manifest = await Manifest.fromConfig(github, 'target-branch', {
         releaseType: 'simple',
@@ -270,6 +277,13 @@ describe('Manifest', () => {
             labels: [],
             files: [],
           },
+        },
+      ]);
+      mockReleases(github, [
+        {
+          tagName: 'v1.2.3',
+          sha: 'abc123',
+          url: 'http://path/to/release',
         },
       ]);
 
@@ -301,6 +315,13 @@ describe('Manifest', () => {
           },
         },
       ]);
+      mockReleases(github, [
+        {
+          tagName: 'v1.2.3',
+          sha: 'abc123',
+          url: 'http://path/to/release',
+        },
+      ]);
 
       const manifest = await Manifest.fromConfig(github, 'target-branch', {
         releaseType: 'simple',
@@ -327,6 +348,13 @@ describe('Manifest', () => {
             labels: [],
             files: [],
           },
+        },
+      ]);
+      mockReleases(github, [
+        {
+          tagName: 'foobar-v1.2.3',
+          sha: 'abc123',
+          url: 'http://path/to/release',
         },
       ]);
 

--- a/test/manifest.ts
+++ b/test/manifest.ts
@@ -578,6 +578,61 @@ describe('Manifest', () => {
         '3.3.3'
       );
     });
+    it('finds manually tagged release commit over earlier automated commit', async () => {
+      mockCommits(github, [
+        {
+          sha: 'abc123',
+          message: 'some commit message',
+          files: [],
+        },
+        {
+          sha: 'def234',
+          message: 'this commit should be found',
+          files: [],
+        },
+        {
+          sha: 'ghi345',
+          message: 'some commit message',
+          files: [],
+          pullRequest: {
+            title: 'chore: release 3.3.1',
+            headBranchName: 'release-please/branches/main',
+            baseBranchName: 'main',
+            number: 123,
+            body: '',
+            labels: [],
+            files: [],
+          },
+        },
+      ]);
+      mockReleases(github, [
+        {
+          tagName: 'v3.3.2',
+          sha: 'def234',
+          url: 'http://path/to/release',
+        },
+        {
+          tagName: 'v3.3.1',
+          sha: 'ghi345',
+          url: 'http://path/to/release',
+        },
+      ]);
+      mockTags(github, []);
+
+      const manifest = await Manifest.fromConfig(github, 'target-branch', {
+        releaseType: 'simple',
+        bumpMinorPreMajor: true,
+        bumpPatchForMinorPreMajor: true,
+      });
+      expect(Object.keys(manifest.repositoryConfig)).lengthOf(1);
+      expect(
+        Object.keys(manifest.releasedVersions),
+        'found release versions'
+      ).lengthOf(1);
+      expect(Object.values(manifest.releasedVersions)[0].toString()).to.eql(
+        '3.3.2'
+      );
+    });
   });
 
   describe('buildPullRequests', () => {


### PR DESCRIPTION
It's possible that a manual release was created/tagged since the last release-please PR was merged/released. The logic currently prefers any merged release PR over manually created releases. Now, we stop iterating through commits after we find the first merged release PR, but still consider recent releases (picking the highest number).

Pro: This method is more robust and resilient
Con: We now always iterate over releases with GraphQL queries.

Fixes #1266
