### PR TITLE
fix: krm blueprints should update yaml files

### DIFF
--- a/__snapshots__/krm-blueprint-version.js
+++ b/__snapshots__/krm-blueprint-version.js
@@ -1,4 +1,4 @@
-exports['KRM Blueprint updateContent updates version in multiKRMwithFn.yaml 1'] = `
+exports['KRM Blueprint updateContent with previousVersion updates version in multiKRMwithFn.yaml 1'] = `
 # Copyright 2021 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -50,7 +50,92 @@ spec:
 
 `
 
-exports['KRM Blueprint updateContent updates version in simpleKRM.yaml 1'] = `
+exports['KRM Blueprint updateContent with previousVersion updates version in simpleKRM.yaml 1'] = `
+# Copyright 2021 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: resourcemanager.cnrm.cloud.google.com/v1beta1
+kind: Project
+metadata:
+  name: project-id # {"$kpt-set":"project-id"}
+  namespace: projects # {"$kpt-set":"projects-namespace"}
+  annotations:
+    cnrm.cloud.google.com/auto-create-network: "false"
+    cnrm.cloud.google.com/blueprint: cnrm/landing-zone:project/v2.1.0
+spec:
+  name: project-id # {"$kpt-set":"project-id"}
+  billingAccountRef:
+    external: "AAAAAA-BBBBBB-CCCCCC" # {"$kpt-set":"billing-account-id"}
+  folderRef:
+    name: name.of.folder # {"$kpt-set":"folder-name"}
+    namespace: hierarchy # {"$kpt-set":"folder-namespace"}
+
+`
+
+exports['KRM Blueprint updateContent without previousVersion updates version in multiKRMwithFn.yaml 1'] = `
+# Copyright 2021 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: resourcemanager.cnrm.cloud.google.com/v1beta1
+kind: Project
+metadata:
+  name: project-id1 # {"$kpt-set":"project-id"}
+  namespace: projects # {"$kpt-set":"projects-namespace"}
+  annotations:
+    cnrm.cloud.google.com/auto-create-network: "false"
+    cnrm.cloud.google.com/blueprint: cnrm/landing-zone:project/v18.0.0
+spec:
+  name: project-id # {"$kpt-set":"project-id"}
+  billingAccountRef:
+    external: "AAAAAA-BBBBBB-CCCCCC" # {"$kpt-set":"billing-account-id"}
+  folderRef:
+    name: name.of.folder # {"$kpt-set":"folder-name"}
+    namespace: hierarchy # {"$kpt-set":"folder-namespace"}
+---
+apiVersion: resourcemanager.cnrm.cloud.google.com/v1beta1
+kind: Project
+metadata:
+  name: project-id2 # {"$kpt-set":"project-id"}
+  namespace: projects # {"$kpt-set":"projects-namespace"}
+  annotations:
+    cnrm.cloud.google.com/auto-create-network: "false"
+    cnrm.cloud.google.com/blueprint: cnrm/landing-zone:project/v18.0.0
+    config.kubernetes.io/function: |
+      container:
+        image: gcr.io/foo/bar:v0.1.0
+spec:
+  name: project-id # {"$kpt-set":"project-id"}
+  billingAccountRef:
+    external: "AAAAAA-BBBBBB-CCCCCC" # {"$kpt-set":"billing-account-id"}
+  folderRef:
+    name: name.of.folder # {"$kpt-set":"folder-name"}
+    namespace: hierarchy # {"$kpt-set":"folder-namespace"}
+
+`
+
+exports['KRM Blueprint updateContent without previousVersion updates version in simpleKRM.yaml 1'] = `
 # Copyright 2021 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/updaters/krm/krm-blueprint-version.ts
+++ b/src/updaters/krm/krm-blueprint-version.ts
@@ -30,7 +30,7 @@ export class KRMBlueprintVersion extends DefaultUpdater {
     let matchRegex = '(cnrm/.*/)(v[0-9]+.[0-9]+.[0-9]+)+(-w+)?';
     // if explicit previous version, match only that version
     if (this.versionsMap?.has('previousVersion')) {
-      matchRegex = `(cnrm/.*/)(${this.versionsMap.get(
+      matchRegex = `(cnrm/.*/)(v${this.versionsMap.get(
         'previousVersion'
       )})+(-w+)?`;
     }

--- a/test/updaters/krm-blueprint-version.ts
+++ b/test/updaters/krm-blueprint-version.ts
@@ -25,26 +25,50 @@ describe('KRM Blueprint', () => {
   const tests = [
     {
       name: 'simpleKRM.yaml',
+      previousVersion: '0.2.0',
       expectedVersion: '2.1.0',
     },
     {
       name: 'multiKRMwithFn.yaml',
+      previousVersion: '0.2.0',
       expectedVersion: '18.0.0',
     },
   ];
   describe('updateContent', () => {
     tests.forEach(test => {
-      it(`updates version in ${test.name}`, async () => {
-        const oldContent = readFileSync(
-          resolve(fixturesPath, test.name),
-          'utf8'
-        ).replace(/\r\n/g, '\n');
+      describe('with previousVersion', () => {
+        it(`updates version in ${test.name}`, async () => {
+          const oldContent = readFileSync(
+            resolve(fixturesPath, test.name),
+            'utf8'
+          ).replace(/\r\n/g, '\n');
 
-        const version = new KRMBlueprintVersion({
-          version: Version.parse(test.expectedVersion),
+          const versionsMap = new Map();
+          versionsMap.set(
+            'previousVersion',
+            Version.parse(test.previousVersion)
+          );
+          const version = new KRMBlueprintVersion({
+            version: Version.parse(test.expectedVersion),
+            versionsMap,
+          });
+          const newContent = version.updateContent(oldContent);
+          snapshot(newContent);
         });
-        const newContent = version.updateContent(oldContent);
-        snapshot(newContent);
+      });
+      describe('without previousVersion', () => {
+        it(`updates version in ${test.name}`, async () => {
+          const oldContent = readFileSync(
+            resolve(fixturesPath, test.name),
+            'utf8'
+          ).replace(/\r\n/g, '\n');
+
+          const version = new KRMBlueprintVersion({
+            version: Version.parse(test.expectedVersion),
+          });
+          const newContent = version.updateContent(oldContent);
+          snapshot(newContent);
+        });
       });
     });
   });


### PR DESCRIPTION
Prior to v13, we were passing around version strings which included `v`. This regex replacement was assuming that the version included `v` which it did not in v13. Also, the tests did not cover the case when a `previousVersion` was provided.

Fixes #1268
