### PR TITLE
fix: recursively fetch directories when using file data API

### DIFF
--- a/test/fixtures/github-data-api/data-api-trees-successful-response-subdir1.json
+++ b/test/fixtures/github-data-api/data-api-trees-successful-response-subdir1.json
@@ -1,0 +1,14 @@
+{
+  "sha": "0ab7edc1143a47be42513c0acc64165cf5da9181",
+  "url": "https://api.github.com/repos/lancedikson/release-please-403-example/git/trees/0ab7edc1143a47be42513c0acc64165cf5da9181",
+  "tree": [
+    {
+      "path": "subdir2",
+      "mode": "040000",
+      "type": "tree",
+      "sha": "1143a47be42513c0acc64165cf5da91810ab7edc",
+      "url": "https://api.github.com/repos/lancedikson/release-please-403-example/git/trees/1143a47be42513c0acc64165cf5da91810ab7edc"
+    }
+  ],
+  "truncated": false
+}

--- a/test/fixtures/github-data-api/data-api-trees-successful-response-subdir2.json
+++ b/test/fixtures/github-data-api/data-api-trees-successful-response-subdir2.json
@@ -1,0 +1,15 @@
+{
+  "sha": "1143a47be42513c0acc64165cf5da91810ab7edc",
+  "url": "https://api.github.com/repos/lancedikson/release-please-403-example/git/trees/1143a47be42513c0acc64165cf5da91810ab7edc",
+  "tree": [
+    {
+      "path": "package-lock.json",
+      "mode": "100644",
+      "type": "blob",
+      "sha": "2f3d2c47bf49f81aca0df9ffc49524a213a2dc33",
+      "size": 1352120,
+      "url": "https://api.github.com/repos/lancedikson/release-please-403-example/git/blobs/2f3d2c47bf49f81aca0df9ffc49524a213a2dc33"
+    }
+  ],
+  "truncated": false
+}

--- a/test/fixtures/github-data-api/data-api-trees-successful-response.json
+++ b/test/fixtures/github-data-api/data-api-trees-successful-response.json
@@ -10,6 +10,13 @@
       "url": "https://api.github.com/repos/lancedikson/release-please-403-example/git/trees/cc64165cf5da91810ab7edc1143a47be42513c0a"
     },
     {
+      "path": "subdir1",
+      "mode": "040000",
+      "type": "tree",
+      "sha": "0ab7edc1143a47be42513c0acc64165cf5da9181",
+      "url": "https://api.github.com/repos/lancedikson/release-please-403-example/git/trees/0ab7edc1143a47be42513c0acc64165cf5da9181"
+    },
+    {
       "path": ".gitignore",
       "mode": "100644",
       "type": "blob",


### PR DESCRIPTION
When using the file data API, you have to go folder by folder to find the tree SHA of each directory. This change recursively fetches the folders before finding the file blob.

Fixes #1090
