### PR TITLE
fix(go-yoshi): allows using go-yoshi with manifest

### DIFF
--- a/__snapshots__/github.js
+++ b/__snapshots__/github.js
@@ -2,6 +2,26 @@ exports['GitHub commentOnIssue can create a comment 1'] = {
   "body": "This is a comment"
 }
 
+exports['GitHub commitsSince backfills commit files for pull requests with lots of files 1'] = [
+  {
+    "sha": "e6daec403626c9987c7af0d97b34f324cd84320a",
+    "message": "Merge pull request #7 from chingor13/feature-branch-plain-merge\n\nfeat: feature that will be plain merged",
+    "pullRequest": {
+      "sha": "e6daec403626c9987c7af0d97b34f324cd84320a",
+      "number": 7,
+      "baseBranchName": "main",
+      "headBranchName": "feature-branch-plain-merge",
+      "title": "feat: feature that will be plain merged",
+      "body": "",
+      "labels": [],
+      "files": []
+    },
+    "files": [
+      "abc"
+    ]
+  }
+]
+
 exports['GitHub commitsSince backfills commit files without pull requests 1'] = [
   {
     "sha": "e6daec403626c9987c7af0d97b34f324cd84320a",

--- a/src/factory.ts
+++ b/src/factory.ts
@@ -141,6 +141,7 @@ export async function buildStrategy(
     changelogNotes,
     pullRequestTitlePattern: options.pullRequestTitlePattern,
     extraFiles: options.extraFiles,
+    tagSeparator: options.tagSeparator,
   };
   switch (options.releaseType) {
     case 'ruby': {

--- a/src/github.ts
+++ b/src/github.ts
@@ -95,6 +95,9 @@ interface GraphQLPullRequest {
     nodes: {
       path: string;
     }[];
+    pageInfo: {
+      hasNextPage: boolean;
+    };
   };
 }
 
@@ -387,7 +390,7 @@ export class GitHub {
       repo: this.repository.repo,
       num: 25,
       targetBranch,
-      maxFilesChanged: 64,
+      maxFilesChanged: 100, // max is 100
     });
 
     // if the branch does exist, return null
@@ -420,9 +423,14 @@ export class GitHub {
           labels: pullRequest.labels.nodes.map(node => node.name),
           files,
         };
-        // We cannot directly fetch files on commits via graphql, only provide file
-        // information for commits with associated pull requests
-        commit.files = files;
+        if (pullRequest.files.pageInfo?.hasNextPage && options.backfillFiles) {
+          logger.info(`PR #${pullRequest.number} has many files, backfilling`);
+          commit.files = await this.getCommitFiles(graphCommit.sha);
+        } else {
+          // We cannot directly fetch files on commits via graphql, only provide file
+          // information for commits with associated pull requests
+          commit.files = files;
+        }
       } else if (options.backfillFiles) {
         // In this case, there is no squashed merge commit. This could be a simple
         // merge commit, a rebase merge commit, or a direct commit to the branch.
@@ -447,13 +455,29 @@ export class GitHub {
    */
   getCommitFiles = wrapAsync(async (sha: string): Promise<string[]> => {
     logger.debug(`Backfilling file list for commit: ${sha}`);
-    const resp = await this.octokit.repos.getCommit({
-      owner: this.repository.owner,
-      repo: this.repository.repo,
-      ref: sha,
-    });
-    const files = resp.data.files || [];
-    return files.map(file => file.filename!).filter(filename => !!filename);
+    const files: string[] = [];
+    for await (const resp of this.octokit.paginate.iterator(
+      this.octokit.repos.getCommit,
+      {
+        owner: this.repository.owner,
+        repo: this.repository.repo,
+        ref: sha,
+      }
+    )) {
+      for (const f of resp.data.files || []) {
+        if (f.filename) {
+          files.push(f.filename);
+        }
+      }
+    }
+    if (files.length >= 3000) {
+      logger.warn(
+        `Found ${files.length} files. This may not include all the files.`
+      );
+    } else {
+      logger.debug(`Found ${files.length} files`);
+    }
+    return files;
   });
 
   private graphqlRequest = wrapAsync(

--- a/src/manifest.ts
+++ b/src/manifest.ts
@@ -58,6 +58,7 @@ export interface ReleaserConfig {
   packageName?: string;
   includeComponentInTag?: boolean;
   pullRequestTitlePattern?: string;
+  tagSeparator?: string;
 
   // Changelog options
   changelogSections?: ChangelogSection[];
@@ -98,6 +99,7 @@ interface ReleaserConfigJson {
   'include-component-in-tag'?: boolean;
   'changelog-type'?: ChangelogNotesType;
   'pull-request-title-pattern'?: string;
+  'tag-separator'?: string;
 
   // Ruby-only
   'version-file'?: string;
@@ -882,6 +884,7 @@ function extractReleaserConfig(
     includeComponentInTag: config['include-component-in-tag'],
     changelogType: config['changelog-type'],
     pullRequestTitlePattern: config['pull-request-title-pattern'],
+    tagSeparator: config['tag-separator'],
   };
 }
 
@@ -1091,6 +1094,9 @@ function mergeReleaserConfig(
     packageName: pathConfig.packageName ?? defaultConfig.packageName,
     versionFile: pathConfig.versionFile ?? defaultConfig.versionFile,
     extraFiles: pathConfig.extraFiles ?? defaultConfig.extraFiles,
+    includeComponentInTag:
+      pathConfig.includeComponentInTag ?? defaultConfig.includeComponentInTag,
+    tagSeparator: pathConfig.tagSeparator ?? defaultConfig.tagSeparator,
     pullRequestTitlePattern:
       pathConfig.pullRequestTitlePattern ??
       defaultConfig.pullRequestTitlePattern,

--- a/src/strategies/go-yoshi.ts
+++ b/src/strategies/go-yoshi.ts
@@ -75,11 +75,6 @@ export class GoYoshi extends BaseStrategy {
     const component = await this.getComponent();
     logger.debug('Filtering commits');
     return commits.filter(commit => {
-      // ignore commits whose scope is in the list of ignored modules
-      if (IGNORED_SUB_MODULES.has(commit.scope || '')) {
-        return false;
-      }
-
       // Only have a single entry of the nightly regen listed in the changelog.
       // If there are more than one of these commits, append associated PR.
       if (

--- a/test/fixtures/commits-since-many-files.json
+++ b/test/fixtures/commits-since-many-files.json
@@ -1,0 +1,63 @@
+{
+  "repository": {
+    "ref": {
+      "target": {
+        "history": {
+          "nodes": [
+            {
+              "associatedPullRequests": {
+                "nodes": [
+                  {
+                    "number": 7,
+                    "title": "feat: feature that will be plain merged",
+                    "baseRefName": "main",
+                    "headRefName": "feature-branch-plain-merge",
+                    "labels": {
+                      "nodes": []
+                    },
+                    "body": "",
+                    "mergeCommit": {
+                      "oid": "e6daec403626c9987c7af0d97b34f324cd84320a"
+                    },
+                    "files": {
+                      "nodes": [],
+                      "pageInfo": {
+                        "hasNextPage": true
+                      }
+                    }
+                  }
+                ]
+              },
+              "sha": "e6daec403626c9987c7af0d97b34f324cd84320a",
+              "message": "Merge pull request #7 from chingor13/feature-branch-plain-merge\n\nfeat: feature that will be plain merged"
+            },
+            {
+              "associatedPullRequests": {
+                "nodes": [
+                  {
+                    "number": 7,
+                    "title": "feat: feature that will be plain merged",
+                    "baseRefName": "main",
+                    "headRefName": "feature-branch-plain-merge",
+                    "labels": {
+                      "nodes": []
+                    },
+                    "body": "",
+                    "mergeCommit": {
+                      "oid": "b29149f890e6f76ee31ed128585744d4c598924c"
+                    },
+                    "files": {
+                      "nodes": []
+                    }
+                  }
+                ]
+              },
+              "sha": "b29149f890e6f76ee31ed128585744d4c598924c",
+              "message": "feat: feature-branch-plain-merge commit 2"
+            }
+          ]
+        }
+      }
+    }
+  }
+}

--- a/test/fixtures/manifest/config/include-component-in-tag.json
+++ b/test/fixtures/manifest/config/include-component-in-tag.json
@@ -1,0 +1,13 @@
+{
+  "release-type": "simple",
+  "include-component-in-tag": true,
+  "packages": {
+    ".": {
+      "component": "root",
+      "include-component-in-tag": false
+    },
+    "packages/bot-config-utils": {
+      "component": "bot-config-utils"
+    }
+  }
+}

--- a/test/fixtures/manifest/config/tag-separator.json
+++ b/test/fixtures/manifest/config/tag-separator.json
@@ -1,0 +1,13 @@
+{
+  "release-type": "simple",
+  "tag-separator": "/",
+  "packages": {
+    ".": {
+      "component": "root",
+      "tag-separator": "-"
+    },
+    "packages/bot-config-utils": {
+      "component": "bot-config-utils"
+    }
+  }
+}

--- a/test/manifest.ts
+++ b/test/manifest.ts
@@ -226,6 +226,67 @@ describe('Manifest', () => {
         manifest.repositoryConfig['packages/cron-utils'].pullRequestTitlePattern
       ).to.eql('chore${scope}: send it v${version}');
     });
+
+    it('should read custom tag separator from manifest', async () => {
+      const getFileContentsStub = sandbox.stub(
+        github,
+        'getFileContentsOnBranch'
+      );
+      getFileContentsStub
+        .withArgs('release-please-config.json', 'main')
+        .resolves(
+          buildGitHubFileContent(
+            fixturesPath,
+            'manifest/config/tag-separator.json'
+          )
+        )
+        .withArgs('.release-please-manifest.json', 'main')
+        .resolves(
+          buildGitHubFileContent(
+            fixturesPath,
+            'manifest/versions/versions.json'
+          )
+        );
+      const manifest = await Manifest.fromManifest(
+        github,
+        github.repository.defaultBranch
+      );
+      expect(manifest.repositoryConfig['.'].tagSeparator).to.eql('-');
+      expect(
+        manifest.repositoryConfig['packages/bot-config-utils'].tagSeparator
+      ).to.eql('/');
+    });
+
+    it('should read custom include component in tag from manifest', async () => {
+      const getFileContentsStub = sandbox.stub(
+        github,
+        'getFileContentsOnBranch'
+      );
+      getFileContentsStub
+        .withArgs('release-please-config.json', 'main')
+        .resolves(
+          buildGitHubFileContent(
+            fixturesPath,
+            'manifest/config/include-component-in-tag.json'
+          )
+        )
+        .withArgs('.release-please-manifest.json', 'main')
+        .resolves(
+          buildGitHubFileContent(
+            fixturesPath,
+            'manifest/versions/versions.json'
+          )
+        );
+      const manifest = await Manifest.fromManifest(
+        github,
+        github.repository.defaultBranch
+      );
+      expect(manifest.repositoryConfig['.'].includeComponentInTag).to.be.false;
+      expect(
+        manifest.repositoryConfig['packages/bot-config-utils']
+          .includeComponentInTag
+      ).to.be.true;
+    });
   });
 
   describe('fromConfig', () => {


### PR DESCRIPTION
fix: allow configuring includeComponentInTag and tagSeparator from manifest config
fix(go-yoshi): should not always skip modules
fix: correctly fetch full list of files
fix: Manifest should be able to find tagged versions without a release