### PR TITLE
feat: allow configuring tag without "v"

### DIFF
--- a/__snapshots__/cli.js
+++ b/__snapshots__/cli.js
@@ -23,6 +23,8 @@ Options:
   --repo-url                    GitHub URL to generate release for    [required]
   --dry-run                     Prepare but do not take action
                                                       [boolean] [default: false]
+  --include-v-in-tags           include "v" in tag versions
+                                                       [boolean] [default: true]
   --monorepo-tags               include library name in tags and release
                                 branches              [boolean] [default: false]
   --pull-request-title-pattern  Title pattern to make release PR        [string]
@@ -199,6 +201,8 @@ Options:
                                     commit log message using the user and email
                                     provided. (format "Name
                                     <email@example.com>").              [string]
+  --include-v-in-tags               include "v" in tag versions
+                                                       [boolean] [default: true]
   --monorepo-tags                   include library name in tags and release
                                     branches          [boolean] [default: false]
   --pull-request-title-pattern      Title pattern to make release PR    [string]

--- a/src/bin/release-please.ts
+++ b/src/bin/release-please.ts
@@ -105,6 +105,7 @@ interface PullRequestStrategyArgs {
 }
 
 interface TaggingArgs {
+  includeVInTags?: boolean;
   monorepoTags?: boolean;
   pullRequestTitlePattern?: string;
 }
@@ -374,6 +375,11 @@ function manifestOptions(yargs: yargs.Argv): yargs.Argv {
 
 function taggingOptions(yargs: yargs.Argv): yargs.Argv {
   return yargs
+    .option('include-v-in-tags', {
+      describe: 'include "v" in tag versions',
+      type: 'boolean',
+      default: true,
+    })
     .option('monorepo-tags', {
       describe: 'include library name in tags and release branches',
       type: 'boolean',
@@ -424,6 +430,7 @@ const createReleasePullRequestCommand: yargs.CommandModule<
           extraFiles: argv.extraFiles,
           versionFile: argv.versionFile,
           includeComponentInTag: argv.monorepoTags,
+          includeVInTag: argv.includeVInTags,
         },
         extractManifestOptions(argv),
         argv.path
@@ -492,6 +499,7 @@ const createReleaseCommand: yargs.CommandModule<{}, CreateReleaseArgs> = {
           draft: argv.draft,
           prerelease: argv.prerelease,
           includeComponentInTag: argv.monorepoTags,
+          includeVInTag: argv.includeVInTags,
         },
         extractManifestOptions(argv),
         argv.path

--- a/src/manifest.ts
+++ b/src/manifest.ts
@@ -57,6 +57,7 @@ export interface ReleaserConfig {
   component?: string;
   packageName?: string;
   includeComponentInTag?: boolean;
+  includeVInTag?: boolean;
   pullRequestTitlePattern?: string;
   tagSeparator?: string;
 
@@ -97,6 +98,7 @@ interface ReleaserConfigJson {
   label?: string;
   'release-label'?: string;
   'include-component-in-tag'?: boolean;
+  'include-v-in-tag'?: boolean;
   'changelog-type'?: ChangelogNotesType;
   'pull-request-title-pattern'?: string;
   'tag-separator'?: string;
@@ -610,7 +612,8 @@ export class Manifest {
       const expectedTag = new TagName(
         expectedVersion,
         component,
-        this.repositoryConfig[path].tagSeparator
+        this.repositoryConfig[path].tagSeparator,
+        this.repositoryConfig[path].includeVInTag
       );
       logger.debug(`looking for tagName: ${expectedTag.toString()}`);
       const foundTag = allTags[expectedTag.toString()];
@@ -942,6 +945,7 @@ function extractReleaserConfig(
     versionFile: config['version-file'],
     extraFiles: config['extra-files'],
     includeComponentInTag: config['include-component-in-tag'],
+    includeVInTag: config['include-v-in-tag'],
     changelogType: config['changelog-type'],
     pullRequestTitlePattern: config['pull-request-title-pattern'],
     tagSeparator: config['tag-separator'],
@@ -1162,6 +1166,7 @@ function mergeReleaserConfig(
     extraFiles: pathConfig.extraFiles ?? defaultConfig.extraFiles,
     includeComponentInTag:
       pathConfig.includeComponentInTag ?? defaultConfig.includeComponentInTag,
+    includeVInTag: pathConfig.includeVInTag ?? defaultConfig.includeVInTag,
     tagSeparator: pathConfig.tagSeparator ?? defaultConfig.tagSeparator,
     pullRequestTitlePattern:
       pathConfig.pullRequestTitlePattern ??

--- a/src/strategies/base.ts
+++ b/src/strategies/base.ts
@@ -64,6 +64,7 @@ export interface BaseStrategyOptions {
   releaseAs?: string;
   changelogNotes?: ChangelogNotes;
   includeComponentInTag?: boolean;
+  includeVInTag?: boolean;
   pullRequestTitlePattern?: string;
   extraFiles?: string[];
 }
@@ -85,6 +86,7 @@ export abstract class BaseStrategy implements Strategy {
   private skipGitHubRelease: boolean;
   private releaseAs?: string;
   protected includeComponentInTag: boolean;
+  protected includeVInTag: boolean;
   private pullRequestTitlePattern?: string;
   readonly extraFiles: string[];
 
@@ -111,6 +113,7 @@ export abstract class BaseStrategy implements Strategy {
     this.changelogNotes =
       options.changelogNotes || new DefaultChangelogNotes(options);
     this.includeComponentInTag = options.includeComponentInTag ?? true;
+    this.includeVInTag = options.includeVInTag ?? true;
     this.pullRequestTitlePattern = options.pullRequestTitlePattern;
     this.extraFiles = options.extraFiles || [];
   }
@@ -239,7 +242,8 @@ export abstract class BaseStrategy implements Strategy {
     const newVersionTag = new TagName(
       newVersion,
       this.includeComponentInTag ? component : undefined,
-      this.tagSeparator
+      this.tagSeparator,
+      this.includeVInTag
     );
     logger.debug('pull request title pattern:', this.pullRequestTitlePattern);
     const pullRequestTitle = PullRequestTitle.ofComponentTargetBranchVersion(
@@ -437,7 +441,8 @@ export abstract class BaseStrategy implements Strategy {
     const tag = new TagName(
       version,
       this.includeComponentInTag ? component : undefined,
-      this.tagSeparator
+      this.tagSeparator,
+      this.includeVInTag
     );
     const releaseName =
       component && this.includeComponentInTag

--- a/src/util/tag-name.ts
+++ b/src/util/tag-name.ts
@@ -15,22 +15,25 @@
 import {Version} from '../version';
 
 const TAG_PATTERN =
-  /^((?<component>.*)(?<separator>[^a-zA-Z]))?v(?<version>\d+\.\d+\.\d+.*)$/;
+  /^((?<component>.*)(?<separator>[^a-zA-Z]))?(?<v>v)?(?<version>\d+\.\d+\.\d+.*)$/;
 const DEFAULT_SEPARATOR = '-';
 
 export class TagName {
   component?: string;
   version: Version;
   separator: string;
+  includeV: boolean;
 
   constructor(
     version: Version,
     component?: string,
-    separator: string = DEFAULT_SEPARATOR
+    separator: string = DEFAULT_SEPARATOR,
+    includeV = true
   ) {
     this.version = version;
     this.component = component;
     this.separator = separator;
+    this.includeV = includeV;
   }
 
   static parse(tagName: string): TagName | undefined {
@@ -39,7 +42,8 @@ export class TagName {
       return new TagName(
         Version.parse(match.groups.version),
         match.groups.component,
-        match.groups.separator
+        match.groups.separator,
+        !!match.groups.v
       );
     }
     return;
@@ -47,8 +51,10 @@ export class TagName {
 
   toString(): string {
     if (this.component) {
-      return `${this.component}${this.separator}v${this.version.toString()}`;
+      return `${this.component}${this.separator}${
+        this.includeV ? 'v' : ''
+      }${this.version.toString()}`;
     }
-    return `v${this.version.toString()}`;
+    return `${this.includeV ? 'v' : ''}${this.version.toString()}`;
   }
 }

--- a/test/fixtures/manifest/config/include-v-in-tag.json
+++ b/test/fixtures/manifest/config/include-v-in-tag.json
@@ -1,0 +1,13 @@
+{
+  "release-type": "simple",
+  "include-v-in-tag": true,
+  "packages": {
+    ".": {
+      "component": "root",
+      "include-v-in-tag": false
+    },
+    "packages/bot-config-utils": {
+      "component": "bot-config-utils"
+    }
+  }
+}

--- a/test/strategies/base.ts
+++ b/test/strategies/base.ts
@@ -186,5 +186,26 @@ describe('Strategy', () => {
       expect(release, 'Release').to.not.be.undefined;
       expect(release!.tag.toString()).to.eql('v1.2.3');
     });
+    it('skips v in release tag', async () => {
+      const strategy = new TestStrategy({
+        targetBranch: 'main',
+        github,
+        component: 'google-cloud-automl',
+        includeComponentInTag: false,
+        includeVInTag: false,
+      });
+      const release = await strategy.buildRelease({
+        title: 'chore(main): release v1.2.3',
+        headBranchName: 'release-please/branches/main',
+        baseBranchName: 'main',
+        number: 1234,
+        body: new PullRequestBody([]).toString(),
+        labels: [],
+        files: [],
+        sha: 'abc123',
+      });
+      expect(release, 'Release').to.not.be.undefined;
+      expect(release!.tag.toString()).to.eql('1.2.3');
+    });
   });
 });

--- a/test/util/tag-name.ts
+++ b/test/util/tag-name.ts
@@ -37,10 +37,37 @@ describe('TagName', () => {
         expect(tagName?.separator).to.eql('/');
         expect(tagName?.toString()).to.eql(name);
       });
+      it('handles tag without a v', () => {
+        const name = 'some-component-1.2.3';
+        const tagName = TagName.parse(name);
+        expect(tagName).to.not.be.undefined;
+        expect(tagName?.component).to.eql('some-component');
+        expect(tagName?.version.toString()).to.eql('1.2.3');
+        expect(tagName?.separator).to.eql('-');
+        expect(tagName?.toString()).to.eql(name);
+      });
+      it('handles tag without a v with a / separator', () => {
+        const name = 'some-component/1.2.3';
+        const tagName = TagName.parse(name);
+        expect(tagName).to.not.be.undefined;
+        expect(tagName?.component).to.eql('some-component');
+        expect(tagName?.version.toString()).to.eql('1.2.3');
+        expect(tagName?.separator).to.eql('/');
+        expect(tagName?.toString()).to.eql(name);
+      });
     });
     describe('without component', () => {
       it('handles a version', () => {
         const name = 'v1.2.3';
+        const tagName = TagName.parse(name);
+        expect(tagName).to.not.be.undefined;
+        expect(tagName?.component).to.be.undefined;
+        expect(tagName?.version.toString()).to.eql('1.2.3');
+        expect(tagName?.separator).to.eql('-');
+        expect(tagName?.toString()).to.eql(name);
+      });
+      it('handles a version without a v', () => {
+        const name = '1.2.3';
         const tagName = TagName.parse(name);
         expect(tagName).to.not.be.undefined;
         expect(tagName?.component).to.be.undefined;


### PR DESCRIPTION
Adds new configuration option `includeVInTag` or `include-v-in-tag` in the manifest JSON.

Fixes #1103
