### PR TITLE
fix: return uploadUrl and body when creating release

### DIFF
--- a/src/github.ts
+++ b/src/github.ts
@@ -163,6 +163,7 @@ export interface GitHubRelease {
   notes?: string;
   url: string;
   draft?: boolean;
+  uploadUrl?: string;
 }
 
 export interface GitHubTag {
@@ -1246,9 +1247,14 @@ export class GitHub {
         name: resp.data.name || undefined,
         tagName: resp.data.tag_name,
         sha: resp.data.target_commitish,
-        notes: resp.data.body_text,
+        notes:
+          resp.data.body_text ||
+          resp.data.body ||
+          resp.data.body_html ||
+          undefined,
         url: resp.data.html_url,
         draft: resp.data.draft,
+        uploadUrl: resp.data.upload_url,
       };
     },
     e => {

--- a/test/github.ts
+++ b/test/github.ts
@@ -604,6 +604,7 @@ describe('GitHub', () => {
           upload_url:
             'https://uploads.github.com/repos/fake/fake/releases/1/assets{?name,label}',
           target_commitish: 'abc123',
+          body: 'Some release notes response.',
         });
       const release = await github.createRelease({
         tag: new TagName(Version.parse('1.2.3')),
@@ -625,6 +626,10 @@ describe('GitHub', () => {
       expect(release.tagName).to.eql('v1.2.3');
       expect(release.sha).to.eql('abc123');
       expect(release.draft).to.be.false;
+      expect(release.uploadUrl).to.eql(
+        'https://uploads.github.com/repos/fake/fake/releases/1/assets{?name,label}'
+      );
+      expect(release.notes).to.eql('Some release notes response.');
     });
 
     it('should raise a DuplicateReleaseError if already_exists', async () => {


### PR DESCRIPTION
release-please now returns an addition `uploadUrl` field when creating a release. Additionally, we fix it to look in all the body fields (`body_text`, `body`, and `body_html`) to attempt to return the release notes. This value has been returned as `notes` since v13 and will continue to do so.

Fixes #1286 
