### PR TITLE
fix: manifest release can handle componentless entry

### DIFF
--- a/__snapshots__/manifest.js
+++ b/__snapshots__/manifest.js
@@ -88,6 +88,35 @@ exports['Manifest buildPullRequests should allow overriding commit message 1'] =
 This PR was generated with [Release Please](https://github.com/googleapis/release-please). See [documentation](https://github.com/googleapis/release-please#release-please).
 `
 
+exports['Manifest buildPullRequests should handle mixing componentless configs 1'] = `
+:robot: I have created a release *beep* *boop*
+---
+
+
+<details><summary>1.0.1</summary>
+
+### [1.0.1](https://github.com/fake-owner/fake-repo/compare/v1.0.0...v1.0.1) (1983-10-10)
+
+
+### Bug Fixes
+
+* some bugfix ([aaaaaa](https://github.com/fake-owner/fake-repo/commit/aaaaaa))
+</details>
+
+<details><summary>pkg2: 0.2.4</summary>
+
+### [0.2.4](https://github.com/fake-owner/fake-repo/compare/pkg2-v0.2.3...pkg2-v0.2.4) (1983-10-10)
+
+
+### Bug Fixes
+
+* some bugfix ([bbbbbb](https://github.com/fake-owner/fake-repo/commit/bbbbbb))
+</details>
+
+---
+This PR was generated with [Release Please](https://github.com/googleapis/release-please). See [documentation](https://github.com/googleapis/release-please#release-please).
+`
+
 exports['Manifest buildPullRequests should handle multiple package repository 1'] = `
 :robot: I have created a release *beep* *boop*
 ---

--- a/__snapshots__/pull-request-body.js
+++ b/__snapshots__/pull-request-body.js
@@ -42,6 +42,25 @@ some special notes go here
 This PR was generated with [Release Please](https://github.com/googleapis/release-please). See [documentation](https://github.com/googleapis/release-please#release-please).
 `
 
+exports['PullRequestBody toString can handle componently entries 1'] = `
+:robot: I have created a release *beep* *boop*
+---
+
+
+<details><summary>1.2.3</summary>
+
+some special notes go here
+</details>
+
+<details><summary>pkg2: 2.0.0</summary>
+
+more special notes go here
+</details>
+
+---
+This PR was generated with [Release Please](https://github.com/googleapis/release-please). See [documentation](https://github.com/googleapis/release-please#release-please).
+`
+
 exports['PullRequestBody toString can handle multiple entries 1'] = `
 :robot: I have created a release *beep* *boop*
 ---

--- a/src/util/pull-request-body.ts
+++ b/src/util/pull-request-body.ts
@@ -64,8 +64,8 @@ export class PullRequestBody {
       return this.releaseData
         .map(release => {
           return `<details><summary>${
-            release.component
-          }: ${release.version?.toString()}</summary>\n\n${
+            release.component ? `${release.component}: ` : ''
+          }${release.version?.toString()}</summary>\n\n${
             release.notes
           }\n</details>`;
         })

--- a/src/util/pull-request-body.ts
+++ b/src/util/pull-request-body.ts
@@ -109,6 +109,7 @@ function splitBody(
 }
 
 const SUMMARY_PATTERN = /^(?<component>.*[^:]):? (?<version>\d+\.\d+\.\d+.*)$/;
+const COMPONENTLESS_SUMMARY_PATTERN = /^(?<version>\d+\.\d+\.\d+.*)$/;
 export interface ReleaseData {
   component?: string;
   version?: Version;
@@ -121,17 +122,27 @@ function extractMultipleReleases(notes: string): ReleaseData[] {
     const summaryNode = detail.getElementsByTagName('summary')[0];
     const summary = summaryNode?.textContent;
     const match = summary.match(SUMMARY_PATTERN);
-    if (!match?.groups) {
-      logger.warn(`Summary: ${summary} did not match the expected pattern`);
-      continue;
+    if (match?.groups) {
+      detail.removeChild(summaryNode);
+      const notes = detail.textContent.trim();
+      data.push({
+        component: match.groups.component,
+        version: Version.parse(match.groups.version),
+        notes,
+      });
+    } else {
+      const componentlessMatch = summary.match(COMPONENTLESS_SUMMARY_PATTERN);
+      if (!componentlessMatch?.groups) {
+        logger.warn(`Summary: ${summary} did not match the expected pattern`);
+        continue;
+      }
+      detail.removeChild(summaryNode);
+      const notes = detail.textContent.trim();
+      data.push({
+        version: Version.parse(componentlessMatch.groups.version),
+        notes,
+      });
     }
-    detail.removeChild(summaryNode);
-    const notes = detail.textContent.trim();
-    data.push({
-      component: match.groups.component,
-      version: Version.parse(match.groups.version),
-      notes,
-    });
   }
   return data;
 }

--- a/test/fixtures/release-notes/mixed-componentless-manifest.txt
+++ b/test/fixtures/release-notes/mixed-componentless-manifest.txt
@@ -1,0 +1,19 @@
+:robot: I have created a release \*beep\* \*boop\*
+---
+<details><summary>3.2.0</summary>
+
+
+### Features
+
+* upgrade to gcf-utils@12 ([#2262](https://www.github.com/googleapis/repo-automation-bots/issues/2262)) ([bd04376](https://www.github.com/googleapis/repo-automation-bots/commit/bd043767ae59a4eed450f1d18741111dc4c3f8e8))
+</details>
+<details><summary>@google-automations/label-utils: 1.1.0</summary>
+
+
+### Features
+
+* upgrade to gcf-utils@12 ([#2262](https://www.github.com/googleapis/repo-automation-bots/issues/2262)) ([bd04376](https://www.github.com/googleapis/repo-automation-bots/commit/bd043767ae59a4eed450f1d18741111dc4c3f8e8))
+</details>
+
+
+This PR was generated with [Release Please](https://github.com/googleapis/release-please). See [documentation](https://github.com/googleapis/release-please#release-please).

--- a/test/util/pull-request-body.ts
+++ b/test/util/pull-request-body.ts
@@ -191,5 +191,21 @@ describe('PullRequestBody', () => {
       expect(pullRequestBody2?.header).to.eql('My special header!!!');
       expect(pullRequestBody2?.footer).to.eql('A custom footer');
     });
+
+    it('can handle componently entries', () => {
+      const data = [
+        {
+          version: Version.parse('1.2.3'),
+          notes: 'some special notes go here',
+        },
+        {
+          component: 'pkg2',
+          version: Version.parse('2.0.0'),
+          notes: 'more special notes go here',
+        },
+      ];
+      const pullRequestBody = new PullRequestBody(data);
+      snapshot(pullRequestBody.toString());
+    });
   });
 });

--- a/test/util/pull-request-body.ts
+++ b/test/util/pull-request-body.ts
@@ -54,6 +54,24 @@ describe('PullRequestBody', () => {
       expect(releaseData[3].version?.toString()).to.eql('2.1.0');
       expect(releaseData[3].notes).matches(/^### Features/);
     });
+    it('should parse multiple components mixed with componentless', () => {
+      const body = readFileSync(
+        resolve(fixturesPath, './mixed-componentless-manifest.txt'),
+        'utf8'
+      );
+      const pullRequestBody = PullRequestBody.parse(body);
+      expect(pullRequestBody).to.not.be.undefined;
+      const releaseData = pullRequestBody!.releaseData;
+      expect(releaseData).lengthOf(2);
+      expect(releaseData[0].component).to.be.undefined;
+      expect(releaseData[0].version?.toString()).to.eql('3.2.0');
+      expect(releaseData[0].notes).matches(/^### Features/);
+      expect(releaseData[1].component).to.eql(
+        '@google-automations/label-utils'
+      );
+      expect(releaseData[1].version?.toString()).to.eql('1.1.0');
+      expect(releaseData[1].notes).matches(/^### Features/);
+    });
     it('should parse single component from legacy manifest release', () => {
       const body = readFileSync(
         resolve(fixturesPath, './single-manifest.txt'),


### PR DESCRIPTION
We now build a more friendly `<summary>` section with just the version. `PullRequestBody` can create and parse this new format.

Fixes #1294
