### PR TITLE
fix: address false-positive matches for autorelease branch naming

### DIFF
--- a/src/util/branch-name.ts
+++ b/src/util/branch-name.ts
@@ -101,8 +101,12 @@ export class BranchName {
  */
 const AUTORELEASE_PATTERN =
   /^release-?(?<component>[\w-.]*)?-v(?<version>[0-9].*)$/;
+const RELEASE_PLEASE_BRANCH_PREFIX = 'release-please--branches';
 class AutoreleaseBranchName extends BranchName {
   static matches(branchName: string): boolean {
+    if (branchName.startsWith(RELEASE_PLEASE_BRANCH_PREFIX)) {
+      return false;
+    }
     return !!branchName.match(AUTORELEASE_PATTERN);
   }
   constructor(branchName: string) {

--- a/test/util/branch-name.ts
+++ b/test/util/branch-name.ts
@@ -76,6 +76,26 @@ describe('BranchName', () => {
       expect(branchName?.toString()).to.eql(name);
     });
 
+    it('parses a target branch that starts with a v', () => {
+      const name = 'release-please--branches--v3.3.x';
+      const branchName = BranchName.parse(name);
+      expect(branchName).to.not.be.undefined;
+      expect(branchName?.getTargetBranch()).to.eql('v3.3.x');
+      expect(branchName?.getComponent()).to.be.undefined;
+      expect(branchName?.getVersion()).to.be.undefined;
+      expect(branchName?.toString()).to.eql(name);
+    });
+
+    it('parses a target branch named with a valid semver', () => {
+      const name = 'release-please--branches--v3.3.9';
+      const branchName = BranchName.parse(name);
+      expect(branchName).to.not.be.undefined;
+      expect(branchName?.getTargetBranch()).to.eql('v3.3.9');
+      expect(branchName?.getComponent()).to.be.undefined;
+      expect(branchName?.getVersion()).to.be.undefined;
+      expect(branchName?.toString()).to.eql(name);
+    });
+
     it('parses a target branch and component', () => {
       const name = 'release-please--branches--main--components--storage';
       const branchName = BranchName.parse(name);


### PR DESCRIPTION
Autorelease branch naming can mistakenly match for any branch
beginning with a v.  A PR branch like
"release-please--branches--v3.3.x" will be treated as an autorelease
branch for a component called "please--branches-".

If the branch name is a valid semver, the wrong class will be chosen
to parse the branch name, and later steps will fail.  If it's not a
valid semver, then branch parsing will completely fail.

This excludes these false-positive matches by excluding branches which
start with "release-please--branches".

- [x] Make sure to open an issue as a [bug/issue](https://github.com/googleapis/release-please/issues/new/choose) before writing your code!  That way we can discuss the change, evaluate designs, and agree on the general idea
- [x] Ensure the tests and linter pass
- [x] Code coverage does not decrease (if any source code was changed)
- [x] Appropriate docs were updated (if necessary)

Fixes #1310 🦕