### PR TITLE
fix: node-workspace plugin should update package.json versions

### DIFF
--- a/__snapshots__/node-workspace.js
+++ b/__snapshots__/node-workspace.js
@@ -18,7 +18,7 @@ Release notes for path: node1, releaseType: node
     * @here/pkgA bumped from 3.3.3 to ^3.3.4
 </details>
 
-<details><summary>@here/pkgC: 1.1.1</summary>
+<details><summary>@here/pkgC: 1.1.2</summary>
 
 ### Dependencies
 
@@ -74,7 +74,7 @@ exports['NodeWorkspace plugin run walks dependency tree and updates previously u
 Release notes for path: node1, releaseType: node
 </details>
 
-<details><summary>@here/pkgB: 2.2.2</summary>
+<details><summary>@here/pkgB: 2.2.3</summary>
 
 ### Dependencies
 
@@ -83,7 +83,7 @@ Release notes for path: node1, releaseType: node
     * @here/pkgA bumped from 3.3.3 to ^3.3.4
 </details>
 
-<details><summary>@here/pkgC: 1.1.1</summary>
+<details><summary>@here/pkgC: 1.1.2</summary>
 
 ### Dependencies
 

--- a/__snapshots__/node-workspace.js
+++ b/__snapshots__/node-workspace.js
@@ -31,6 +31,27 @@ Release notes for path: node1, releaseType: node
 This PR was generated with [Release Please](https://github.com/googleapis/release-please). See [documentation](https://github.com/googleapis/release-please#release-please).
 `
 
+exports['NodeWorkspace plugin run appends dependency notes to an updated module 2'] = `
+other notes
+`
+
+exports['NodeWorkspace plugin run appends dependency notes to an updated module 3'] = `
+### Dependencies
+
+* update dependency foo/bar to 1.2.3
+* The following workspace dependencies were updated
+  * dependencies
+    * @here/pkgA bumped from 3.3.3 to ^3.3.4
+`
+
+exports['NodeWorkspace plugin run appends dependency notes to an updated module 4'] = `
+### Dependencies
+
+* The following workspace dependencies were updated
+  * dependencies
+    * @here/pkgB bumped from 2.2.2 to ^2.2.3
+`
+
 exports['NodeWorkspace plugin run combines node packages 1'] = `
 :robot: I have created a release *beep* *boop*
 ---

--- a/src/plugins/node-workspace.ts
+++ b/src/plugins/node-workspace.ts
@@ -157,6 +157,13 @@ export class NodeWorkspace extends WorkspacePlugin<Package> {
       throw new Error(`Could not find graph package for ${pkg.name}`);
     }
     const updatedPackage = pkg.clone();
+    // Update version of the package
+    const newVersion = updatedVersions.get(updatedPackage.name);
+    if (newVersion) {
+      logger.info(`Updating ${updatedPackage.name} to ${newVersion}`);
+      updatedPackage.version = newVersion.toString();
+    }
+    // Update dependency versions
     for (const [depName, resolved] of graphPackage.localDependencies) {
       const depVersion = updatedVersions.get(depName);
       if (depVersion && resolved.type !== 'directory') {
@@ -213,6 +220,12 @@ export class NodeWorkspace extends WorkspacePlugin<Package> {
       throw new Error(`Could not find graph package for ${pkg.name}`);
     }
     const updatedPackage = pkg.clone();
+    // Update version of the package
+    const newVersion = updatedVersions.get(updatedPackage.name);
+    if (newVersion) {
+      logger.info(`Updating ${updatedPackage.name} to ${newVersion}`);
+      updatedPackage.version = newVersion.toString();
+    }
     for (const [depName, resolved] of graphPackage.localDependencies) {
       const depVersion = updatedVersions.get(depName);
       if (depVersion && resolved.type !== 'directory') {

--- a/src/plugins/node-workspace.ts
+++ b/src/plugins/node-workspace.ts
@@ -185,10 +185,13 @@ export class NodeWorkspace extends WorkspacePlugin<Package> {
             jsonStringify(updatedPackage.toJSON(), updatedPackage.rawContent)
           );
         } else if (update.updater instanceof Changelog) {
-          update.updater.changelogEntry = appendDependenciesSectionToChangelog(
-            update.updater.changelogEntry,
-            dependencyNotes
-          );
+          if (dependencyNotes) {
+            update.updater.changelogEntry =
+              appendDependenciesSectionToChangelog(
+                update.updater.changelogEntry,
+                dependencyNotes
+              );
+          }
         }
         return update;
       });
@@ -264,7 +267,10 @@ export class NodeWorkspace extends WorkspacePlugin<Package> {
           createIfMissing: false,
           updater: new Changelog({
             version,
-            changelogEntry: dependencyNotes,
+            changelogEntry: appendDependenciesSectionToChangelog(
+              '',
+              dependencyNotes
+            ),
           }),
         },
       ],

--- a/test/plugins/node-workspace.ts
+++ b/test/plugins/node-workspace.ts
@@ -53,6 +53,13 @@ export function buildMockPackageUpdate(
   };
 }
 
+function assertHasVersionUpdate(update: Update, expectedVersion: string) {
+  expect(update.updater).instanceof(RawContent);
+  const updater = update.updater as RawContent;
+  const data = JSON.parse(updater.rawContent);
+  expect(data.version).to.eql(expectedVersion);
+}
+
 describe('NodeWorkspace plugin', () => {
   let github: GitHub;
   let plugin: ManifestPlugin;
@@ -170,10 +177,22 @@ describe('NodeWorkspace plugin', () => {
       );
       expect(nodeCandidate).to.not.be.undefined;
       const updates = nodeCandidate!.pullRequest.updates;
-      assertHasUpdate(updates, 'node1/package.json', RawContent);
-      assertHasUpdate(updates, 'node2/package.json', RawContent);
-      assertHasUpdate(updates, 'node3/package.json', RawContent);
-      assertHasUpdate(updates, 'node4/package.json', RawContent);
+      assertHasVersionUpdate(
+        assertHasUpdate(updates, 'node1/package.json', RawContent),
+        '3.3.4'
+      );
+      assertHasVersionUpdate(
+        assertHasUpdate(updates, 'node2/package.json', RawContent),
+        '2.2.3'
+      );
+      assertHasVersionUpdate(
+        assertHasUpdate(updates, 'node3/package.json', RawContent),
+        '1.1.2'
+      );
+      assertHasVersionUpdate(
+        assertHasUpdate(updates, 'node4/package.json', RawContent),
+        '4.4.5'
+      );
       snapshot(dateSafe(nodeCandidate!.pullRequest.body.toString()));
     });
     it('appends dependency notes to an updated module', async () => {
@@ -212,9 +231,18 @@ describe('NodeWorkspace plugin', () => {
       );
       expect(nodeCandidate).to.not.be.undefined;
       const updates = nodeCandidate!.pullRequest.updates;
-      assertHasUpdate(updates, 'node1/package.json', RawContent);
-      assertHasUpdate(updates, 'node2/package.json', RawContent);
-      assertHasUpdate(updates, 'node3/package.json', RawContent);
+      assertHasVersionUpdate(
+        assertHasUpdate(updates, 'node1/package.json', RawContent),
+        '3.3.4'
+      );
+      assertHasVersionUpdate(
+        assertHasUpdate(updates, 'node2/package.json', RawContent),
+        '2.2.3'
+      );
+      assertHasVersionUpdate(
+        assertHasUpdate(updates, 'node3/package.json', RawContent),
+        '1.1.2'
+      );
       assertNoHasUpdate(updates, 'node4/package.json');
       snapshot(dateSafe(nodeCandidate!.pullRequest.body.toString()));
     });


### PR DESCRIPTION
We are correctly calculating the final version numbers in the node-workspace plugin, but we aren't setting the version entry in the package.json (we were correctly updating the versions in the dependencies sections).

Fixes #1317
