### PR TITLE
feat: keep non-conforming commits as `undefined` type

### DIFF
--- a/src/changelog-notes.ts
+++ b/src/changelog-notes.ts
@@ -51,6 +51,7 @@ const DEFAULT_HEADINGS: Record<string, string> = {
   test: 'Tests',
   build: 'Build System',
   ci: 'Continuous Integration',
+  undefined: 'Non-conforming Commits',
 };
 
 export function buildChangelogSections(scopes: string[]): ChangelogSection[] {

--- a/test/commits.ts
+++ b/test/commits.ts
@@ -24,15 +24,19 @@ describe('parseConventionalCommits', () => {
       buildMockCommit('feat: some feature'),
       buildMockCommit('fix: some bugfix'),
       buildMockCommit('docs: some documentation'),
+      buildMockCommit('invalid message'),
     ];
     const conventionalCommits = parseConventionalCommits(commits);
-    expect(conventionalCommits).lengthOf(3);
+    expect(conventionalCommits).lengthOf(4);
     expect(conventionalCommits[0].type).to.equal('feat');
     expect(conventionalCommits[0].scope).is.null;
     expect(conventionalCommits[1].type).to.equal('fix');
     expect(conventionalCommits[1].scope).is.null;
     expect(conventionalCommits[2].type).to.equal('docs');
     expect(conventionalCommits[2].scope).is.null;
+    expect(conventionalCommits[3].type).to.equal('undefined');
+    expect(conventionalCommits[3].scope).is.null;
+    expect(conventionalCommits[3].bareMessage).is.equal('invalid message');
   });
 
   it('can parse a breaking change', async () => {


### PR DESCRIPTION
Conventional commits are great, but people make mistakes. Commits without conventional format got thrown away completely. This patch allows them to be displayed in Release Notes, and passed to a custom Release Notes generator as well. That way, information from those commits won't be lost during release.

This change should not be breaking,  despite its nature.

**Use-cases**
- Enable `undefined` type and simply append non-conforming commits to Release Notes
- Support "dirty" repo not following conventional commits spec completely (this can happen easily when for example forking repo and updating from upstream)
- Custom Release Notes generator, which might need all commits to work with.

Change itself is a bit dirty, but was easier way to add the support, and keep all the complex logic of commit processing in place.

Since this change might be a bit controversial, I'm open to a discussion :-)