### PR TITLE
feat: introduce generic xml updater

### DIFF
--- a/__snapshots__/generic-xml.js
+++ b/__snapshots__/generic-xml.js
@@ -1,0 +1,22 @@
+exports['GenericXml updateContent updates matching entry 1'] = `
+<?xml version="1.0" encoding="utf-8"?>
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <Version>2.3.4</Version>
+    <TargetFrameworks>netstandard2.0;net461</TargetFrameworks>
+    <GenerateDocumentationFile>true</GenerateDocumentationFile>
+    <Description>Recommended Google client library to access the Google Cloud Channel API, which enables Google Cloud resellers and distributors to manage their customers, channel partners, entitlements and reports.</Description>
+    <PackageTags>channel;reseller;Google;Cloud</PackageTags>
+    <CodeAnalysisRuleSet>..\\..\\..\\grpc.ruleset</CodeAnalysisRuleSet>
+  </PropertyGroup>
+  <ItemGroup>
+    <PackageReference Include="ConfigureAwaitChecker.Analyzer" Version="5.0.0" PrivateAssets="All"/>
+    <PackageReference Include="Google.Api.Gax.Grpc.GrpcCore" Version="[3.5.0, 4.0.0)"/>
+    <PackageReference Include="Google.LongRunning" Version="[2.3.0, 3.0.0)"/>
+    <PackageReference Include="Grpc.Core" Version="[2.38.1, 3.0.0)" PrivateAssets="None"/>
+    <PackageReference Include="Microsoft.DotNet.Analyzers.Compatibility" Version="0.2.12-alpha" PrivateAssets="All"/>
+    <PackageReference Include="Microsoft.NETFramework.ReferenceAssemblies" Version="1.0.2" PrivateAssets="All"/>
+    <Analyzer Condition="Exists('..\\..\\..\\tools\\Google.Cloud.Tools.Analyzers\\bin\\$(Configuration)\\netstandard1.3\\publish\\Google.Cloud.Tools.Analyzers.dll')" Include="..\\..\\..\\tools\\Google.Cloud.Tools.Analyzers\\bin\\$(Configuration)\\netstandard1.3\\publish\\Google.Cloud.Tools.Analyzers.dll"/>
+  </ItemGroup>
+</Project>
+`

--- a/docs/customizing.md
+++ b/docs/customizing.md
@@ -167,3 +167,22 @@ configuration.
 [JSONPath](https://goessner.net/articles/JsonPath/) is a simple query syntax
 for JSON that is similar to XPath for XML. The `jsonpath` configuration
 informs release-please on which JSON field to update with the new version.
+
+## Updating arbitrary XML files
+
+For most release strategies, you can provide additional files to update
+using the [GenericXml](/src/updaters/generic-xml.ts) updater. You can
+specify a configuration object in the `extra-files` option in the manifest
+configuration.
+
+```json
+{
+  "extra-files": [
+    {
+      "type": "xml",
+      "path": "path/to/file.xml",
+      "xpath": "//xpath/to/field"
+    }
+  ]
+}
+```

--- a/package.json
+++ b/package.json
@@ -47,6 +47,7 @@
     "@types/pino": "^7.0.0",
     "@types/semver": "^7.0.0",
     "@types/sinon": "^10.0.0",
+    "@types/xmldom": "^0.1.31",
     "@types/yargs": "^17.0.0",
     "c8": "^7.0.0",
     "chai": "^4.2.0",
@@ -85,6 +86,8 @@
     "typescript": "^3.8.3",
     "unist-util-visit": "^2.0.3",
     "unist-util-visit-parents": "^3.1.1",
+    "xmldom": "^0.6.0",
+    "xpath": "^0.0.32",
     "yargs": "^17.0.0"
   },
   "engines": {

--- a/src/manifest.ts
+++ b/src/manifest.ts
@@ -43,7 +43,12 @@ type ExtraJsonFile = {
   path: string;
   jsonpath: string;
 };
-export type ExtraFile = string | ExtraJsonFile;
+type ExtraXmlFile = {
+  type: 'xml';
+  path: string;
+  xpath: string;
+};
+export type ExtraFile = string | ExtraJsonFile | ExtraXmlFile;
 /**
  * These are configurations provided to each strategy per-path.
  */

--- a/src/strategies/base.ts
+++ b/src/strategies/base.ts
@@ -38,6 +38,7 @@ import {PullRequest} from '../pull-request';
 import {mergeUpdates} from '../updaters/composite';
 import {Generic} from '../updaters/generic';
 import {GenericJson} from '../updaters/generic-json';
+import {GenericXml} from '../updaters/generic-xml';
 
 const DEFAULT_CHANGELOG_PATH = 'CHANGELOG.md';
 
@@ -305,8 +306,18 @@ export abstract class BaseStrategy implements Strategy {
               createIfMissing: false,
               updater: new GenericJson(extraFile.jsonpath, version),
             };
+          case 'xml':
+            return {
+              path: this.addPath(extraFile.path),
+              createIfMissing: false,
+              updater: new GenericXml(extraFile.xpath, version),
+            };
           default:
-            throw new Error(`unsupported extraFile type: ${extraFile.type}`);
+            throw new Error(
+              `unsupported extraFile type: ${
+                (extraFile as {type: string}).type
+              }`
+            );
         }
       }
       return {

--- a/src/updaters/generic-xml.ts
+++ b/src/updaters/generic-xml.ts
@@ -1,0 +1,49 @@
+// Copyright 2022 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import {Updater} from '../update';
+import {Version} from '../version';
+import * as xpath from 'xpath';
+import * as dom from 'xmldom';
+
+export class GenericXml implements Updater {
+  private xpath: string;
+  private version: Version;
+
+  constructor(xpath: string, version: Version) {
+    this.xpath = xpath;
+    this.version = version;
+  }
+  /**
+   * Given initial file contents, return updated contents.
+   * @param {string} content The initial content
+   * @returns {string} The updated content
+   */
+  updateContent(content: string): string {
+    const document = new dom.DOMParser().parseFromString(content);
+    const iterator = xpath.evaluate(this.xpath, document, null, 0, null);
+    let node: Node | null;
+    let updated = false;
+    while (node = iterator.iterateNext()) {
+      node.textContent = this.version.toString();
+      updated = true;
+    }
+
+    if (updated) {
+      return new dom.XMLSerializer().serializeToString(document);
+    } else {
+      return content;
+    }
+  }
+}

--- a/src/updaters/generic-xml.ts
+++ b/src/updaters/generic-xml.ts
@@ -35,7 +35,7 @@ export class GenericXml implements Updater {
     const iterator = xpath.evaluate(this.xpath, document, null, 0, null);
     let node: Node | null;
     let updated = false;
-    while (node = iterator.iterateNext()) {
+    while ((node = iterator.iterateNext())) {
       node.textContent = this.version.toString();
       updated = true;
     }

--- a/test/strategies/base.ts
+++ b/test/strategies/base.ts
@@ -23,6 +23,7 @@ import snapshot = require('snap-shot-it');
 import {dateSafe, assertHasUpdate} from '../helpers';
 import {GenericJson} from '../../src/updaters/generic-json';
 import {Generic} from '../../src/updaters/generic';
+import {GenericXml} from '../../src/updaters/generic-xml';
 
 const sandbox = sinon.createSandbox();
 
@@ -110,6 +111,23 @@ describe('Strategy', () => {
       expect(updates).to.be.an('array');
       assertHasUpdate(updates!, '0', Generic);
       assertHasUpdate(updates!, '3.json', GenericJson);
+    });
+    it('updates extra Xml files', async () => {
+      const strategy = new TestStrategy({
+        targetBranch: 'main',
+        github,
+        component: 'google-cloud-automl',
+        extraFiles: ['0', {type: 'xml', path: '/3.xml', xpath: '$.foo'}],
+      });
+      const pullRequest = await strategy.buildReleasePullRequest(
+        [{sha: 'aaa', message: 'fix: a bugfix'}],
+        undefined
+      );
+      expect(pullRequest).to.exist;
+      const updates = pullRequest?.updates;
+      expect(updates).to.be.an('array');
+      assertHasUpdate(updates!, '0', Generic);
+      assertHasUpdate(updates!, '3.xml', GenericXml);
     });
     it('rejects relative extra files', async () => {
       const extraFiles = [

--- a/test/updaters/generic-xml.ts
+++ b/test/updaters/generic-xml.ts
@@ -18,7 +18,7 @@ import * as snapshot from 'snap-shot-it';
 import {describe, it} from 'mocha';
 import {Version} from '../../src/version';
 import {GenericXml} from '../../src/updaters/generic-xml';
-import {expect, assert} from 'chai';
+import {expect} from 'chai';
 
 const fixturesPath = './test/updaters/fixtures';
 
@@ -29,7 +29,10 @@ describe('GenericXml', () => {
         resolve(fixturesPath, './Foo.csproj'),
         'utf8'
       ).replace(/\r\n/g, '\n');
-      const updater = new GenericXml('//Project/PropertyGroup/Version', Version.parse('v2.3.4'));
+      const updater = new GenericXml(
+        '//Project/PropertyGroup/Version',
+        Version.parse('v2.3.4')
+      );
       const newContent = updater.updateContent(oldContent);
       snapshot(newContent);
     });
@@ -38,7 +41,10 @@ describe('GenericXml', () => {
         resolve(fixturesPath, './Foo.csproj'),
         'utf8'
       ).replace(/\r\n/g, '\n');
-      const updater = new GenericXml('//project/nonExistent', Version.parse('v2.3.4'));
+      const updater = new GenericXml(
+        '//project/nonExistent',
+        Version.parse('v2.3.4')
+      );
       const newContent = updater.updateContent(oldContent);
       expect(newContent).to.eql(oldContent);
     });

--- a/test/updaters/generic-xml.ts
+++ b/test/updaters/generic-xml.ts
@@ -1,0 +1,46 @@
+// Copyright 2022 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import {readFileSync} from 'fs';
+import {resolve} from 'path';
+import * as snapshot from 'snap-shot-it';
+import {describe, it} from 'mocha';
+import {Version} from '../../src/version';
+import {GenericXml} from '../../src/updaters/generic-xml';
+import {expect, assert} from 'chai';
+
+const fixturesPath = './test/updaters/fixtures';
+
+describe('GenericXml', () => {
+  describe('updateContent', () => {
+    it('updates matching entry', async () => {
+      const oldContent = readFileSync(
+        resolve(fixturesPath, './Foo.csproj'),
+        'utf8'
+      ).replace(/\r\n/g, '\n');
+      const updater = new GenericXml('//Project/PropertyGroup/Version', Version.parse('v2.3.4'));
+      const newContent = updater.updateContent(oldContent);
+      snapshot(newContent);
+    });
+    it('ignores non-matching entry', async () => {
+      const oldContent = readFileSync(
+        resolve(fixturesPath, './Foo.csproj'),
+        'utf8'
+      ).replace(/\r\n/g, '\n');
+      const updater = new GenericXml('//project/nonExistent', Version.parse('v2.3.4'));
+      const newContent = updater.updateContent(oldContent);
+      expect(newContent).to.eql(oldContent);
+    });
+  });
+});


### PR DESCRIPTION
For most release strategies, you can provide additional files to update
using the [GenericXml](/src/updaters/generic-xml.ts) updater. You can
specify a configuration object in the `extra-files` option in the manifest
configuration.

```json
{
  "extra-files": [
    {
      "type": "xml",
      "path": "path/to/file.xml",
      "xpath": "//xpath/to/field"
    }
  ]
}
```

