### PR TITLE
feat: extensible factories

### DIFF
--- a/__snapshots__/cli.js
+++ b/__snapshots__/cli.js
@@ -182,7 +182,7 @@ Options:
   --snapshot                        is it a snapshot (or pre-release) being
                                     generated?        [boolean] [default: false]
   --versioning-strategy             strategy used for bumping versions
-  [choices: "default", "always-bump-patch", "service-pack"] [default: "default"]
+  [choices: "always-bump-patch", "default", "service-pack"] [default: "default"]
   --changelog-path                  where can the CHANGELOG be found in the
                                     project?  [string] [default: "CHANGELOG.md"]
   --changelog-type                  type of changelog to build

--- a/src/factories/changelog-notes-factory.ts
+++ b/src/factories/changelog-notes-factory.ts
@@ -54,6 +54,10 @@ export function registerChangelogNotes(
   changelogNotesFactories[name] = changelogNotesBuilder;
 }
 
+export function unregisterChangelogNotes(name: string) {
+  delete changelogNotesFactories[name];
+}
+
 export function getChangelogTypes(): readonly ChangelogNotesType[] {
   return Object.keys(changelogNotesFactories).sort();
 }

--- a/src/factories/changelog-notes-factory.ts
+++ b/src/factories/changelog-notes-factory.ts
@@ -1,0 +1,59 @@
+// Copyright 2022 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import {GitHub} from '../github';
+import {ChangelogNotes, ChangelogSection} from '../changelog-notes';
+import {GitHubChangelogNotes} from '../changelog-notes/github';
+import {DefaultChangelogNotes} from '../changelog-notes/default';
+
+export type ChangelogNotesType = string;
+
+export interface ChangelogNotesFactoryOptions {
+  type: ChangelogNotesType;
+  github: GitHub;
+  changelogSections?: ChangelogSection[];
+  commitPartial?: string;
+  headerPartial?: string;
+  mainTemplate?: string;
+}
+
+export type ChangelogNotesBuilder = (
+  options: ChangelogNotesFactoryOptions
+) => ChangelogNotes;
+
+const changelogNotesFactories: Record<string, ChangelogNotesBuilder> = {
+  github: options => new GitHubChangelogNotes(options.github),
+  default: options => new DefaultChangelogNotes(options),
+};
+
+export function buildChangelogNotes(
+  options: ChangelogNotesFactoryOptions
+): ChangelogNotes {
+  const builder = changelogNotesFactories[options.type];
+  if (builder) {
+    return builder(options);
+  }
+  throw new Error(`Unknown changelog type: ${options.type}`);
+}
+
+export function registerChangelogNotes(
+  name: string,
+  changelogNotesBuilder: ChangelogNotesBuilder
+) {
+  changelogNotesFactories[name] = changelogNotesBuilder;
+}
+
+export function getChangelogTypes(): readonly ChangelogNotesType[] {
+  return Object.keys(changelogNotesFactories).sort();
+}

--- a/src/factories/plugin-factory.ts
+++ b/src/factories/plugin-factory.ts
@@ -84,6 +84,10 @@ export function registerPlugin(name: string, pluginBuilder: PluginBuilder) {
   pluginFactories[name] = pluginBuilder;
 }
 
+export function unregisterPlugin(name: string) {
+  delete pluginFactories[name];
+}
+
 export function getPluginTypes(): readonly VersioningStrategyType[] {
   return Object.keys(pluginFactories).sort();
 }

--- a/src/factories/plugin-factory.ts
+++ b/src/factories/plugin-factory.ts
@@ -1,0 +1,89 @@
+// Copyright 2022 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import {
+  LinkedVersionPluginConfig,
+  PluginType,
+  RepositoryConfig,
+} from '../manifest';
+import {GitHub} from '../github';
+import {ManifestPlugin} from '../plugin';
+import {LinkedVersions} from '../plugins/linked-versions';
+import {CargoWorkspace} from '../plugins/cargo-workspace';
+import {NodeWorkspace} from '../plugins/node-workspace';
+import {VersioningStrategyType} from './versioning-strategy-factory';
+
+export interface PluginFactoryOptions {
+  type: PluginType;
+  github: GitHub;
+  targetBranch: string;
+  repositoryConfig: RepositoryConfig;
+
+  // node options
+  alwaysLinkLocal?: boolean;
+
+  // workspace options
+  updateAllPackages?: boolean;
+}
+
+export type PluginBuilder = (options: PluginFactoryOptions) => ManifestPlugin;
+
+const pluginFactories: Record<string, PluginBuilder> = {
+  'linked-versions': options =>
+    new LinkedVersions(
+      options.github,
+      options.targetBranch,
+      options.repositoryConfig,
+      (options.type as LinkedVersionPluginConfig).groupName,
+      (options.type as LinkedVersionPluginConfig).components
+    ),
+  'cargo-workspace': options =>
+    new CargoWorkspace(
+      options.github,
+      options.targetBranch,
+      options.repositoryConfig,
+      options
+    ),
+  'node-workspace': options =>
+    new NodeWorkspace(
+      options.github,
+      options.targetBranch,
+      options.repositoryConfig,
+      options
+    ),
+};
+
+export function buildPlugin(options: PluginFactoryOptions): ManifestPlugin {
+  if (typeof options.type === 'object') {
+    const builder = pluginFactories[options.type.type];
+    if (builder) {
+      return builder(options);
+    }
+    throw new Error(`Unknown plugin type: ${options.type.type}`);
+  } else {
+    const builder = pluginFactories[options.type];
+    if (builder) {
+      return builder(options);
+    }
+    throw new Error(`Unknown plugin type: ${options.type}`);
+  }
+}
+
+export function registerPlugin(name: string, pluginBuilder: PluginBuilder) {
+  pluginFactories[name] = pluginBuilder;
+}
+
+export function getPluginTypes(): readonly VersioningStrategyType[] {
+  return Object.keys(pluginFactories).sort();
+}

--- a/src/factories/versioning-strategy-factory.ts
+++ b/src/factories/versioning-strategy-factory.ts
@@ -1,0 +1,57 @@
+// Copyright 2022 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import {VersioningStrategy} from '../versioning-strategy';
+import {DefaultVersioningStrategy} from '../versioning-strategies/default';
+import {AlwaysBumpPatch} from '../versioning-strategies/always-bump-patch';
+import {ServicePackVersioningStrategy} from '../versioning-strategies/service-pack';
+
+export type VersioningStrategyType = string;
+
+export interface VersioningStrategyFactoryOptions {
+  type?: VersioningStrategyType;
+  bumpMinorPreMajor?: boolean;
+  bumpPatchForMinorPreMajor?: boolean;
+}
+
+export type VersioningStrategyBuilder = (
+  options: VersioningStrategyFactoryOptions
+) => VersioningStrategy;
+
+const versioningTypes: Record<string, VersioningStrategyBuilder> = {
+  default: options => new DefaultVersioningStrategy(options),
+  'always-bump-patch': options => new AlwaysBumpPatch(options),
+  'service-pack': options => new ServicePackVersioningStrategy(options),
+};
+
+export function buildVersioningStrategy(
+  options: VersioningStrategyFactoryOptions
+): VersioningStrategy {
+  const builder = versioningTypes[options.type || 'default'];
+  if (builder) {
+    return builder(options);
+  }
+  throw new Error(`Unknown versioning strategy type: ${options.type}`);
+}
+
+export function registerVersioningStrategy(
+  name: string,
+  versioningStrategyBuilder: VersioningStrategyBuilder
+) {
+  versioningTypes[name] = versioningStrategyBuilder;
+}
+
+export function getVersioningStrategyTypes(): readonly VersioningStrategyType[] {
+  return Object.keys(versioningTypes).sort();
+}

--- a/src/factories/versioning-strategy-factory.ts
+++ b/src/factories/versioning-strategy-factory.ts
@@ -52,6 +52,10 @@ export function registerVersioningStrategy(
   versioningTypes[name] = versioningStrategyBuilder;
 }
 
+export function unregisterVersioningStrategy(name: string) {
+  delete versioningTypes[name];
+}
+
 export function getVersioningStrategyTypes(): readonly VersioningStrategyType[] {
   return Object.keys(versioningTypes).sort();
 }

--- a/src/factory.ts
+++ b/src/factory.ts
@@ -117,25 +117,11 @@ export async function buildStrategy(
     changelogSections: options.changelogSections,
   });
   const strategyOptions: BaseStrategyOptions = {
-    github: options.github,
+    skipGitHubRelease: options.skipGithubRelease, // Note the case difference in GitHub
+    ...options,
     targetBranch,
-    path: options.path,
-    bumpMinorPreMajor: options.bumpMinorPreMajor,
-    bumpPatchForMinorPreMajor: options.bumpPatchForMinorPreMajor,
-    component: options.component,
-    packageName: options.packageName,
-    changelogPath: options.changelogPath,
-    changelogSections: options.changelogSections,
     versioningStrategy,
-    skipGitHubRelease: options.skipGithubRelease,
-    releaseAs: options.releaseAs,
-    includeComponentInTag: options.includeComponentInTag,
     changelogNotes,
-    pullRequestTitlePattern: options.pullRequestTitlePattern,
-    extraFiles: options.extraFiles,
-    tagSeparator: options.tagSeparator,
-    versionFile: options.versionFile,
-    snapshotLabels: options.snapshotLabels,
   };
 
   const builder = releasers[options.releaseType];

--- a/src/factory.ts
+++ b/src/factory.ts
@@ -21,10 +21,10 @@ import {OCaml} from './strategies/ocaml';
 import {PHP} from './strategies/php';
 import {PHPYoshi} from './strategies/php-yoshi';
 import {Python} from './strategies/python';
-import {Ruby, RubyStrategyOptions} from './strategies/ruby';
-import {RubyYoshi, RubyYoshiStrategyOptions} from './strategies/ruby-yoshi';
+import {Ruby} from './strategies/ruby';
+import {RubyYoshi} from './strategies/ruby-yoshi';
 import {Rust} from './strategies/rust';
-import {Simple, SimpleStrategyOptions} from './strategies/simple';
+import {Simple} from './strategies/simple';
 import {TerraformModule} from './strategies/terraform-module';
 import {Helm} from './strategies/helm';
 import {Elixir} from './strategies/elixir';
@@ -37,7 +37,7 @@ import {ServicePackVersioningStrategy} from './versioning-strategies/service-pac
 import {DependencyManifest} from './versioning-strategies/dependency-manifest';
 import {BaseStrategyOptions} from './strategies/base';
 import {DotnetYoshi} from './strategies/dotnet-yoshi';
-import {Java, JavaStrategyOptions} from './strategies/java';
+import {Java} from './strategies/java';
 import {Maven} from './strategies/maven';
 import {buildVersioningStrategy} from './factories/versioning-strategy-factory';
 import {buildChangelogNotes} from './factories/changelog-notes-factory';
@@ -51,15 +51,8 @@ export * from './factories/versioning-strategy-factory';
 // add any new releasers you create to this type as well as the `releasers`
 // object below.
 
-export type AnyStrategyOptions =
-  | BaseStrategyOptions
-  | JavaStrategyOptions
-  | RubyStrategyOptions
-  | RubyYoshiStrategyOptions
-  | SimpleStrategyOptions;
-
 export type ReleaseType = string;
-export type ReleaseBuilder = (options: AnyStrategyOptions) => Strategy;
+export type ReleaseBuilder = (options: BaseStrategyOptions) => Strategy;
 
 export interface StrategyFactoryOptions extends ReleaserConfig {
   github: GitHub;
@@ -123,7 +116,7 @@ export async function buildStrategy(
     github: options.github,
     changelogSections: options.changelogSections,
   });
-  const strategyOptions: AnyStrategyOptions = {
+  const strategyOptions: BaseStrategyOptions = {
     github: options.github,
     targetBranch,
     path: options.path,

--- a/src/factory.ts
+++ b/src/factory.ts
@@ -21,100 +21,92 @@ import {OCaml} from './strategies/ocaml';
 import {PHP} from './strategies/php';
 import {PHPYoshi} from './strategies/php-yoshi';
 import {Python} from './strategies/python';
-import {Ruby} from './strategies/ruby';
-import {RubyYoshi} from './strategies/ruby-yoshi';
+import {Ruby, RubyStrategyOptions} from './strategies/ruby';
+import {RubyYoshi, RubyYoshiStrategyOptions} from './strategies/ruby-yoshi';
 import {Rust} from './strategies/rust';
-import {Simple} from './strategies/simple';
+import {Simple, SimpleStrategyOptions} from './strategies/simple';
 import {TerraformModule} from './strategies/terraform-module';
 import {Helm} from './strategies/helm';
 import {Elixir} from './strategies/elixir';
 import {Dart} from './strategies/dart';
 import {Node} from './strategies/node';
 import {GitHub} from './github';
-import {ReleaserConfig, PluginType, RepositoryConfig} from './manifest';
-import {DefaultVersioningStrategy} from './versioning-strategies/default';
-import {VersioningStrategy} from './versioning-strategy';
+import {ReleaserConfig} from './manifest';
 import {AlwaysBumpPatch} from './versioning-strategies/always-bump-patch';
 import {ServicePackVersioningStrategy} from './versioning-strategies/service-pack';
 import {DependencyManifest} from './versioning-strategies/dependency-manifest';
-import {ManifestPlugin} from './plugin';
-import {NodeWorkspace} from './plugins/node-workspace';
-import {CargoWorkspace} from './plugins/cargo-workspace';
-import {ChangelogNotes, ChangelogSection} from './changelog-notes';
-import {GitHubChangelogNotes} from './changelog-notes/github';
-import {DefaultChangelogNotes} from './changelog-notes/default';
 import {BaseStrategyOptions} from './strategies/base';
-import {LinkedVersions} from './plugins/linked-versions';
 import {DotnetYoshi} from './strategies/dotnet-yoshi';
-import {Java} from './strategies/java';
+import {Java, JavaStrategyOptions} from './strategies/java';
 import {Maven} from './strategies/maven';
+import {buildVersioningStrategy} from './factories/versioning-strategy-factory';
+import {buildChangelogNotes} from './factories/changelog-notes-factory';
+
+export * from './factories/changelog-notes-factory';
+export * from './factories/plugin-factory';
+export * from './factories/versioning-strategy-factory';
 
 // Factory shared by GitHub Action and CLI for creating Release PRs
 // and GitHub Releases:
 // add any new releasers you create to this type as well as the `releasers`
 // object below.
-const allReleaseTypes = [
-  'dart',
-  'dotnet-yoshi',
-  'elixir',
-  'go',
-  'go-yoshi',
-  'helm',
-  'java',
-  'java-backport',
-  'java-bom',
-  'java-lts',
-  'java-yoshi',
-  'krm-blueprint',
-  'maven',
-  'node',
-  'ocaml',
-  'php',
-  'php-yoshi',
-  'python',
-  'ruby',
-  'ruby-yoshi',
-  'rust',
-  'simple',
-  'terraform-module',
-] as const;
-export type ReleaseType = typeof allReleaseTypes[number];
-type ReleaseBuilder = (options: BaseStrategyOptions) => Strategy;
-type Releasers = Record<string, ReleaseBuilder>;
-const releasers: Releasers = {
-  'dotnet-yoshi': options => new DotnetYoshi(options),
-  go: options => new Go(options),
-  'go-yoshi': options => new GoYoshi(options),
-  'krm-blueprint': options => new KRMBlueprint(options),
-  node: options => new Node(options),
-  ocaml: options => new OCaml(options),
-  php: options => new PHP(options),
-  'php-yoshi': options => new PHPYoshi(options),
-  python: options => new Python(options),
-  rust: options => new Rust(options),
-  'terraform-module': options => new TerraformModule(options),
-  helm: options => new Helm(options),
-  elixir: options => new Elixir(options),
-  dart: options => new Dart(options),
-};
 
-export function getReleaserTypes(): readonly ReleaseType[] {
-  return allReleaseTypes;
-}
+export type AnyStrategyOptions =
+  | BaseStrategyOptions
+  | JavaStrategyOptions
+  | RubyStrategyOptions
+  | RubyYoshiStrategyOptions
+  | SimpleStrategyOptions;
 
-export function getVersioningStrategyTypes(): readonly VersioningStrategyType[] {
-  return allVersioningTypes;
-}
-
-export function getChangelogTypes(): readonly ChangelogNotesType[] {
-  return allChangelogNotesTypes;
-}
+export type ReleaseType = string;
+export type ReleaseBuilder = (options: AnyStrategyOptions) => Strategy;
 
 export interface StrategyFactoryOptions extends ReleaserConfig {
   github: GitHub;
   path?: string;
   targetBranch?: string;
 }
+
+const releasers: Record<string, ReleaseBuilder> = {
+  'dotnet-yoshi': options => new DotnetYoshi(options),
+  go: options => new Go(options),
+  'go-yoshi': options => new GoYoshi(options),
+  java: options => new Java(options),
+  maven: options => new Maven(options),
+  'java-yoshi': options => new JavaYoshi(options),
+  'java-backport': options =>
+    new JavaYoshi({
+      ...options,
+      versioningStrategy: new AlwaysBumpPatch(),
+    }),
+  'java-bom': options =>
+    new JavaYoshi({
+      ...options,
+      versioningStrategy: new DependencyManifest({
+        bumpMinorPreMajor: options.bumpMinorPreMajor,
+        bumpPatchForMinorPreMajor: options.bumpPatchForMinorPreMajor,
+      }),
+    }),
+  'java-lts': options =>
+    new JavaYoshi({
+      ...options,
+      versioningStrategy: new ServicePackVersioningStrategy(),
+    }),
+  'krm-blueprint': options => new KRMBlueprint(options),
+  node: options => new Node(options),
+  ocaml: options => new OCaml(options),
+  php: options => new PHP(options),
+  'php-yoshi': options => new PHPYoshi(options),
+  python: options => new Python(options),
+  ruby: options => new Ruby(options),
+  'ruby-yoshi': options => new RubyYoshi(options),
+  rust: options => new Rust(options),
+  simple: options => new Simple(options),
+  'terraform-module': options => new TerraformModule(options),
+  helm: options => new Helm(options),
+  elixir: options => new Elixir(options),
+  dart: options => new Dart(options),
+};
 
 export async function buildStrategy(
   options: StrategyFactoryOptions
@@ -131,7 +123,7 @@ export async function buildStrategy(
     github: options.github,
     changelogSections: options.changelogSections,
   });
-  const strategyOptions: BaseStrategyOptions = {
+  const strategyOptions: AnyStrategyOptions = {
     github: options.github,
     targetBranch,
     path: options.path,
@@ -149,167 +141,24 @@ export async function buildStrategy(
     pullRequestTitlePattern: options.pullRequestTitlePattern,
     extraFiles: options.extraFiles,
     tagSeparator: options.tagSeparator,
+    versionFile: options.versionFile,
+    snapshotLabels: options.snapshotLabels,
   };
-  switch (options.releaseType) {
-    case 'ruby': {
-      return new Ruby({
-        ...strategyOptions,
-        versionFile: options.versionFile,
-      });
-    }
-    case 'ruby-yoshi': {
-      return new RubyYoshi({
-        ...strategyOptions,
-        versionFile: options.versionFile,
-      });
-    }
-    case 'java': {
-      return new Java({
-        ...strategyOptions,
-        snapshotLabels: options.snapshotLabels,
-      });
-    }
-    case 'maven': {
-      return new Maven({
-        ...strategyOptions,
-        snapshotLabels: options.snapshotLabels,
-      });
-    }
-    case 'java-yoshi': {
-      return new JavaYoshi({
-        ...strategyOptions,
-        snapshotLabels: options.snapshotLabels,
-      });
-    }
-    case 'java-backport': {
-      return new JavaYoshi({
-        ...strategyOptions,
-        versioningStrategy: new AlwaysBumpPatch(),
-      });
-    }
-    case 'java-bom': {
-      return new JavaYoshi({
-        ...strategyOptions,
-        versioningStrategy: new DependencyManifest({
-          bumpMinorPreMajor: options.bumpMinorPreMajor,
-          bumpPatchForMinorPreMajor: options.bumpPatchForMinorPreMajor,
-        }),
-      });
-    }
-    case 'java-lts': {
-      return new JavaYoshi({
-        ...strategyOptions,
-        versioningStrategy: new ServicePackVersioningStrategy(),
-      });
-    }
-    case 'simple': {
-      return new Simple({
-        ...strategyOptions,
-        versionFile: options.versionFile,
-      });
-    }
-    default: {
-      const builder = releasers[options.releaseType];
-      if (builder) {
-        return builder(strategyOptions);
-      }
-      throw new Error(`Unknown release type: ${options.releaseType}`);
-    }
+
+  const builder = releasers[options.releaseType];
+  if (builder) {
+    return builder(strategyOptions);
   }
+  throw new Error(`Unknown release type: ${options.releaseType}`);
 }
 
-const allVersioningTypes = [
-  'default',
-  'always-bump-patch',
-  'service-pack',
-] as const;
-export type VersioningStrategyType = typeof allVersioningTypes[number];
-interface VersioningStrategyFactoryOptions {
-  type?: VersioningStrategyType;
-  bumpMinorPreMajor?: boolean;
-  bumpPatchForMinorPreMajor?: boolean;
-}
-function buildVersioningStrategy(
-  options: VersioningStrategyFactoryOptions
-): VersioningStrategy {
-  switch (options.type) {
-    case 'always-bump-patch':
-      return new AlwaysBumpPatch(options);
-    case 'service-pack':
-      return new ServicePackVersioningStrategy(options);
-    default:
-      return new DefaultVersioningStrategy(options);
-  }
+export function registerReleaseType(
+  name: string,
+  strategyBuilder: ReleaseBuilder
+) {
+  releasers[name] = strategyBuilder;
 }
 
-interface PluginFactoryOptions {
-  type: PluginType;
-  github: GitHub;
-  targetBranch: string;
-  repositoryConfig: RepositoryConfig;
-
-  // node options
-  alwaysLinkLocal?: boolean;
-
-  // workspace options
-  updateAllPackages?: boolean;
-}
-
-export function buildPlugin(options: PluginFactoryOptions): ManifestPlugin {
-  if (typeof options.type === 'object') {
-    switch (options.type.type) {
-      case 'linked-versions':
-        return new LinkedVersions(
-          options.github,
-          options.targetBranch,
-          options.repositoryConfig,
-          options.type.groupName,
-          options.type.components
-        );
-      default:
-        throw new Error(`Unknown plugin type: ${options.type}`);
-    }
-  }
-  switch (options.type) {
-    case 'cargo-workspace':
-      return new CargoWorkspace(
-        options.github,
-        options.targetBranch,
-        options.repositoryConfig,
-        options
-      );
-    case 'node-workspace':
-      return new NodeWorkspace(
-        options.github,
-        options.targetBranch,
-        options.repositoryConfig,
-        options
-      );
-    default:
-      throw new Error(`Unknown plugin type: ${options.type}`);
-  }
-}
-
-const allChangelogNotesTypes = ['default', 'github'] as const;
-export type ChangelogNotesType = typeof allChangelogNotesTypes[number];
-interface ChangelogNotesFactoryOptions {
-  type: ChangelogNotesType;
-  github: GitHub;
-  changelogSections?: ChangelogSection[];
-  commitPartial?: string;
-  headerPartial?: string;
-  mainTemplate?: string;
-}
-
-export function buildChangelogNotes(
-  options: ChangelogNotesFactoryOptions
-): ChangelogNotes {
-  switch (options.type) {
-    case 'github':
-      return new GitHubChangelogNotes(options.github);
-    case 'default':
-      return new DefaultChangelogNotes(options);
-    default:
-      throw new Error(`Unknown changelog type: ${options.type}`);
-  }
+export function getReleaserTypes(): readonly ReleaseType[] {
+  return Object.keys(releasers).sort();
 }

--- a/src/factory.ts
+++ b/src/factory.ts
@@ -138,6 +138,10 @@ export function registerReleaseType(
   releasers[name] = strategyBuilder;
 }
 
+export function unregisterReleaseType(name: string) {
+  delete releasers[name];
+}
+
 export function getReleaserTypes(): readonly ReleaseType[] {
   return Object.keys(releasers).sort();
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -13,14 +13,45 @@
 // limitations under the License.
 
 export * as Errors from './errors';
-export {Manifest, ReleaserConfig, ManifestOptions} from './manifest';
 export {
+  Manifest,
+  ReleaserConfig,
+  ManifestOptions,
+  PluginType,
+} from './manifest';
+export {Commit, ConventionalCommit} from './commit';
+export {BaseStrategyOptions, BuildUpdatesOptions} from './strategies/base';
+export {
+  AnyStrategyOptions,
+  ReleaseBuilder,
   ReleaseType,
   getReleaserTypes,
-  VersioningStrategyType,
-  getVersioningStrategyTypes,
+  registerReleaseType,
+} from './factory';
+export {
+  ChangelogNotesBuilder,
+  ChangelogNotesFactoryOptions,
   ChangelogNotesType,
   getChangelogTypes,
-} from './factory';
+  registerChangelogNotes,
+} from './factories/changelog-notes-factory';
+export {
+  PluginBuilder,
+  PluginFactoryOptions,
+  getPluginTypes,
+  registerPlugin,
+} from './factories/plugin-factory';
+export {
+  VersioningStrategyBuilder,
+  VersioningStrategyFactoryOptions,
+  VersioningStrategyType,
+  getVersioningStrategyTypes,
+  registerVersioningStrategy,
+} from './factories/versioning-strategy-factory';
+export {
+  BuildNotesOptions,
+  ChangelogNotes,
+  ChangelogSection,
+} from './changelog-notes';
 export {Logger, setLogger} from './util/logger';
 export {GitHub} from './github';

--- a/src/index.ts
+++ b/src/index.ts
@@ -22,7 +22,6 @@ export {
 export {Commit, ConventionalCommit} from './commit';
 export {BaseStrategyOptions, BuildUpdatesOptions} from './strategies/base';
 export {
-  AnyStrategyOptions,
   ReleaseBuilder,
   ReleaseType,
   getReleaserTypes,

--- a/src/manifest.ts
+++ b/src/manifest.ts
@@ -66,7 +66,7 @@ export interface ReleaserConfig {
 
   // Strategy options
   releaseAs?: string;
-  skipGithubRelease?: boolean;
+  skipGithubRelease?: boolean; // Note this should be renamed to skipGitHubRelease in next major release
   draft?: boolean;
   prerelease?: boolean;
   draftPullRequest?: boolean;

--- a/src/manifest.ts
+++ b/src/manifest.ts
@@ -119,12 +119,9 @@ interface ReleaserConfigJson {
   'changelog-type'?: ChangelogNotesType;
   'pull-request-title-pattern'?: string;
   'tag-separator'?: string;
-
-  // Ruby-only
-  'version-file'?: string;
-  // Java-only
   'extra-files'?: string[];
-  'snapshot-label'?: string;
+  'version-file'?: string;
+  'snapshot-label'?: string; // Java-only
 }
 
 export interface ManifestOptions {

--- a/src/manifest.ts
+++ b/src/manifest.ts
@@ -151,13 +151,19 @@ interface ReleaserPackageConfig extends ReleaserConfigJson {
   'changelog-path'?: string;
 }
 
-type DirectPluginType = 'node-workspace' | 'cargo-workspace';
-interface LinkedVersionPluginConfig {
+export type DirectPluginType = string;
+export interface ConfigurablePluginType {
+  type: string;
+}
+export interface LinkedVersionPluginConfig extends ConfigurablePluginType {
   type: 'linked-versions';
   groupName: string;
   components: string[];
 }
-export type PluginType = DirectPluginType | LinkedVersionPluginConfig;
+export type PluginType =
+  | DirectPluginType
+  | ConfigurablePluginType
+  | LinkedVersionPluginConfig;
 
 /**
  * This is the schema of the manifest config json

--- a/src/strategies/base.ts
+++ b/src/strategies/base.ts
@@ -71,6 +71,8 @@ export interface BaseStrategyOptions {
   includeVInTag?: boolean;
   pullRequestTitlePattern?: string;
   extraFiles?: ExtraFile[];
+  versionFile?: string;
+  snapshotLabels?: string[]; // Java-only
 }
 
 /**

--- a/src/strategies/java.ts
+++ b/src/strategies/java.ts
@@ -46,10 +46,6 @@ const CHANGELOG_SECTIONS = [
   {type: 'ci', section: 'Continuous Integration', hidden: true},
 ];
 
-export interface JavaStrategyOptions extends BaseStrategyOptions {
-  snapshotLabels?: string[];
-}
-
 export interface JavaBuildUpdatesOption extends BuildUpdatesOptions {
   isSnapshot?: boolean;
 }
@@ -63,7 +59,7 @@ export class Java extends BaseStrategy {
   protected readonly snapshotVersioning: VersioningStrategy;
   protected readonly snapshotLabels: string[];
 
-  constructor(options: JavaStrategyOptions) {
+  constructor(options: BaseStrategyOptions) {
     options.changelogSections = options.changelogSections ?? CHANGELOG_SECTIONS;
     // wrap the configured versioning strategy with snapshotting
     const parentVersioningStrategy =

--- a/src/strategies/ruby-yoshi.ts
+++ b/src/strategies/ruby-yoshi.ts
@@ -42,7 +42,7 @@ const CHANGELOG_SECTIONS = [
   {type: 'ci', section: 'Continuous Integration', hidden: true},
 ];
 
-interface RubyYoshiStrategyOptions extends BaseStrategyOptions {
+export interface RubyYoshiStrategyOptions extends BaseStrategyOptions {
   versionFile?: string;
 }
 

--- a/src/strategies/ruby-yoshi.ts
+++ b/src/strategies/ruby-yoshi.ts
@@ -42,13 +42,9 @@ const CHANGELOG_SECTIONS = [
   {type: 'ci', section: 'Continuous Integration', hidden: true},
 ];
 
-export interface RubyYoshiStrategyOptions extends BaseStrategyOptions {
-  versionFile?: string;
-}
-
 export class RubyYoshi extends BaseStrategy {
   readonly versionFile: string;
-  constructor(options: RubyYoshiStrategyOptions) {
+  constructor(options: BaseStrategyOptions) {
     super({
       ...options,
       changelogSections: CHANGELOG_SECTIONS,

--- a/src/strategies/ruby.ts
+++ b/src/strategies/ruby.ts
@@ -23,7 +23,7 @@ import {BaseStrategy, BuildUpdatesOptions, BaseStrategyOptions} from './base';
 import {ConventionalCommit} from '../commit';
 import {Update} from '../update';
 
-interface RubyStrategyOptions extends BaseStrategyOptions {
+export interface RubyStrategyOptions extends BaseStrategyOptions {
   versionFile?: string;
 }
 

--- a/src/strategies/ruby.ts
+++ b/src/strategies/ruby.ts
@@ -23,13 +23,9 @@ import {BaseStrategy, BuildUpdatesOptions, BaseStrategyOptions} from './base';
 import {ConventionalCommit} from '../commit';
 import {Update} from '../update';
 
-export interface RubyStrategyOptions extends BaseStrategyOptions {
-  versionFile?: string;
-}
-
 export class Ruby extends BaseStrategy {
   readonly versionFile: string;
-  constructor(options: RubyStrategyOptions) {
+  constructor(options: BaseStrategyOptions) {
     super(options);
     this.versionFile = options.versionFile ?? '';
     this.tagSeparator = '/';

--- a/src/strategies/simple.ts
+++ b/src/strategies/simple.ts
@@ -19,7 +19,7 @@ import {BaseStrategy, BuildUpdatesOptions, BaseStrategyOptions} from './base';
 import {Update} from '../update';
 import {DefaultUpdater} from '../updaters/default';
 
-interface SimpleStrategyOptions extends BaseStrategyOptions {
+export interface SimpleStrategyOptions extends BaseStrategyOptions {
   versionFile?: string;
 }
 

--- a/src/strategies/simple.ts
+++ b/src/strategies/simple.ts
@@ -19,13 +19,9 @@ import {BaseStrategy, BuildUpdatesOptions, BaseStrategyOptions} from './base';
 import {Update} from '../update';
 import {DefaultUpdater} from '../updaters/default';
 
-export interface SimpleStrategyOptions extends BaseStrategyOptions {
-  versionFile?: string;
-}
-
 export class Simple extends BaseStrategy {
   readonly versionFile: string;
-  constructor(options: SimpleStrategyOptions) {
+  constructor(options: BaseStrategyOptions) {
     super(options);
     this.versionFile = options.versionFile ?? 'version.txt';
   }

--- a/test/factories/changelog-notes-factory.ts
+++ b/test/factories/changelog-notes-factory.ts
@@ -1,0 +1,85 @@
+// Copyright 2022 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import {beforeEach, describe, it} from 'mocha';
+import {expect} from 'chai';
+import {
+  ChangelogNotesType,
+  getChangelogTypes,
+  GitHub,
+  registerChangelogNotes,
+} from '../../src';
+import {buildChangelogNotes} from '../../src/factories/changelog-notes-factory';
+import {DefaultChangelogNotes} from '../../src/changelog-notes/default';
+
+describe('ChangelogNotesFactory', () => {
+  let github: GitHub;
+  beforeEach(async () => {
+    github = await GitHub.create({
+      owner: 'fake-owner',
+      repo: 'fake-repo',
+      defaultBranch: 'main',
+      token: 'fake-token',
+    });
+  });
+  describe('buildChangelogNotes', () => {
+    const changelogTypes = ['default', 'github'];
+    for (const changelogType of changelogTypes) {
+      it(`should build a simple ${changelogType}`, () => {
+        const changelogNotes = buildChangelogNotes({
+          github,
+          type: changelogType,
+        });
+        expect(changelogNotes).to.not.be.undefined;
+      });
+    }
+    it('should throw for unknown type', () => {
+      expect(() =>
+        buildChangelogNotes({github, type: 'non-existent'})
+      ).to.throw();
+    });
+  });
+  describe('getChangelogTypes', () => {
+    it('should return default types', () => {
+      const defaultTypes: ChangelogNotesType[] = ['default', 'github'];
+
+      const types = getChangelogTypes();
+      defaultTypes.forEach(type => expect(types).to.contain(type));
+    });
+  });
+  describe('registerChangelogNotes', () => {
+    const changelogType = 'custom-test';
+
+    class CustomTest extends DefaultChangelogNotes {}
+
+    it('should register new releaser', async () => {
+      registerChangelogNotes(changelogType, options => new CustomTest(options));
+
+      const changelogNotesOptions = {
+        type: changelogType,
+        github,
+        repositoryConfig: {},
+        targetBranch: 'main',
+      };
+      const strategy = await buildChangelogNotes(changelogNotesOptions);
+      expect(strategy).to.be.instanceof(CustomTest);
+    });
+    it('should return custom type', () => {
+      registerChangelogNotes(changelogType, options => new CustomTest(options));
+
+      const allTypes = getChangelogTypes();
+      expect(allTypes).to.contain(changelogType);
+    });
+  });
+});

--- a/test/factories/changelog-notes-factory.ts
+++ b/test/factories/changelog-notes-factory.ts
@@ -20,7 +20,10 @@ import {
   GitHub,
   registerChangelogNotes,
 } from '../../src';
-import {buildChangelogNotes} from '../../src/factories/changelog-notes-factory';
+import {
+  buildChangelogNotes,
+  unregisterChangelogNotes,
+} from '../../src/factories/changelog-notes-factory';
 import {DefaultChangelogNotes} from '../../src/changelog-notes/default';
 
 describe('ChangelogNotesFactory', () => {
@@ -62,6 +65,10 @@ describe('ChangelogNotesFactory', () => {
     const changelogType = 'custom-test';
 
     class CustomTest extends DefaultChangelogNotes {}
+
+    afterEach(() => {
+      unregisterChangelogNotes(changelogType);
+    });
 
     it('should register new releaser', async () => {
       registerChangelogNotes(changelogType, options => new CustomTest(options));

--- a/test/factories/plugin-factory.ts
+++ b/test/factories/plugin-factory.ts
@@ -18,6 +18,7 @@ import {
   buildPlugin,
   getPluginTypes,
   registerPlugin,
+  unregisterPlugin,
 } from '../../src/factories/plugin-factory';
 import {expect} from 'chai';
 import {LinkedVersions} from '../../src/plugins/linked-versions';
@@ -94,6 +95,10 @@ describe('PluginFactory', () => {
     const pluginType = 'custom-test';
 
     class CustomTest extends ManifestPlugin {}
+
+    afterEach(() => {
+      unregisterPlugin(pluginType);
+    });
 
     it('should register new releaser', async () => {
       registerPlugin(

--- a/test/factories/plugin-factory.ts
+++ b/test/factories/plugin-factory.ts
@@ -1,0 +1,133 @@
+// Copyright 2022 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import {beforeEach, describe, it} from 'mocha';
+import {PluginType, RepositoryConfig} from '../../src/manifest';
+import {
+  buildPlugin,
+  getPluginTypes,
+  registerPlugin,
+} from '../../src/factories/plugin-factory';
+import {expect} from 'chai';
+import {LinkedVersions} from '../../src/plugins/linked-versions';
+import {ManifestPlugin} from '../../src/plugin';
+import {GitHub} from '../../src';
+
+describe('PluginFactory', () => {
+  let github: GitHub;
+  beforeEach(async () => {
+    github = await GitHub.create({
+      owner: 'fake-owner',
+      repo: 'fake-repo',
+      defaultBranch: 'main',
+      token: 'fake-token',
+    });
+  });
+  describe('buildPlugin', () => {
+    const simplePluginTypes: PluginType[] = [
+      'cargo-workspace',
+      'node-workspace',
+    ];
+    const repositoryConfig: RepositoryConfig = {
+      '.': {releaseType: 'simple'},
+    };
+    for (const pluginType of simplePluginTypes) {
+      it(`should build a simple ${pluginType}`, () => {
+        const plugin = buildPlugin({
+          github,
+          type: pluginType,
+          targetBranch: 'target-branch',
+          repositoryConfig,
+        });
+        expect(plugin).to.not.be.undefined;
+      });
+    }
+    it('should throw for unknown type', () => {
+      expect(() =>
+        buildPlugin({
+          github,
+          type: 'non-existent',
+          targetBranch: 'target-branch',
+          repositoryConfig,
+        })
+      ).to.throw();
+    });
+    it('should build a linked-versions config', () => {
+      const plugin = buildPlugin({
+        github,
+        type: {
+          type: 'linked-versions',
+          groupName: 'group-name',
+          components: ['pkg1', 'pkg2'],
+        },
+        targetBranch: 'target-branch',
+        repositoryConfig,
+      });
+      expect(plugin).to.not.be.undefined;
+      expect(plugin).instanceof(LinkedVersions);
+    });
+  });
+  describe('getPluginTypes', () => {
+    it('should return default types', () => {
+      const defaultTypes: PluginType[] = [
+        'cargo-workspace',
+        'node-workspace',
+        'linked-versions',
+      ];
+
+      const types = getPluginTypes();
+      defaultTypes.forEach(type => expect(types).to.contain(type));
+    });
+  });
+  describe('registerPlugin', () => {
+    const pluginType = 'custom-test';
+
+    class CustomTest extends ManifestPlugin {}
+
+    it('should register new releaser', async () => {
+      registerPlugin(
+        pluginType,
+        options =>
+          new CustomTest(
+            options.github,
+            options.targetBranch,
+            options.repositoryConfig
+          )
+      );
+
+      const pluginOptions = {
+        type: pluginType,
+        github,
+        repositoryConfig: {},
+        targetBranch: 'main',
+      };
+      const strategy = await buildPlugin(pluginOptions);
+      expect(strategy).to.be.instanceof(CustomTest);
+    });
+    it('should return custom type', () => {
+      registerPlugin(
+        pluginType,
+        options =>
+          new CustomTest(
+            options.github,
+            options.targetBranch,
+            options.repositoryConfig
+          )
+      );
+
+      const allTypes = getPluginTypes();
+      expect(allTypes).to.contain(pluginType);
+    });
+  });
+});

--- a/test/factories/versioning-strategy-factory.ts
+++ b/test/factories/versioning-strategy-factory.ts
@@ -1,0 +1,81 @@
+// Copyright 2022 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+import {describe, it} from 'mocha';
+import {expect} from 'chai';
+import {
+  getVersioningStrategyTypes,
+  registerVersioningStrategy,
+  VersioningStrategyType,
+} from '../../src';
+import {DefaultVersioningStrategy} from '../../src/versioning-strategies/default';
+import {buildVersioningStrategy} from '../../src/factories/versioning-strategy-factory';
+
+describe('VersioningStrategyFactory', () => {
+  const defaultTypes: VersioningStrategyType[] = [
+    'default',
+    'always-bump-patch',
+    'service-pack',
+  ];
+
+  describe('buildVersioningStrategy', () => {
+    for (const type of defaultTypes) {
+      it(`should build a simple ${type}`, () => {
+        const versioningStrategy = buildVersioningStrategy({
+          type: type,
+        });
+        expect(versioningStrategy).to.not.be.undefined;
+      });
+    }
+    it('should throw for unknown type', () => {
+      expect(() =>
+        buildVersioningStrategy({
+          type: 'non-existent',
+        })
+      ).to.throw();
+    });
+  });
+  describe('getVersioningStrategyTypes', () => {
+    it('should return default types', () => {
+      const types = getVersioningStrategyTypes();
+      defaultTypes.forEach(type => expect(types).to.contain(type));
+    });
+  });
+  describe('registerVersioningStrategy', () => {
+    const versioningStrategyType = 'custom-test';
+
+    class CustomTest extends DefaultVersioningStrategy {}
+
+    it('should register new releaser', async () => {
+      registerVersioningStrategy(
+        versioningStrategyType,
+        options => new CustomTest(options)
+      );
+
+      const versioningStrategyOptions = {
+        type: versioningStrategyType,
+      };
+      const strategy = await buildVersioningStrategy(versioningStrategyOptions);
+      expect(strategy).to.be.instanceof(CustomTest);
+    });
+    it('should return custom type', () => {
+      registerVersioningStrategy(
+        versioningStrategyType,
+        options => new CustomTest(options)
+      );
+
+      const allTypes = getVersioningStrategyTypes();
+      expect(allTypes).to.contain(versioningStrategyType);
+    });
+  });
+});

--- a/test/factories/versioning-strategy-factory.ts
+++ b/test/factories/versioning-strategy-factory.ts
@@ -19,7 +19,10 @@ import {
   VersioningStrategyType,
 } from '../../src';
 import {DefaultVersioningStrategy} from '../../src/versioning-strategies/default';
-import {buildVersioningStrategy} from '../../src/factories/versioning-strategy-factory';
+import {
+  buildVersioningStrategy,
+  unregisterVersioningStrategy,
+} from '../../src/factories/versioning-strategy-factory';
 
 describe('VersioningStrategyFactory', () => {
   const defaultTypes: VersioningStrategyType[] = [
@@ -55,6 +58,10 @@ describe('VersioningStrategyFactory', () => {
     const versioningStrategyType = 'custom-test';
 
     class CustomTest extends DefaultVersioningStrategy {}
+
+    afterEach(() => {
+      unregisterVersioningStrategy(versioningStrategyType);
+    });
 
     it('should register new releaser', async () => {
       registerVersioningStrategy(

--- a/test/factory.ts
+++ b/test/factory.ts
@@ -17,6 +17,7 @@ import {
   buildStrategy,
   getReleaserTypes,
   registerReleaseType,
+  unregisterReleaseType,
 } from '../src/factory';
 import {GitHub} from '../src/github';
 import {expect} from 'chai';
@@ -228,6 +229,10 @@ describe('factory', () => {
     const releaseType = 'custom-test';
 
     class CustomTest extends Simple {}
+
+    afterEach(() => {
+      unregisterReleaseType(releaseType);
+    });
 
     it('should register new releaser', async () => {
       registerReleaseType(releaseType, options => new CustomTest(options));

--- a/test/manifest.ts
+++ b/test/manifest.ts
@@ -33,7 +33,7 @@ import {Version} from '../src/version';
 import {PullRequest} from '../src/pull-request';
 import {readFileSync} from 'fs';
 import {resolve} from 'path';
-import * as factory from '../src/factory';
+import * as pluginFactory from '../src/factories/plugin-factory';
 import {NodeWorkspace} from '../src/plugins/node-workspace';
 import {CargoWorkspace} from '../src/plugins/cargo-workspace';
 import {PullRequestTitle} from '../src/util/pull-request-title';
@@ -2355,7 +2355,7 @@ describe('Manifest', () => {
         mockPlugin.run.returnsArg(0);
         mockPlugin.preconfigure.returnsArg(0);
         sandbox
-          .stub(factory, 'buildPlugin')
+          .stub(pluginFactory, 'buildPlugin')
           .withArgs(sinon.match.has('type', 'node-workspace'))
           .returns(mockPlugin);
         const pullRequests = await manifest.buildPullRequests();
@@ -2395,7 +2395,7 @@ describe('Manifest', () => {
         mockPlugin2.run.returnsArg(0);
         mockPlugin2.preconfigure.returnsArg(0);
         sandbox
-          .stub(factory, 'buildPlugin')
+          .stub(pluginFactory, 'buildPlugin')
           .withArgs(sinon.match.has('type', 'node-workspace'))
           .returns(mockPlugin)
           .withArgs(sinon.match.has('type', 'cargo-workspace'))


### PR DESCRIPTION
Extend current code by registering new plugin/strategy before invoking release-please. This makes possible to extend this tool by composition, instead of inheritance (forking).

Closes #1341