### PR TITLE
refactor: pass raw commit log to ChangelogNotes.buildNotes

### DIFF
--- a/src/changelog-notes.ts
+++ b/src/changelog-notes.ts
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import {ConventionalCommit} from './commit';
+import {Commit, ConventionalCommit} from './commit';
 
 export interface BuildNotesOptions {
   host?: string;
@@ -23,6 +23,7 @@ export interface BuildNotesOptions {
   currentTag: string;
   targetBranch: string;
   changelogSections?: ChangelogSection[];
+  commits?: Commit[];
 }
 
 export interface ChangelogNotes {

--- a/src/strategies/base.ts
+++ b/src/strategies/base.ts
@@ -173,7 +173,8 @@ export abstract class BaseStrategy implements Strategy {
     conventionalCommits: ConventionalCommit[],
     newVersion: Version,
     newVersionTag: TagName,
-    latestRelease?: Release
+    latestRelease?: Release,
+    commits?: Commit[]
   ): Promise<string> {
     return await this.changelogNotes.buildNotes(conventionalCommits, {
       owner: this.repository.owner,
@@ -183,6 +184,7 @@ export abstract class BaseStrategy implements Strategy {
       currentTag: newVersionTag.toString(),
       targetBranch: this.targetBranch,
       changelogSections: this.changelogSections,
+      commits: commits,
     });
   }
 
@@ -258,7 +260,8 @@ export abstract class BaseStrategy implements Strategy {
       conventionalCommits,
       newVersion,
       newVersionTag,
-      latestRelease
+      latestRelease,
+      commits
     );
     if (this.changelogEmpty(releaseNotesBody)) {
       logger.info(

--- a/src/strategies/go-yoshi.ts
+++ b/src/strategies/go-yoshi.ts
@@ -15,7 +15,7 @@
 import {BaseStrategy, BuildUpdatesOptions, BaseStrategyOptions} from './base';
 import {Update} from '../update';
 import {Changelog} from '../updaters/changelog';
-import {ConventionalCommit} from '../commit';
+import {Commit, ConventionalCommit} from '../commit';
 import {Version} from '../version';
 import {TagName} from '../util/tag-name';
 import {Release} from '../release';
@@ -164,13 +164,15 @@ export class GoYoshi extends BaseStrategy {
     conventionalCommits: ConventionalCommit[],
     newVersion: Version,
     newVersionTag: TagName,
-    latestRelease?: Release
+    latestRelease?: Release,
+    commits?: Commit[]
   ): Promise<string> {
     const releaseNotes = await super.buildReleaseNotes(
       conventionalCommits,
       newVersion,
       newVersionTag,
-      latestRelease
+      latestRelease,
+      commits
     );
     return releaseNotes.replace(/, closes /g, ', refs ');
   }


### PR DESCRIPTION
Related to #1331 and #1341, this improves extendibility of the tool. 

Sometimes changelog generator might use raw commits as a source (as actually does `GitHubChangelogNotes` in a way), or combination of both.