### PR TITLE
fix: Restore v12 changelog formatting for ruby-yoshi

### DIFF
--- a/__snapshots__/ruby-yoshi.js
+++ b/__snapshots__/ruby-yoshi.js
@@ -3,7 +3,7 @@ exports['RubyYoshi buildReleasePullRequest returns release PR changes with semve
 ---
 
 
-### [0.123.5]() / 1983-10-10
+### 0.123.5 / 1983-10-10
 
 #### Bug Fixes
 
@@ -11,20 +11,5 @@ exports['RubyYoshi buildReleasePullRequest returns release PR changes with semve
 * update dependency com.google.cloud:google-cloud-storage to v1.120.0
 
 ---
-
-### Commits since last release:
-
-* [fix(deps): update dependency com.google.cloud:google-cloud-storage to v1.120.0](https://github.com/googleapis/ruby-test-repo/commit/845db1381b3d5d20151cad2588f85feb)
-* [fix(deps): update dependency com.google.cloud:google-cloud-spanner to v1.50.0](https://github.com/googleapis/ruby-test-repo/commit/08ca01180a91c0a1ba8992b491db9212)
-* [chore: update common templates](https://github.com/googleapis/ruby-test-repo/commit/7fb2ced60e3096b048ee38caa410c05c)
-
-### Files edited since last release:
-
-<pre><code>path1/foo.rb
-path2/bar.rb
-</code></pre>
-[Compare Changes](https://github.com/googleapis/ruby-test-repo/compare/abc123...HEAD)
-
-
 This PR was generated with [Release Please](https://github.com/googleapis/release-please). See [documentation](https://github.com/googleapis/release-please#release-please).
 `

--- a/test/strategies/ruby-yoshi.ts
+++ b/test/strategies/ruby-yoshi.ts
@@ -28,7 +28,7 @@ const sandbox = sinon.createSandbox();
 
 const COMMITS = [
   buildMockCommit(
-    'fix(deps): update dependency com.google.cloud:google-cloud-storage to v1.120.0',
+    'fix(deps): update dependency com.google.cloud:google-cloud-storage to v1.120.0 (#1234)',
     ['path1/foo.rb']
   ),
   buildMockCommit(


### PR DESCRIPTION
Currently Ruby repos are pinned to release-please 12.x for several reasons, among them being that the release-please 13 rewrite reverted Ruby's preferred changelog formatting. This PR updates the `ruby-yoshi` strategy to reimplement this formatting as a postprocessing pass to buildReleaseNotes. Specifically:

* It standardizes on h3 for all version headers, regardless of whether it's a major/minor or patch version.
* It removes the diff link on version headers, as we prefer not to have links in the changelog.
* If a commit message includes a pull request number, conventional commits turns it into a link. We remove that link.
* We collapse vertical whitespace of two or more blank lines.

This PR also removes the custom pull request body logic in `yoshi-ruby`. We were not using that information.

The standard `ruby` strategy is unaltered, so that third parties using it are not affected.