### PR TITLE
feat: support selecting a single path when releasing from a manifest

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node: [12, 14, 15]
+        node: [12, 14, 16]
     steps:
       - uses: actions/checkout@v3
       - uses: actions/setup-node@v3

--- a/src/bin/release-please.ts
+++ b/src/bin/release-please.ts
@@ -442,7 +442,9 @@ const createReleasePullRequestCommand: yargs.CommandModule<
         targetBranch,
         argv.configFile,
         argv.manifestFile,
-        manifestOptions
+        manifestOptions,
+        argv.path,
+        argv.releaseAs
       );
     }
 

--- a/test/cli.ts
+++ b/test/cli.ts
@@ -500,7 +500,9 @@ describe('CLI', () => {
           'main',
           DEFAULT_RELEASE_PLEASE_CONFIG,
           DEFAULT_RELEASE_PLEASE_MANIFEST,
-          sinon.match.any
+          sinon.match.any,
+          undefined,
+          undefined
         );
         sinon.assert.calledOnce(createPullRequestsStub);
       });
@@ -521,7 +523,9 @@ describe('CLI', () => {
           'main',
           'foo.json',
           '.bar.json',
-          sinon.match.any
+          sinon.match.any,
+          undefined,
+          undefined
         );
         sinon.assert.calledOnce(createPullRequestsStub);
       });
@@ -542,7 +546,9 @@ describe('CLI', () => {
             '1.x',
             DEFAULT_RELEASE_PLEASE_CONFIG,
             DEFAULT_RELEASE_PLEASE_MANIFEST,
-            sinon.match.any
+            sinon.match.any,
+            undefined,
+            undefined
           );
           sinon.assert.calledOnce(createPullRequestsStub);
         });
@@ -568,7 +574,9 @@ describe('CLI', () => {
           'main',
           DEFAULT_RELEASE_PLEASE_CONFIG,
           DEFAULT_RELEASE_PLEASE_MANIFEST,
-          sinon.match.any
+          sinon.match.any,
+          undefined,
+          undefined
         );
         sinon.assert.calledOnce(buildPullRequestsStub);
       });

--- a/test/manifest.ts
+++ b/test/manifest.ts
@@ -149,7 +149,7 @@ describe('Manifest', () => {
   });
 
   describe('fromManifest', () => {
-    it('should parse config and manifest from repostiory', async () => {
+    it('should parse config and manifest from repository', async () => {
       const getFileContentsStub = sandbox.stub(
         github,
         'getFileContentsOnBranch'
@@ -171,6 +171,69 @@ describe('Manifest', () => {
         github.repository.defaultBranch
       );
       expect(Object.keys(manifest.repositoryConfig)).lengthOf(8);
+      expect(Object.keys(manifest.releasedVersions)).lengthOf(8);
+    });
+    it('should limit manifest loading to the given path', async () => {
+      const getFileContentsStub = sandbox.stub(
+        github,
+        'getFileContentsOnBranch'
+      );
+      getFileContentsStub
+        .withArgs('release-please-config.json', 'main')
+        .resolves(
+          buildGitHubFileContent(fixturesPath, 'manifest/config/config.json')
+        )
+        .withArgs('.release-please-manifest.json', 'main')
+        .resolves(
+          buildGitHubFileContent(
+            fixturesPath,
+            'manifest/versions/versions.json'
+          )
+        );
+      const manifest = await Manifest.fromManifest(
+        github,
+        github.repository.defaultBranch,
+        undefined,
+        undefined,
+        undefined,
+        'packages/gcf-utils'
+      );
+      expect(Object.keys(manifest.repositoryConfig)).lengthOf(1);
+      expect(
+        manifest.repositoryConfig['packages/gcf-utils'].releaseType
+      ).to.eql('node');
+      expect(Object.keys(manifest.releasedVersions)).lengthOf(8);
+    });
+    it('should override release-as with the given argument', async () => {
+      const getFileContentsStub = sandbox.stub(
+        github,
+        'getFileContentsOnBranch'
+      );
+      getFileContentsStub
+        .withArgs('release-please-config.json', 'main')
+        .resolves(
+          buildGitHubFileContent(fixturesPath, 'manifest/config/config.json')
+        )
+        .withArgs('.release-please-manifest.json', 'main')
+        .resolves(
+          buildGitHubFileContent(
+            fixturesPath,
+            'manifest/versions/versions.json'
+          )
+        );
+      const manifest = await Manifest.fromManifest(
+        github,
+        github.repository.defaultBranch,
+        undefined,
+        undefined,
+        undefined,
+        'packages/gcf-utils',
+        '12.34.56'
+      );
+      expect(Object.keys(manifest.repositoryConfig)).lengthOf(1);
+      expect(manifest.repositoryConfig['packages/gcf-utils'].releaseAs).to.eql(
+        '12.34.56'
+      );
       expect(Object.keys(manifest.releasedVersions)).lengthOf(8);
     });
     it('should read the default release-type from manifest', async () => {


### PR DESCRIPTION
I would like to honor the `--path` and `--release-as` flags when running `release-pr` with a manifest. These command-line flags already exist and are used in the non-manifest case but are currently ignored in the manifest case.

* `--path` would cause only the specified path to be run from the manifest, and would skip all others.
* `--release-as` would set the `releaseAs` option for _all_ packages to be released (and would override any settings in the config file). Typically it would be used in conjunction with `--path`.

I want these for google-cloud-ruby because:

* I'd rather have a single manifest listing all ~300 packages instead of separate manifests for each package (since the latter would require ~300 executions of release-please and massively inefficient especially in terms of GitHub API usage). However...
* We do have the use case where I want to release just one specific package (and sometimes also want to set releaseAs without having to go through the song and dance of modifying and later restoring config files).

feat: enable overriding release-as