### PR TITLE
chore: update ci to test node 16 rather than node 15

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node: [12, 14, 15]
+        node: [12, 14, 16]
     steps:
       - uses: actions/checkout@v3
       - uses: actions/setup-node@v3


### PR DESCRIPTION
Looks like one of the dependencies doesn't like node 15. (See #1363, a no-op change that is failing CI on node 15.)