### PR TITLE
chore: remove unused legacy config

### DIFF
--- a/.bots/header-checker-lint.json
+++ b/.bots/header-checker-lint.json
@@ -1,6 +1,0 @@
-{
-  "ignoreFiles": [
-    "**/__snapshots__/*"
-  ]
-}
-


### PR DESCRIPTION
The header-checker-lint bot uses a .github yaml file instead of this custom json file
