### PR TITLE
fix: fixed maxResults check in tag and release iterators

### DIFF
--- a/src/github.ts
+++ b/src/github.ts
@@ -649,7 +649,7 @@ export class GitHub {
         }
         yield response.data[i];
       }
-      if (!response.pageInfo.hasNextPage) {
+      if (results > maxResults || !response.pageInfo.hasNextPage) {
         break;
       }
       cursor = response.pageInfo.endCursor;
@@ -741,6 +741,7 @@ export class GitHub {
           sha: tag.commit.sha,
         };
       }
+      if (results > maxResults) break;
     }
   }
 


### PR DESCRIPTION
If the results exceed maxResults, the iteration doesn't stop immediately. It keeps making requests until the data runs out (or we run into quota/throttling issues) because the existing break (lines 648 and 737) break out of the inner loop, not the outer loop.