### PR TITLE
feat(cli): show file diff for release-pr command with --dry-run and --trace

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,6 +39,7 @@
   "devDependencies": {
     "@octokit/types": "^6.1.0",
     "@types/chai": "^4.1.7",
+    "@types/diff": "^5.0.2",
     "@types/iarna__toml": "^2.0.1",
     "@types/js-yaml": "^4.0.0",
     "@types/jsonpath": "^0.2.0",
@@ -80,6 +81,7 @@
     "conventional-changelog-writer": "^5.0.0",
     "conventional-commits-filter": "^2.0.2",
     "detect-indent": "^6.1.0",
+    "diff": "^5.0.0",
     "figures": "^3.0.0",
     "js-yaml": "^4.0.0",
     "jsonpath": "^1.1.1",


### PR DESCRIPTION
This will aid in debugging release-pr creation

Note that `diff` `^5.0.0` is what's used by the underlying `code-suggester` library as well.

Example usage:
```
release-please release-pr \
  --token=${GITHUB_TOKEN} \
  --repo-url=googleapis/java-bigquery \
  --release-type=java-yoshi \
  --trace \
  --dry-run
```