### PR TITLE
fix(java): snapshots should bump versionsMap versions

### DIFF
--- a/src/strategies/base.ts
+++ b/src/strategies/base.ts
@@ -355,17 +355,11 @@ export abstract class BaseStrategy implements Strategy {
     conventionalCommits: ConventionalCommit[],
     _newVersion: Version
   ): Promise<VersionsMap> {
-    for (const versionKey of versionsMap.keys()) {
-      const version = versionsMap.get(versionKey);
-      if (!version) {
-        logger.warn(`didn't find version for ${versionKey}`);
-        continue;
-      }
-      const newVersion = await this.versioningStrategy.bump(
-        version,
-        conventionalCommits
+    for (const [component, version] of versionsMap.entries()) {
+      versionsMap.set(
+        component,
+        await this.versioningStrategy.bump(version, conventionalCommits)
       );
-      versionsMap.set(versionKey, newVersion);
     }
     return versionsMap;
   }

--- a/src/strategies/java.ts
+++ b/src/strategies/java.ts
@@ -107,6 +107,12 @@ export class Java extends BaseStrategy {
       ? await this.snapshotVersioning.bump(latestRelease.tag.version, [])
       : this.initialReleaseVersion();
     const versionsMap = await this.buildVersionsMap([]);
+    for (const [component, version] of versionsMap.entries()) {
+      versionsMap.set(
+        component,
+        await this.snapshotVersioning.bump(version, [])
+      );
+    }
     const pullRequestTitle = PullRequestTitle.ofComponentTargetBranchVersion(
       component || '',
       this.targetBranch,

--- a/test/strategies/java-yoshi.ts
+++ b/test/strategies/java-yoshi.ts
@@ -235,7 +235,11 @@ describe('JavaYoshi', () => {
       const updates = release!.updates;
       assertHasUpdate(updates, 'CHANGELOG.md', Changelog);
       const {updater} = assertHasUpdate(updates, 'path1/pom.xml', JavaUpdate);
-      expect((updater as JavaUpdate).isSnapshot).to.be.false;
+      const javaUpdater = updater as JavaUpdate;
+      expect(javaUpdater.isSnapshot).to.be.false;
+      expect(
+        javaUpdater.versionsMap?.get('google-cloud-trace')?.toString()
+      ).to.eql('0.108.1-beta');
       assertHasUpdate(updates, 'path2/pom.xml', JavaUpdate);
       assertHasUpdate(updates, 'path1/build.gradle', JavaUpdate);
       assertHasUpdate(updates, 'path1/build.gradle', JavaUpdate);
@@ -303,7 +307,11 @@ describe('JavaYoshi', () => {
       const updates = release!.updates;
       assertNoHasUpdate(updates, 'CHANGELOG.md');
       const {updater} = assertHasUpdate(updates, 'path1/pom.xml', JavaUpdate);
-      expect((updater as JavaUpdate).isSnapshot).to.be.true;
+      const javaUpdater = updater as JavaUpdate;
+      expect(javaUpdater.isSnapshot).to.be.true;
+      expect(
+        javaUpdater.versionsMap?.get('google-cloud-trace')?.toString()
+      ).to.eql('0.108.1-beta-SNAPSHOT');
       assertHasUpdate(updates, 'path2/pom.xml', JavaUpdate);
       assertHasUpdate(updates, 'path1/build.gradle', JavaUpdate);
       assertHasUpdate(updates, 'path1/build.gradle', JavaUpdate);


### PR DESCRIPTION
Files were not being updated because the `versionsMap` was not version bumping the component versions

Fixes #1381
