### PR TITLE
feat: standardize Python headers in the changelog

### DIFF
--- a/src/strategies/python.ts
+++ b/src/strategies/python.ts
@@ -154,4 +154,27 @@ export class Python extends BaseStrategy {
   protected initialReleaseVersion(): Version {
     return Version.parse('0.1.0');
   }
+  
+  protected async buildReleaseNotes(
+    conventionalCommits: ConventionalCommit[],
+    newVersion: Version,
+    newVersionTag: TagName,
+    latestRelease?: Release,
+    commits?: Commit[]
+  ): Promise<string> {
+    const releaseNotes = await super.buildReleaseNotes(
+      conventionalCommits,
+      newVersion,
+      newVersionTag,
+      latestRelease,
+      commits
+    );
+    return (
+      releaseNotes
+        // Remove links in version title line and standardize on h2
+        .replace(/^###? \[([\d.]+)\]\([^)]*\)/gm, '## $1')
+        // Standardize on h3 for change type subheaders
+        .replace(/^###? (Features|Bug Fixes|Documentation)$/gm, '### $1')
+    );
+  }
 }


### PR DESCRIPTION
Ported over existing entry from the Ruby-yoshi changelog updater. Only modifying for header changes and removing links in the version titles.

For any headers of size 2 or 3 for version change entries, they will be standardized to header size 2.

For any headers of size 2 or 3 for change type entries, they will be standardized to header size 3.

Fixes #1389 🦕
