### PR TITLE
fix(deps): switch from `xmldom` to `@xmldom/xmldom` and update to v0.8.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -75,6 +75,7 @@
     "@octokit/request-error": "^2.1.0",
     "@octokit/rest": "^18.12.0",
     "@types/npm-package-arg": "^6.1.0",
+    "@xmldom/xmldom": "^0.8.2",
     "chalk": "^4.0.0",
     "code-suggester": "^2.0.0",
     "conventional-changelog-conventionalcommits": "^4.6.0",
@@ -92,7 +93,6 @@
     "typescript": "^3.8.3",
     "unist-util-visit": "^2.0.3",
     "unist-util-visit-parents": "^3.1.1",
-    "xmldom": "^0.6.0",
     "xpath": "^0.0.32",
     "yargs": "^17.0.0"
   },

--- a/src/updaters/base-xml.ts
+++ b/src/updaters/base-xml.ts
@@ -13,7 +13,7 @@
 // limitations under the License.
 
 import {Updater} from '../update';
-import * as dom from 'xmldom';
+import * as dom from '@xmldom/xmldom';
 
 /**
  * Base class for all updaters working with XML files.


### PR DESCRIPTION
xmldom could no longer be published, so the maintainers switched to a
namespaced package name.
