### PR TITLE
fix: Allow an empty value for --label

### DIFF
--- a/src/bin/release-please.ts
+++ b/src/bin/release-please.ts
@@ -752,8 +752,10 @@ function extractManifestOptions(
   if ('fork' in argv && argv.fork !== undefined) {
     manifestOptions.fork = argv.fork;
   }
-  if (argv.label) {
-    manifestOptions.labels = argv.label.split(',');
+  if (argv.label !== undefined) {
+    let labels: string[] = argv.label.split(',');
+    if (labels.length === 1 && labels[0] === '') labels = [];
+    manifestOptions.labels = labels;
   }
   if ('releaseLabel' in argv && argv.releaseLabel) {
     manifestOptions.releaseLabels = argv.releaseLabel.split(',');

--- a/test/cli.ts
+++ b/test/cli.ts
@@ -243,6 +243,27 @@ describe('CLI', () => {
       sinon.assert.calledOnce(createPullRequestsStub);
     });
 
+    it('handles empty --label', async () => {
+      await parser.parseAsync(
+        'manifest-pr --repo-url=googleapis/release-please-cli --label='
+      );
+
+      sinon.assert.calledOnceWithExactly(gitHubCreateStub, {
+        owner: 'googleapis',
+        repo: 'release-please-cli',
+        token: undefined,
+      });
+      sinon.assert.calledOnceWithExactly(
+        fromManifestStub,
+        fakeGitHub,
+        'main',
+        DEFAULT_RELEASE_PLEASE_CONFIG,
+        DEFAULT_RELEASE_PLEASE_MANIFEST,
+        sinon.match({labels: []})
+      );
+      sinon.assert.calledOnce(createPullRequestsStub);
+    });
+
     // it('handles --draft', async () => {
     //   await parser.parseAsync(
     //     'manifest-pr --repo-url=googleapis/release-please-cli --draft'


### PR DESCRIPTION
I want to be able to pass `--label=` (i.e. an empty value) to prevent release-please from attempting to add any labels. Currently this doesn't work because javascript thinks `""` is falsy, and the labels still default to `autorelease: pending`.