### PR TITLE
feat: add a flag to disable adding labels to new pull requests

### DIFF
--- a/__snapshots__/cli.js
+++ b/__snapshots__/cli.js
@@ -87,6 +87,8 @@ Options:
   --dry-run             Prepare but do not take action[boolean] [default: false]
   --label               comma-separated list of labels to add to from release PR
                                                [default: "autorelease: pending"]
+  --skip-labeling       skip application of labels to pull requests
+                                                      [boolean] [default: false]
   --fork                should the PR be created from a fork
                                                       [boolean] [default: false]
   --draft-pull-request  mark pull request as a draft  [boolean] [default: false]
@@ -199,6 +201,8 @@ Options:
   --label                           comma-separated list of labels to add to
                                     from release PR
                                                [default: "autorelease: pending"]
+  --skip-labeling                   skip application of labels to pull requests
+                                                      [boolean] [default: false]
   --fork                            should the PR be created from a fork
                                                       [boolean] [default: false]
   --draft-pull-request              mark pull request as a draft

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -56,6 +56,7 @@ Extra options:
 | `--draft-pull-request` | `boolean` | If set, create pull requests as drafts |
 | `--label` | `string` | Comma-separated list of labels to apply to the release pull requests. Defaults to `autorelease: pending` |
 | `--release-label` | `string` | Comma-separated list of labels to apply to the pull request after the release has been tagged. Defaults to `autorelease: tagged` |
+| `--skip-labeling` | `boolean` | If set, labels will not be applied to pull requests |
 | `--changelog-path` | `string` | Override the path to the managed CHANGELOG. Defaults to `CHANGELOG.md` |
 | `--changelog-type` | [`ChangelogType`](/docs/customizing.md#changelog-types) | Strategy for building the changelog contents. Defaults to `default` |
 | `--changelog-sections` | `string` | Comma-separated list of commit scopes to show in changelog headings |

--- a/src/bin/release-please.ts
+++ b/src/bin/release-please.ts
@@ -92,6 +92,7 @@ interface ReleaseArgs {
 interface PullRequestArgs {
   draftPullRequest?: boolean;
   label?: string;
+  skipLabeling?: boolean;
   signoff?: string;
 }
 
@@ -229,6 +230,11 @@ function pullRequestOptions(yargs: yargs.Argv): yargs.Argv {
     .option('label', {
       default: 'autorelease: pending',
       describe: 'comma-separated list of labels to add to from release PR',
+    })
+    .option('skip-labeling', {
+      describe: 'skip application of labels to pull requests',
+      type: 'boolean',
+      default: false,
     })
     .option('fork', {
       describe: 'should the PR be created from a fork',
@@ -756,6 +762,9 @@ function extractManifestOptions(
     let labels: string[] = argv.label.split(',');
     if (labels.length === 1 && labels[0] === '') labels = [];
     manifestOptions.labels = labels;
+  }
+  if ('skipLabeling' in argv && argv.skipLabeling !== undefined) {
+    manifestOptions.skipLabeling = argv.skipLabeling;
   }
   if ('releaseLabel' in argv && argv.releaseLabel) {
     manifestOptions.releaseLabels = argv.releaseLabel.split(',');

--- a/src/github.ts
+++ b/src/github.ts
@@ -891,12 +891,16 @@ export class GitHub {
     options?: {
       signoffUser?: string;
       fork?: boolean;
+      skipLabeling?: boolean;
     }
   ): Promise<PullRequest> {
     let message = releasePullRequest.title.toString();
     if (options?.signoffUser) {
       message = signoffCommitMessage(message, options.signoffUser);
     }
+    const pullRequestLabels: string[] = options?.skipLabeling
+      ? []
+      : releasePullRequest.labels;
     return await this.createPullRequest(
       {
         headBranchName: releasePullRequest.headRefName,
@@ -904,7 +908,7 @@ export class GitHub {
         number: -1,
         title: releasePullRequest.title.toString(),
         body: releasePullRequest.body.toString().slice(0, MAX_ISSUE_BODY_SIZE),
-        labels: releasePullRequest.labels,
+        labels: pullRequestLabels,
         files: [],
       },
       targetBranch,

--- a/src/manifest.ts
+++ b/src/manifest.ts
@@ -134,6 +134,7 @@ export interface ManifestOptions {
   signoff?: string;
   manifestPath?: string;
   labels?: string[];
+  skipLabeling?: boolean;
   releaseLabels?: string[];
   snapshotLabels?: string[];
   draft?: boolean;
@@ -214,6 +215,7 @@ export class Manifest {
   readonly fork: boolean;
   private signoffUser?: string;
   private labels: string[];
+  private skipLabeling?: boolean;
   private releaseLabels: string[];
   private snapshotLabels: string[];
   private plugins: PluginType[];
@@ -277,6 +279,7 @@ export class Manifest {
     this.releaseLabels =
       manifestOptions?.releaseLabels || DEFAULT_RELEASE_LABELS;
     this.labels = manifestOptions?.labels || DEFAULT_LABELS;
+    this.skipLabeling = manifestOptions?.skipLabeling || false;
     this.snapshotLabels =
       manifestOptions?.snapshotLabels || DEFAULT_SNAPSHOT_LABELS;
     this.bootstrapSha = manifestOptions?.bootstrapSha;
@@ -826,6 +829,7 @@ export class Manifest {
       {
         fork: this.fork,
         signoffUser: this.signoffUser,
+        skipLabeling: this.skipLabeling,
       }
     );
     return newPullRequest;

--- a/test/cli.ts
+++ b/test/cli.ts
@@ -264,6 +264,27 @@ describe('CLI', () => {
       sinon.assert.calledOnce(createPullRequestsStub);
     });
 
+    it('handles --skip-labeling', async () => {
+      await parser.parseAsync(
+        'manifest-pr --repo-url=googleapis/release-please-cli --skip-labeling'
+      );
+
+      sinon.assert.calledOnceWithExactly(gitHubCreateStub, {
+        owner: 'googleapis',
+        repo: 'release-please-cli',
+        token: undefined,
+      });
+      sinon.assert.calledOnceWithExactly(
+        fromManifestStub,
+        fakeGitHub,
+        'main',
+        DEFAULT_RELEASE_PLEASE_CONFIG,
+        DEFAULT_RELEASE_PLEASE_MANIFEST,
+        sinon.match({skipLabeling: true})
+      );
+      sinon.assert.calledOnce(createPullRequestsStub);
+    });
+
     // it('handles --draft', async () => {
     //   await parser.parseAsync(
     //     'manifest-pr --repo-url=googleapis/release-please-cli --draft'


### PR DESCRIPTION
Introduces the flag `--skip-labeling` that skips the application of labels to newly created pull requests (even if the `label` option is set). We keep the label option set (e.g. to its default of `['autorelease: pending']`) throughout the manifest logic so that it does not affect that logic or plugin logic, but then when it gets into the `github.ts` layer we use the new flag to disable the additional API call that sets the labels after the pull request is created.

This is needed for use cases that call the release-please CLI using a token (such as `YOSHI_CODE_BOT_TOKEN`) that does not have permissions on the repo. In such cases, the second call that sets labels on the newly created PR will fail from insufficient permissions, thus causing release-please to terminate with an error. Repos that run into this case (such as google-cloud-ruby) have other mechanisms to set the labels after release-please is finished. All we need is some way to prevent release-please from erroring out.

I originally tried to handle this use case by passing an empty array using the `--label=` flag. This, however, fails because this value is used for other purposes in addition to setting the labels for new release PRs. For example, it is used to identify existing untagged release PRs. Thus, we cannot empty the `label` option, and we must introduce some other means to tell release-please not to attempt to make the problematic PR edit call.

Tested end-to-end locally.