### PR TITLE
feat: Support sequential-calls manifest field that disables concurrency when creating multiple pull requests or releases

### DIFF
--- a/docs/cli.md
+++ b/docs/cli.md
@@ -56,7 +56,6 @@ Extra options:
 | `--draft-pull-request` | `boolean` | If set, create pull requests as drafts |
 | `--label` | `string` | Comma-separated list of labels to apply to the release pull requests. Defaults to `autorelease: pending` |
 | `--release-label` | `string` | Comma-separated list of labels to apply to the pull request after the release has been tagged. Defaults to `autorelease: tagged` |
-| `--skip-labeling` | `boolean` | If set, labels will not be applied to pull requests |
 | `--changelog-path` | `string` | Override the path to the managed CHANGELOG. Defaults to `CHANGELOG.md` |
 | `--changelog-type` | [`ChangelogType`](/docs/customizing.md#changelog-types) | Strategy for building the changelog contents. Defaults to `default` |
 | `--changelog-sections` | `string` | Comma-separated list of commit scopes to show in changelog headings |
@@ -83,6 +82,7 @@ Extra options:
 | ------ | ---- | ----------- |
 | `--config-file` | string | Override the path to the release-please config file. Defaults to `release-please-config.json` |
 | `--manifest-file` | string | Override the path to the release-please manifest file. Defaults to `.release-please-manifest.json` |
+| `--skip-labeling` | `boolean` | If set, labels will not be applied to pull requests |
 
 ### Without a manifest config
 
@@ -109,6 +109,7 @@ need to specify your release options:
 | `--signoff` | string | Add [`Signed-off-by`](https://git-scm.com/docs/git-commit#Documentation/git-commit.txt---signoff) line at the end of the commit log message using the user and email provided. (format "Name \<email@example.com\>") |
 | `--extra-files` | `string[]` | Extra file paths for the release strategy to consider |
 | `--version-file` | `string` | Ruby only. Path to the `version.rb` file |
+| `--skip-labeling` | `boolean` | If set, labels will not be applied to pull requests |
 
 ## Creating a release on GitHub
 

--- a/docs/manifest-releaser.md
+++ b/docs/manifest-releaser.md
@@ -225,6 +225,14 @@ documented in comments)
   // value, but it will increase the number of API calls used.
   "commit-search-depth": 500,
 
+  // when creating multiple pull requests or releases, issue GitHub API requests
+  // sequentially rather than concurrently, waiting for the previous request to
+  // complete before issuing the next one.
+  // This option may reduce failures due to throttling on repositories releasing
+  // large numbers of packages at once.
+  // absence defaults to false, causing calls to be issued concurrently.
+  "sequential-calls": false,
+
   // per package configuration: at least one entry required.
   // the key is the relative path from the repo root to the folder that contains
   // all the files for that package.


### PR DESCRIPTION
When running release-please on the google-cloud-ruby manifest, we're running afoul of secondary rate limits. Currently release-please runs pull request creation concurrently, and in this case, it was trying to open 33 pull requests at once which seemed to be too much. So we're introducing an option to run them sequentially using blocking calls.

This was added to the manifest config rather than the CLI options, because it seems to be a scaling-related knob that should be set per repository, rather than something that depends on how release-please is invoked.

I honestly do not know how to write a test for this. I tested manually both the sequential and concurrent cases to make sure the functionality was still correct, but I'm not sure how to test whether something happened concurrently or not.