### PR TITLE
feat: allow configuring separate-pull-requests per component

### DIFF
--- a/src/manifest.ts
+++ b/src/manifest.ts
@@ -76,6 +76,7 @@ export interface ReleaserConfig {
   includeVInTag?: boolean;
   pullRequestTitlePattern?: string;
   tagSeparator?: string;
+  separatePullRequests?: boolean;
 
   // Changelog options
   changelogSections?: ChangelogSection[];
@@ -120,6 +121,7 @@ interface ReleaserConfigJson {
   'changelog-type'?: ChangelogNotesType;
   'changelog-host'?: string;
   'pull-request-title-pattern'?: string;
+  'separate-pull-requests'?: boolean;
   'tag-separator'?: string;
   'extra-files'?: string[];
   'version-file'?: string;
@@ -177,7 +179,6 @@ export interface ManifestConfig extends ReleaserConfigJson {
   'last-release-sha'?: string;
   'always-link-local'?: boolean;
   plugins?: PluginType[];
-  'separate-pull-requests'?: boolean;
   'group-pull-request-title-pattern'?: string;
   'release-search-depth'?: number;
   'commit-search-depth'?: number;
@@ -1140,6 +1141,7 @@ function extractReleaserConfig(
     changelogType: config['changelog-type'],
     pullRequestTitlePattern: config['pull-request-title-pattern'],
     tagSeparator: config['tag-separator'],
+    separatePullRequests: config['separate-pull-requests'],
   };
 }
 
@@ -1386,6 +1388,8 @@ function mergeReleaserConfig(
     pullRequestTitlePattern:
       pathConfig.pullRequestTitlePattern ??
       defaultConfig.pullRequestTitlePattern,
+    separatePullRequests:
+      pathConfig.separatePullRequests ?? defaultConfig.separatePullRequests,
   };
 }
 

--- a/src/plugins/merge.ts
+++ b/src/plugins/merge.ts
@@ -55,11 +55,23 @@ export class Merge extends ManifestPlugin {
     }
     logger.info(`Merging ${candidates.length} pull requests`);
 
+    const [inScopeCandidates, outOfScopeCandidates] = candidates.reduce(
+      (collection, candidate) => {
+        if (candidate.config.separatePullRequests) {
+          collection[1].push(candidate);
+        } else {
+          collection[0].push(candidate);
+        }
+        return collection;
+      },
+      [[], []] as CandidateReleasePullRequest[][]
+    );
+
     const releaseData: ReleaseData[] = [];
     const labels = new Set<string>();
     let rawUpdates: Update[] = [];
     let rootRelease: CandidateReleasePullRequest | null = null;
-    for (const candidate of candidates) {
+    for (const candidate of inScopeCandidates) {
       const pullRequest = candidate.pullRequest;
       rawUpdates = rawUpdates.concat(...pullRequest.updates);
       for (const label of pullRequest.labels) {
@@ -99,6 +111,7 @@ export class Merge extends ManifestPlugin {
           releaseType,
         },
       },
+      ...outOfScopeCandidates,
     ];
   }
 }

--- a/src/plugins/merge.ts
+++ b/src/plugins/merge.ts
@@ -55,7 +55,9 @@ export class Merge extends ManifestPlugin {
     }
     logger.info(`Merging ${candidates.length} pull requests`);
 
-    const [inScopeCandidates, outOfScopeCandidates] = candidates.reduce(
+    const [inScopeCandidates, outOfScopeCandidates] = candidates.reduce<
+      Array<Array<CandidateReleasePullRequest>>
+    >(
       (collection, candidate) => {
         if (candidate.config.separatePullRequests) {
           collection[1].push(candidate);
@@ -64,7 +66,7 @@ export class Merge extends ManifestPlugin {
         }
         return collection;
       },
-      [[], []] as CandidateReleasePullRequest[][]
+      [[], []]
     );
 
     const releaseData: ReleaseData[] = [];

--- a/src/strategies/base.ts
+++ b/src/strategies/base.ts
@@ -152,6 +152,10 @@ export abstract class BaseStrategy implements Strategy {
     );
   }
 
+  protected async getBranchComponent(): Promise<string | undefined> {
+    return this.component || (await this.getDefaultComponent());
+  }
+
   async getPackageName(): Promise<string | undefined> {
     return this.packageName ?? (await this.getDefaultPackageName());
   }
@@ -265,8 +269,9 @@ export abstract class BaseStrategy implements Strategy {
       newVersion,
       this.pullRequestTitlePattern
     );
-    const branchName = component
-      ? BranchName.ofComponentTargetBranch(component, this.targetBranch)
+    const branchComponent = await this.getBranchComponent();
+    const branchName = branchComponent
+      ? BranchName.ofComponentTargetBranch(branchComponent, this.targetBranch)
       : BranchName.ofTargetBranch(this.targetBranch);
     const releaseNotesBody = await this.buildReleaseNotes(
       conventionalCommits,

--- a/test/manifest.ts
+++ b/test/manifest.ts
@@ -2889,6 +2889,44 @@ describe('Manifest', () => {
           'release-please--branches--main--components--d'
         );
       });
+
+      it('should allow configuring individual separate pull requests with includeComponentInTag = false', async () => {
+        const manifest = new Manifest(
+          github,
+          'main',
+          {
+            'pkg/b': {
+              releaseType: 'simple',
+              component: 'b',
+            },
+            'pkg/c': {
+              releaseType: 'simple',
+              component: 'c',
+            },
+            'pkg/d': {
+              releaseType: 'simple',
+              component: 'd',
+              separatePullRequests: true,
+              includeComponentInTag: false,
+            },
+          },
+          {
+            'pkg/b': Version.parse('1.0.0'),
+            'pkg/c': Version.parse('2.0.0'),
+            'pkg/d': Version.parse('3.0.0'),
+          }
+        );
+        const pullRequests = await manifest.buildPullRequests();
+        expect(pullRequests).lengthOf(2);
+        const pullRequest = pullRequests[0];
+        expect(pullRequest.headRefName).to.eql(
+          'release-please--branches--main'
+        );
+        const mainPullRequest = pullRequests[1];
+        expect(mainPullRequest.headRefName).to.eql(
+          'release-please--branches--main--components--d'
+        );
+      });
     });
   });
 


### PR DESCRIPTION
Allows configuring `separate-pull-requests` for individual components. They will be excluded from any merged pull request.

Fixes #1411
