### PR TITLE
fix: node-workspace should not bump versions for peer dependencies

### DIFF
--- a/__snapshots__/node-workspace.js
+++ b/__snapshots__/node-workspace.js
@@ -85,6 +85,20 @@ Release notes for path: node1, releaseType: node
 This PR was generated with [Release Please](https://github.com/googleapis/release-please). See [documentation](https://github.com/googleapis/release-please#release-please).
 `
 
+exports['NodeWorkspace plugin run should ignore peer dependencies 1'] = `
+:robot: I have created a release *beep* *boop*
+---
+
+
+<details><summary>@here/pkgA: 3.3.4</summary>
+
+Release notes for path: node1, releaseType: node
+</details>
+
+---
+This PR was generated with [Release Please](https://github.com/googleapis/release-please). See [documentation](https://github.com/googleapis/release-please#release-please).
+`
+
 exports['NodeWorkspace plugin run walks dependency tree and updates previously untouched packages 1'] = `
 :robot: I have created a release *beep* *boop*
 ---

--- a/src/plugins/node-workspace.ts
+++ b/src/plugins/node-workspace.ts
@@ -311,7 +311,6 @@ export class NodeWorkspace extends WorkspacePlugin<Package> {
         ...(packageJson.dependencies ?? {}),
         ...(packageJson.devDependencies ?? {}),
         ...(packageJson.optionalDependencies ?? {}),
-        ...(packageJson.peerDependencies ?? {}),
       });
       const workspaceDeps = allDeps.filter(dep =>
         workspacePackageNames.has(dep)

--- a/test/fixtures/plugins/node-workspace/plugin1/package.json
+++ b/test/fixtures/plugins/node-workspace/plugin1/package.json
@@ -1,0 +1,7 @@
+{
+  "name": "@here/plugin1",
+  "version": "4.4.4",
+  "peerDependencies": {
+    "@here/pkgA": "^3.3.3"
+  }
+}


### PR DESCRIPTION
Fixes #1403 
