### PR TITLE
fix(cargo-workspace): stop defaulting to updating all components

### DIFF
--- a/__snapshots__/cargo-workspace.js
+++ b/__snapshots__/cargo-workspace.js
@@ -27,13 +27,6 @@ Release notes for path: packages/rustA, releaseType: rust
     * pkgB bumped from 2.2.2 to 2.2.3
 </details>
 
-<details><summary>pkgD: 1.2.4</summary>
-
-### Dependencies
-
-
-</details>
-
 ---
 This PR was generated with [Release Please](https://github.com/googleapis/release-please). See [documentation](https://github.com/googleapis/release-please#release-please).
 `
@@ -65,6 +58,29 @@ exports['CargoWorkspace plugin run handles a single rust package 1'] = `
 <details><summary>pkgA: 1.1.2</summary>
 
 Release notes for path: packages/rustA, releaseType: rust
+</details>
+
+---
+This PR was generated with [Release Please](https://github.com/googleapis/release-please). See [documentation](https://github.com/googleapis/release-please#release-please).
+`
+
+exports['CargoWorkspace plugin run skips component if not touched 1'] = `
+:robot: I have created a release *beep* *boop*
+---
+
+
+<details><summary>pkgB: 2.3.0</summary>
+
+Release notes for path: packages/rustB, releaseType: rust
+</details>
+
+<details><summary>pkgC: 3.3.4</summary>
+
+### Dependencies
+
+* The following workspace dependencies were updated
+  * dependencies
+    * pkgB bumped from 2.2.2 to 2.3.0
 </details>
 
 ---

--- a/src/plugins/cargo-workspace.ts
+++ b/src/plugins/cargo-workspace.ts
@@ -12,18 +12,9 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import {
-  CandidateReleasePullRequest,
-  RepositoryConfig,
-  ROOT_PROJECT_PATH,
-} from '../manifest';
+import {CandidateReleasePullRequest, ROOT_PROJECT_PATH} from '../manifest';
 import {logger} from '../util/logger';
-import {
-  WorkspacePlugin,
-  DependencyGraph,
-  DependencyNode,
-  WorkspacePluginOptions,
-} from './workspace';
+import {WorkspacePlugin, DependencyGraph, DependencyNode} from './workspace';
 import {
   CargoManifest,
   parseCargoManifest,
@@ -31,7 +22,6 @@ import {
   CargoDependency,
 } from '../updaters/rust/common';
 import {VersionsMap, Version} from '../version';
-import {GitHub} from '../github';
 import {CargoToml} from '../updaters/rust/cargo-toml';
 import {RawContent} from '../updaters/raw-content';
 import {Changelog} from '../updaters/changelog';
@@ -82,17 +72,6 @@ interface CrateInfo {
  * into a single rust package.
  */
 export class CargoWorkspace extends WorkspacePlugin<CrateInfo> {
-  constructor(
-    github: GitHub,
-    targetBranch: string,
-    repositoryConfig: RepositoryConfig,
-    options: WorkspacePluginOptions = {}
-  ) {
-    super(github, targetBranch, repositoryConfig, {
-      ...options,
-      updateAllPackages: true,
-    });
-  }
   protected async buildAllPackages(
     candidates: CandidateReleasePullRequest[]
   ): Promise<{

--- a/src/plugins/workspace.ts
+++ b/src/plugins/workspace.ts
@@ -277,6 +277,10 @@ export abstract class WorkspacePlugin<T> extends ManifestPlugin {
     graph: DependencyGraph<T>,
     packageNamesToUpdate: string[]
   ): T[] {
+    logger.info(
+      `building graph order, existing package names: ${packageNamesToUpdate}`
+    );
+
     // invert the graph so it's dependency name => packages that depend on it
     const dependentGraph = this.invertGraph(graph);
     const visited: Set<T> = new Set();


### PR DESCRIPTION
It's unclear why we always bump cargo versions for untouched components.

Fixes #1407
