### PR TITLE
fix: release tagging can find branch components

### DIFF
--- a/src/strategies/base.ts
+++ b/src/strategies/base.ts
@@ -468,13 +468,14 @@ export abstract class BaseStrategy implements Strategy {
       pullRequestBody.releaseData.length === 1 &&
       !pullRequestBody.releaseData[0].component
     ) {
+      const branchComponent = await this.getBranchComponent();
       // standalone release PR, ensure the components match
       if (
         this.normalizeComponent(branchName.component) !==
-        this.normalizeComponent(component)
+        this.normalizeComponent(branchComponent)
       ) {
         logger.warn(
-          `PR component: ${branchName.component} does not match configured component: ${component}`
+          `PR component: ${branchName.component} does not match configured component: ${branchComponent}`
         );
         return;
       }

--- a/test/manifest.ts
+++ b/test/manifest.ts
@@ -3888,7 +3888,7 @@ describe('Manifest', () => {
         [],
         [
           {
-            headBranchName: 'release-please/branches/main',
+            headBranchName: 'release-please--branches--main',
             baseBranchName: 'main',
             number: 1234,
             title: 'chore(main): release 3.2.7',
@@ -3905,6 +3905,50 @@ describe('Manifest', () => {
         {
           '.': {
             releaseType: 'simple',
+          },
+        },
+        {
+          '.': Version.parse('3.2.6'),
+        }
+      );
+      const releases = await manifest.buildReleases();
+      expect(releases).lengthOf(1);
+      expect(releases[0].tag.toString()).to.eql('v3.2.7');
+      expect(releases[0].sha).to.eql('abc123');
+      expect(releases[0].notes)
+        .to.be.a('string')
+        .and.satisfy((msg: string) => msg.startsWith('### [3.2.7]'));
+      expect(releases[0].path).to.eql('.');
+      expect(releases[0].name).to.eql('v3.2.7');
+      expect(releases[0].draft).to.be.undefined;
+      expect(releases[0].prerelease).to.be.undefined;
+    });
+
+    it('should handle a single component release', async () => {
+      mockPullRequests(
+        github,
+        [],
+        [
+          {
+            headBranchName: 'release-please--branches--main--components--foo',
+            baseBranchName: 'main',
+            number: 1234,
+            title: 'chore(main): release 3.2.7',
+            body: pullRequestBody('release-notes/single.txt'),
+            labels: ['autorelease: pending'],
+            files: [],
+            sha: 'abc123',
+          },
+        ]
+      );
+      const manifest = new Manifest(
+        github,
+        'main',
+        {
+          '.': {
+            releaseType: 'simple',
+            component: 'foo',
+            includeComponentInTag: false,
           },
         },
         {
@@ -4276,7 +4320,8 @@ describe('Manifest', () => {
         [],
         [
           {
-            headBranchName: 'release-please/branches/main',
+            headBranchName:
+              'release-please--branches--main--components--release-brancher',
             baseBranchName: 'main',
             number: 1234,
             title: 'chore(main): release v1.3.1',


### PR DESCRIPTION
Fixes #1424 

When tagging a single component, correctly use the branch component for finding appropriate release notes.