### PR TITLE
fix: CommitSplit with includeEmpty should add commit to all packages

### DIFF
--- a/src/util/commit-split.ts
+++ b/src/util/commit-split.ts
@@ -114,8 +114,15 @@ export class CommitSplit {
         splitCommits[pkgName].push(commit);
       }
       if (commit.files.length === 0 && this.includeEmpty) {
-        for (const pkgName in splitCommits) {
-          splitCommits[pkgName].push(commit);
+        if (this.packagePaths) {
+          for (const pkgName of this.packagePaths) {
+            splitCommits[pkgName] = splitCommits[pkgName] || [];
+            splitCommits[pkgName].push(commit);
+          }
+        } else {
+          for (const pkgName in splitCommits) {
+            splitCommits[pkgName].push(commit);
+          }
         }
       }
     });

--- a/src/util/commit-split.ts
+++ b/src/util/commit-split.ts
@@ -41,6 +41,12 @@ export interface CommitSplitOptions {
   packagePaths?: string[];
 }
 
+/**
+ * Helper class for splitting commits by component path. If `packagePaths`
+ * is configured, then only consider the provided paths. If `includeEmpty`
+ * is configured, then commits without any touched files apply to all
+ * configured component paths.
+ */
 export class CommitSplit {
   includeEmpty: boolean;
   packagePaths?: string[];
@@ -81,7 +87,15 @@ export class CommitSplit {
     }
   }
 
-  // split(commits: Commit[]): Record<string, Commit[]>
+  /**
+   * Split commits by component path. If the commit splitter is configured
+   * with a set of tracked package paths, then only consider paths for
+   * configured components. If `includeEmpty` is configured, then a commit
+   * that does not touch any files will be applied to all components'
+   * commits.
+   * @param {Commit[]} commits The commits to split
+   * @returns {Record<string, Commit[]>} Commits indexed by component path
+   */
   split<T extends Commit>(commits: T[]): Record<string, T[]> {
     const splitCommits: Record<string, T[]> = {};
     commits.forEach(commit => {

--- a/test/util/commit-split.ts
+++ b/test/util/commit-split.ts
@@ -1,0 +1,89 @@
+// Copyright 2022 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import {describe, it} from 'mocha';
+import {expect} from 'chai';
+import {CommitSplit} from '../../src/util/commit-split';
+import {Commit} from '../../src/commit';
+
+describe('CommitSplit', () => {
+  const commits: Commit[] = [
+    {
+      sha: 'abc123',
+      message: 'commit abc123',
+      files: ['pkg1/foo.txt', 'pkg2/bar.txt'],
+    },
+    {
+      sha: 'def234',
+      message: 'commit def234',
+      files: ['pkg1/foo2.txt', 'pkg3/asdf.txt'],
+    },
+    {
+      sha: 'efg',
+      message: 'empty files',
+      files: [],
+    },
+  ];
+  it('defaults to excluding empty commits', () => {
+    const commitSplit = new CommitSplit();
+    expect(commitSplit.includeEmpty).to.be.false;
+  });
+  describe('including empty commits', () => {
+    it('should separate commits', () => {
+      const commitSplit = new CommitSplit({
+        includeEmpty: true,
+      });
+      const splitCommits = commitSplit.split(commits);
+      expect(splitCommits['pkg1']).lengthOf(3);
+      expect(splitCommits['pkg2']).lengthOf(2);
+      expect(splitCommits['pkg3']).lengthOf(2);
+      expect(splitCommits['pkg4']).to.be.undefined;
+    });
+    it('should separate commits with limited list of paths', () => {
+      const commitSplit = new CommitSplit({
+        includeEmpty: true,
+        packagePaths: ['pkg1', 'pkg4'],
+      });
+      const splitCommits = commitSplit.split(commits);
+      expect(splitCommits['pkg1']).lengthOf(3);
+      expect(splitCommits['pkg2']).to.be.undefined;
+      expect(splitCommits['pkg3']).to.be.undefined;
+      expect(splitCommits['pkg4']).lengthOf(1);
+    });
+  });
+
+  describe('excluding empty commits', () => {
+    it('should separate commits', () => {
+      const commitSplit = new CommitSplit({
+        includeEmpty: false,
+      });
+      const splitCommits = commitSplit.split(commits);
+      expect(splitCommits['pkg1']).lengthOf(2);
+      expect(splitCommits['pkg2']).lengthOf(1);
+      expect(splitCommits['pkg3']).lengthOf(1);
+      expect(splitCommits['pkg4']).to.be.undefined;
+    });
+    it('should separate commits with limited list of paths', () => {
+      const commitSplit = new CommitSplit({
+        includeEmpty: false,
+        packagePaths: ['pkg1', 'pkg4'],
+      });
+      const splitCommits = commitSplit.split(commits);
+      expect(splitCommits['pkg1']).lengthOf(2);
+      expect(splitCommits['pkg2']).to.be.undefined;
+      expect(splitCommits['pkg3']).to.be.undefined;
+      expect(splitCommits['pkg4']).to.be.undefined;
+    });
+  });
+});


### PR DESCRIPTION
When using `CommitSplit` with `includeEmpty` and `packagePaths`, include empty commits in all `packagePaths`, not just the ones that already have commits to them.

Fixes #1360 
