### PR TITLE
fix: add release labels if release PR was completed

### DIFF
--- a/test/manifest.ts
+++ b/test/manifest.ts
@@ -5223,8 +5223,8 @@ describe('Manifest', () => {
         expect(err).instanceof(DuplicateReleaseError);
       }
       sinon.assert.notCalled(commentStub);
-      sinon.assert.notCalled(addLabelsStub);
-      sinon.assert.notCalled(removeLabelsStub);
+      sinon.assert.calledOnce(addLabelsStub);
+      sinon.assert.calledOnce(removeLabelsStub);
     });
   });
 });


### PR DESCRIPTION
release-please is currently not able to recover from quota issues on very large release manifest PRs.

After this PR, release-please will set the correct releases labels on the PR if it created all the releases or found duplicate tags for the non-created ones.

Towards https://github.com/googleapis/repo-automation-bots/issues/3428
