### PR TITLE
fix: Manifest.fromConfig should find branch component

### DIFF
--- a/src/manifest.ts
+++ b/src/manifest.ts
@@ -382,13 +382,13 @@ export class Manifest {
       github,
       ...config,
     });
-    const component = await strategy.getComponent();
+    const component = await strategy.getBranchComponent();
     const releasedVersions: ReleasedVersions = {};
     const latestVersion = await latestReleaseVersion(
       github,
       targetBranch,
       version => isPublishedVersion(strategy, version),
-      config.includeComponentInTag ? component : '',
+      component,
       config.pullRequestTitlePattern
     );
     if (latestVersion) {

--- a/src/strategies/base.ts
+++ b/src/strategies/base.ts
@@ -152,7 +152,7 @@ export abstract class BaseStrategy implements Strategy {
     );
   }
 
-  protected async getBranchComponent(): Promise<string | undefined> {
+  async getBranchComponent(): Promise<string | undefined> {
     return this.component || (await this.getDefaultComponent());
   }
 

--- a/src/strategy.ts
+++ b/src/strategy.ts
@@ -60,6 +60,13 @@ export interface Strategy {
   getComponent(): Promise<string | undefined>;
 
   /**
+   * Return the component for this strategy used in the branch name.
+   * This may be a computed field.
+   * @returns {string}
+   */
+  getBranchComponent(): Promise<string | undefined>;
+
+  /**
    * Validate whether version is a valid release.
    * @param version Released version.
    * @returns true of release is valid, false if it should be skipped.

--- a/test/manifest.ts
+++ b/test/manifest.ts
@@ -671,7 +671,8 @@ describe('Manifest', () => {
           message: 'some commit message',
           files: [],
           pullRequest: {
-            headBranchName: 'release-please/branches/main',
+            headBranchName:
+              'release-please--branches--main--components--foobar',
             baseBranchName: 'main',
             title: 'release: 1.2.3',
             number: 123,
@@ -708,7 +709,8 @@ describe('Manifest', () => {
           files: [],
           pullRequest: {
             title: 'chore: release 1.2.3',
-            headBranchName: 'release-please/branches/main',
+            headBranchName:
+              'release-please--branches--main--components--foobar',
             baseBranchName: 'main',
             number: 123,
             body: '',


### PR DESCRIPTION
Pull request branch name should check the branch component. This causes some release PRs to be missed.