### PR TITLE
fix: Fix parsing of tags with major versions higher than 9

### DIFF
--- a/src/util/tag-name.ts
+++ b/src/util/tag-name.ts
@@ -15,7 +15,7 @@
 import {Version} from '../version';
 
 const TAG_PATTERN =
-  /^((?<component>.*)(?<separator>[^a-zA-Z]))?(?<v>v)?(?<version>\d+\.\d+\.\d+.*)$/;
+  /^((?<component>.*)(?<separator>[^a-zA-Z0-9]))?(?<v>v)?(?<version>\d+\.\d+\.\d+.*)$/;
 const DEFAULT_SEPARATOR = '-';
 
 export class TagName {

--- a/test/util/tag-name.ts
+++ b/test/util/tag-name.ts
@@ -75,6 +75,42 @@ describe('TagName', () => {
         expect(tagName?.separator).to.eql('-');
         expect(tagName?.toString()).to.eql(name);
       });
+      it('handles a dual digit version without v', () => {
+        const name = '10.2.3';
+        const tagName = TagName.parse(name);
+        expect(tagName).to.not.be.undefined;
+        expect(tagName?.component).to.be.undefined;
+        expect(tagName?.version.toString()).to.eql('10.2.3');
+        expect(tagName?.separator).to.eql('-');
+        expect(tagName?.toString()).to.eql(name);
+      });
+      it('handles a dual digit version', () => {
+        const name = 'v10.2.3';
+        const tagName = TagName.parse(name);
+        expect(tagName).to.not.be.undefined;
+        expect(tagName?.component).to.be.undefined;
+        expect(tagName?.version.toString()).to.eql('10.2.3');
+        expect(tagName?.separator).to.eql('-');
+        expect(tagName?.toString()).to.eql(name);
+      });
+      it('handles a triple digit version without v', () => {
+        const name = '178.2.3';
+        const tagName = TagName.parse(name);
+        expect(tagName).to.not.be.undefined;
+        expect(tagName?.component).to.be.undefined;
+        expect(tagName?.version.toString()).to.eql('178.2.3');
+        expect(tagName?.separator).to.eql('-');
+        expect(tagName?.toString()).to.eql(name);
+      });
+      it('handles a triple digit version', () => {
+        const name = 'v178.2.3';
+        const tagName = TagName.parse(name);
+        expect(tagName).to.not.be.undefined;
+        expect(tagName?.component).to.be.undefined;
+        expect(tagName?.version.toString()).to.eql('178.2.3');
+        expect(tagName?.separator).to.eql('-');
+        expect(tagName?.toString()).to.eql(name);
+      });
     });
   });
 });


### PR DESCRIPTION
- [ ] Make sure to open an issue as a [bug/issue](https://github.com/googleapis/release-please/issues/new/choose) before writing your code!  That way we can discuss the change, evaluate designs, and agree on the general idea
- [x] Ensure the tests and linter pass
- [x] Code coverage does not decrease (if any source code was changed)
- [ ] Appropriate docs were updated (if necessary)

First of all: Sorry I did not create an issue first, but the change is luckily not that big. I'm happy to change.

The underlying issue appeared in our [logs ](https://github.com/netlify/cli/runs/6599918199?check_suite_focus=true) with:

```
⚠ Found release tag with component 'v', but not configured in manifest
```

The problem started with this PR: #1346. This PR changed the tag parsing and made the `v` optional. This works for versions like `v1.1.1`, but as soon as the major version is above 9 like `v10.1.1` it will detect `v` as the component, `1` as the separator and `0.1.1` as the version.

The fix is simply to ensure the separator is not a number, which I believe is a reasonable assumption. :)

I'm a little bit confused why it is working for this repository, as you also have already major version 13, but you might be using an older version of release-please yourself? 🤷 For us it started with one of the recent updates in the github action.

Let me know what you think.
