### PR TITLE
feat(yaml): add support for yaml updater

### DIFF
--- a/__snapshots__/generic-yaml.js
+++ b/__snapshots__/generic-yaml.js
@@ -1,0 +1,52 @@
+exports['GenericYaml updateContent updates deep entry in json 1'] = `
+name: release-please
+version: 11.1.0
+lockfileVersion: 2
+requires: true
+packages:
+  '':
+    name: release-please
+    version: 2.3.4
+
+`
+
+exports['GenericYaml updateContent updates deep entry in yaml 1'] = `
+name: helm-test-repo
+version: 1.0.0
+apiVersion: v2
+appVersion: 2.0.0
+dependencies:
+  - name: another-repo
+    version: 2.3.4
+    repository: linkToHelmChartRepo
+maintainers:
+  - Abhinav Khanna
+
+`
+
+exports['GenericYaml updateContent updates matching entry 1'] = `
+name: helm-test-repo
+version: 2.3.4
+apiVersion: v2
+appVersion: 2.0.0
+dependencies:
+  - name: another-repo
+    version: 0.15.3
+    repository: linkToHelmChartRepo
+maintainers:
+  - Abhinav Khanna
+
+`
+
+exports['GenericYaml updateContent updates multi-document yaml 1'] = `
+---
+name: first
+version: 2.3.4
+---
+name: second
+version: 2.3.4
+---
+name: third
+version: 2.3.4
+
+`

--- a/src/manifest.ts
+++ b/src/manifest.ts
@@ -47,6 +47,11 @@ type ExtraJsonFile = {
   path: string;
   jsonpath: string;
 };
+type ExtraYamlFile = {
+  type: 'yaml';
+  path: string;
+  jsonpath: string;
+};
 type ExtraXmlFile = {
   type: 'xml';
   path: string;
@@ -56,7 +61,12 @@ type ExtraPomFile = {
   type: 'pom';
   path: string;
 };
-export type ExtraFile = string | ExtraJsonFile | ExtraXmlFile | ExtraPomFile;
+export type ExtraFile =
+  | string
+  | ExtraJsonFile
+  | ExtraYamlFile
+  | ExtraXmlFile
+  | ExtraPomFile;
 /**
  * These are configurations provided to each strategy per-path.
  */

--- a/src/strategies/base.ts
+++ b/src/strategies/base.ts
@@ -40,6 +40,7 @@ import {Generic} from '../updaters/generic';
 import {GenericJson} from '../updaters/generic-json';
 import {GenericXml} from '../updaters/generic-xml';
 import {PomXml} from '../updaters/java/pom-xml';
+import {GenericYaml} from '../updaters/generic-yaml';
 
 const DEFAULT_CHANGELOG_PATH = 'CHANGELOG.md';
 
@@ -328,6 +329,12 @@ export abstract class BaseStrategy implements Strategy {
               path: this.addPath(extraFile.path),
               createIfMissing: false,
               updater: new GenericJson(extraFile.jsonpath, version),
+            };
+          case 'yaml':
+            return {
+              path: this.addPath(extraFile.path),
+              createIfMissing: false,
+              updater: new GenericYaml(extraFile.jsonpath, version),
             };
           case 'xml':
             return {

--- a/src/updaters/generic-yaml.ts
+++ b/src/updaters/generic-yaml.ts
@@ -1,0 +1,81 @@
+// Copyright 2022 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import {Updater} from '../update';
+import {Version} from '../version';
+import * as jp from 'jsonpath';
+import * as yaml from 'js-yaml';
+import {logger} from '../util/logger';
+
+const DOCUMENT_SEPARATOR = '---\n';
+
+/**
+ * Updates YAML document according to given JSONPath.
+ *
+ * Note that used parser does reformat the document and removes all comments,
+ * and converts everything to pure YAML (even JSON source).
+ * If you want to retain formatting, use generic updater with comment hints.
+ *
+ * When applied on multi-document file, it updates all documents.
+ */
+export class GenericYaml implements Updater {
+  readonly jsonpath: string;
+  readonly version: Version;
+
+  constructor(jsonpath: string, version: Version) {
+    this.jsonpath = jsonpath;
+    this.version = version;
+  }
+  /**
+   * Given initial file contents, return updated contents.
+   * @param {string} content The initial content
+   * @returns {string} The updated content
+   */
+  updateContent(content: string): string {
+    // Parse possibly multi-document file
+    let docs: unknown[];
+    try {
+      docs = yaml.loadAll(content, null, {json: true});
+    } catch (e) {
+      logger.warn('Invalid yaml, cannot be parsed', e);
+      return content;
+    }
+
+    // Update each document
+    let modified = false;
+    docs.forEach(data => {
+      const nodes = jp.apply(data, this.jsonpath, _val => {
+        return this.version.toString();
+      });
+      if (nodes && nodes.length) {
+        modified = true;
+      }
+    });
+
+    // If nothing was modified, return original content
+    if (!modified) {
+      logger.warn(`No entries modified in ${this.jsonpath}`);
+      return content;
+    }
+
+    // Stringify documents
+    if (docs.length === 1) {
+      // Single doc
+      return yaml.dump(docs[0]);
+    } else {
+      // Multi-document, each document starts with separator
+      return docs.map(data => DOCUMENT_SEPARATOR + yaml.dump(data)).join('');
+    }
+  }
+}

--- a/test/strategies/base.ts
+++ b/test/strategies/base.ts
@@ -25,6 +25,7 @@ import {GenericJson} from '../../src/updaters/generic-json';
 import {Generic} from '../../src/updaters/generic';
 import {GenericXml} from '../../src/updaters/generic-xml';
 import {PomXml} from '../../src/updaters/java/pom-xml';
+import {GenericYaml} from '../../src/updaters/generic-yaml';
 
 const sandbox = sinon.createSandbox();
 
@@ -112,6 +113,23 @@ describe('Strategy', () => {
       expect(updates).to.be.an('array');
       assertHasUpdate(updates!, '0', Generic);
       assertHasUpdate(updates!, '3.json', GenericJson);
+    });
+    it('updates extra YAML files', async () => {
+      const strategy = new TestStrategy({
+        targetBranch: 'main',
+        github,
+        component: 'google-cloud-automl',
+        extraFiles: ['0', {type: 'yaml', path: '/3.yaml', jsonpath: '$.foo'}],
+      });
+      const pullRequest = await strategy.buildReleasePullRequest(
+        [{sha: 'aaa', message: 'fix: a bugfix'}],
+        undefined
+      );
+      expect(pullRequest).to.exist;
+      const updates = pullRequest?.updates;
+      expect(updates).to.be.an('array');
+      assertHasUpdate(updates!, '0', Generic);
+      assertHasUpdate(updates!, '3.yaml', GenericYaml);
     });
     it('updates extra Xml files', async () => {
       const strategy = new TestStrategy({

--- a/test/updaters/fixtures/yaml/invalid.txt
+++ b/test/updaters/fixtures/yaml/invalid.txt
@@ -1,0 +1,1 @@
+boo: invalid:yaml:

--- a/test/updaters/fixtures/yaml/multi.yaml
+++ b/test/updaters/fixtures/yaml/multi.yaml
@@ -1,0 +1,9 @@
+---
+name: first
+version: 0.0.1
+---
+name: second
+version: 0.2.0
+---
+name: third
+version: 3.0.0

--- a/test/updaters/generic-yaml.ts
+++ b/test/updaters/generic-yaml.ts
@@ -1,0 +1,98 @@
+// Copyright 2022 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import {readFileSync} from 'fs';
+import {resolve} from 'path';
+import * as snapshot from 'snap-shot-it';
+import {describe, it} from 'mocha';
+import {Version} from '../../src/version';
+import {expect, assert} from 'chai';
+import {GenericYaml} from '../../src/updaters/generic-yaml';
+
+const fixturesPath = './test/updaters/fixtures';
+
+describe('GenericYaml', () => {
+  describe('updateContent', () => {
+    it('updates matching entry', async () => {
+      const oldContent = readFileSync(
+        resolve(fixturesPath, './helm/Chart.yaml'),
+        'utf8'
+      ).replace(/\r\n/g, '\n');
+      const updater = new GenericYaml('$.version', Version.parse('v2.3.4'));
+      const newContent = updater.updateContent(oldContent);
+      snapshot(newContent);
+    });
+    it('updates deep entry in json', async () => {
+      const oldContent = readFileSync(
+        resolve(fixturesPath, './package-lock-v2.json'),
+        'utf8'
+      ).replace(/\r\n/g, '\n');
+      const updater = new GenericYaml(
+        '$.packages..version',
+        Version.parse('v2.3.4')
+      );
+      const newContent = updater.updateContent(oldContent);
+      snapshot(newContent);
+    });
+    it('updates deep entry in yaml', async () => {
+      const oldContent = readFileSync(
+        resolve(fixturesPath, './helm/Chart.yaml'),
+        'utf8'
+      ).replace(/\r\n/g, '\n');
+      const updater = new GenericYaml(
+        '$.dependencies..version',
+        Version.parse('v2.3.4')
+      );
+      const newContent = updater.updateContent(oldContent);
+      snapshot(newContent);
+    });
+    it('ignores non-matching entry', async () => {
+      const oldContent = readFileSync(
+        resolve(fixturesPath, './helm/Chart.yaml'),
+        'utf8'
+      ).replace(/\r\n/g, '\n');
+      const updater = new GenericYaml('$.nonExistent', Version.parse('v2.3.4'));
+      const newContent = updater.updateContent(oldContent);
+      expect(newContent).to.eql(oldContent);
+    });
+    it('warns on invalid jsonpath', async () => {
+      const oldContent = readFileSync(
+        resolve(fixturesPath, './helm/Chart.yaml'),
+        'utf8'
+      ).replace(/\r\n/g, '\n');
+      const updater = new GenericYaml('bad jsonpath', Version.parse('v2.3.4'));
+      assert.throws(() => {
+        updater.updateContent(oldContent);
+      });
+    });
+    it('ignores invalid file', async () => {
+      const oldContent = readFileSync(
+        resolve(fixturesPath, './yaml/invalid.txt'),
+        'utf8'
+      ).replace(/\r\n/g, '\n');
+      const updater = new GenericYaml('$.boo', Version.parse('v2.3.4'));
+      const newContent = updater.updateContent(oldContent);
+      expect(newContent).to.eql(oldContent);
+    });
+    it('updates multi-document yaml', async () => {
+      const oldContent = readFileSync(
+        resolve(fixturesPath, './yaml/multi.yaml'),
+        'utf8'
+      ).replace(/\r\n/g, '\n');
+      const updater = new GenericYaml('$.version', Version.parse('v2.3.4'));
+      const newContent = updater.updateContent(oldContent);
+      snapshot(newContent);
+    });
+  });
+});


### PR DESCRIPTION
This complements `GenericJson` updater.

Note that used parser does reformat the document and removes all comments,
and converts everything to pure YAML (even JSON source). It is same behavior is `ChartYaml` updater has.
If you want to retain formatting, use generic updater with comment hints.

When applied on multi-document file, it updates all documents.