### PR TITLE
docs: Correct broken link

### DIFF
--- a/docs/customizing.md
+++ b/docs/customizing.md
@@ -54,7 +54,7 @@ Release Please will only consider commits that touch files on that path. The for
 relative to the repository root.
 
 To configure multiple components on different paths, configure a
-[manifest release](/docs/manifest-releaser).
+[manifest release](/docs/manifest-releaser.md).
 
 ## Changelog Types
 


### PR DESCRIPTION
I noticed one of the links in the documentation was broken, so I fixed it:

- [ ] Make sure to open an issue as a [bug/issue](https://github.com/googleapis/release-please/issues/new/choose) before writing your code!  That way we can discuss the change, evaluate designs, and agree on the general idea
- [ ] Ensure the tests and linter pass
- [X] Code coverage does not decrease (if any source code was changed)
- [X] Appropriate docs were updated (if necessary)
