### PR TITLE
fix: factory errors for unknown types throw ConfigurationError instead of Error

### DIFF
--- a/src/factories/changelog-notes-factory.ts
+++ b/src/factories/changelog-notes-factory.ts
@@ -16,6 +16,7 @@ import {GitHub} from '../github';
 import {ChangelogNotes, ChangelogSection} from '../changelog-notes';
 import {GitHubChangelogNotes} from '../changelog-notes/github';
 import {DefaultChangelogNotes} from '../changelog-notes/default';
+import {ConfigurationError} from '../errors';
 
 export type ChangelogNotesType = string;
 
@@ -44,7 +45,11 @@ export function buildChangelogNotes(
   if (builder) {
     return builder(options);
   }
-  throw new Error(`Unknown changelog type: ${options.type}`);
+  throw new ConfigurationError(
+    `Unknown changelog type: ${options.type}`,
+    'core',
+    `${options.github.repository.owner}/${options.github.repository.repo}`
+  );
 }
 
 export function registerChangelogNotes(

--- a/src/factories/plugin-factory.ts
+++ b/src/factories/plugin-factory.ts
@@ -24,6 +24,7 @@ import {CargoWorkspace} from '../plugins/cargo-workspace';
 import {NodeWorkspace} from '../plugins/node-workspace';
 import {VersioningStrategyType} from './versioning-strategy-factory';
 import {MavenWorkspace} from '../plugins/maven-workspace';
+import {ConfigurationError} from '../errors';
 
 export interface PluginFactoryOptions {
   type: PluginType;
@@ -79,13 +80,21 @@ export function buildPlugin(options: PluginFactoryOptions): ManifestPlugin {
     if (builder) {
       return builder(options);
     }
-    throw new Error(`Unknown plugin type: ${options.type.type}`);
+    throw new ConfigurationError(
+      `Unknown plugin type: ${options.type.type}`,
+      'core',
+      `${options.github.repository.owner}/${options.github.repository.repo}`
+    );
   } else {
     const builder = pluginFactories[options.type];
     if (builder) {
       return builder(options);
     }
-    throw new Error(`Unknown plugin type: ${options.type}`);
+    throw new ConfigurationError(
+      `Unknown plugin type: ${options.type}`,
+      'core',
+      `${options.github.repository.owner}/${options.github.repository.repo}`
+    );
   }
 }
 

--- a/src/factories/versioning-strategy-factory.ts
+++ b/src/factories/versioning-strategy-factory.ts
@@ -16,6 +16,8 @@ import {VersioningStrategy} from '../versioning-strategy';
 import {DefaultVersioningStrategy} from '../versioning-strategies/default';
 import {AlwaysBumpPatch} from '../versioning-strategies/always-bump-patch';
 import {ServicePackVersioningStrategy} from '../versioning-strategies/service-pack';
+import {GitHub} from '../github';
+import {ConfigurationError} from '../errors';
 
 export type VersioningStrategyType = string;
 
@@ -23,6 +25,7 @@ export interface VersioningStrategyFactoryOptions {
   type?: VersioningStrategyType;
   bumpMinorPreMajor?: boolean;
   bumpPatchForMinorPreMajor?: boolean;
+  github: GitHub;
 }
 
 export type VersioningStrategyBuilder = (
@@ -42,7 +45,11 @@ export function buildVersioningStrategy(
   if (builder) {
     return builder(options);
   }
-  throw new Error(`Unknown versioning strategy type: ${options.type}`);
+  throw new ConfigurationError(
+    `Unknown versioning strategy type: ${options.type}`,
+    'core',
+    `${options.github.repository.owner}/${options.github.repository.repo}`
+  );
 }
 
 export function registerVersioningStrategy(

--- a/src/factory.ts
+++ b/src/factory.ts
@@ -41,6 +41,7 @@ import {Java} from './strategies/java';
 import {Maven} from './strategies/maven';
 import {buildVersioningStrategy} from './factories/versioning-strategy-factory';
 import {buildChangelogNotes} from './factories/changelog-notes-factory';
+import {ConfigurationError} from './errors';
 
 export * from './factories/changelog-notes-factory';
 export * from './factories/plugin-factory';
@@ -107,6 +108,7 @@ export async function buildStrategy(
   const targetBranch =
     options.targetBranch ?? options.github.repository.defaultBranch;
   const versioningStrategy = buildVersioningStrategy({
+    github: options.github,
     type: options.versioning,
     bumpMinorPreMajor: options.bumpMinorPreMajor,
     bumpPatchForMinorPreMajor: options.bumpPatchForMinorPreMajor,
@@ -128,7 +130,11 @@ export async function buildStrategy(
   if (builder) {
     return builder(strategyOptions);
   }
-  throw new Error(`Unknown release type: ${options.releaseType}`);
+  throw new ConfigurationError(
+    `Unknown release type: ${options.releaseType}`,
+    'core',
+    `${options.github.repository.owner}/${options.github.repository.repo}`
+  );
 }
 
 export function registerReleaseType(

--- a/test/factories/versioning-strategy-factory.ts
+++ b/test/factories/versioning-strategy-factory.ts
@@ -17,6 +17,7 @@ import {
   getVersioningStrategyTypes,
   registerVersioningStrategy,
   VersioningStrategyType,
+  GitHub,
 } from '../../src';
 import {DefaultVersioningStrategy} from '../../src/versioning-strategies/default';
 import {
@@ -30,11 +31,20 @@ describe('VersioningStrategyFactory', () => {
     'always-bump-patch',
     'service-pack',
   ];
+  let github: GitHub;
+  beforeEach(async () => {
+    github = await GitHub.create({
+      owner: 'test-owner',
+      repo: 'test-repo',
+      defaultBranch: 'main',
+    });
+  });
 
   describe('buildVersioningStrategy', () => {
     for (const type of defaultTypes) {
       it(`should build a simple ${type}`, () => {
         const versioningStrategy = buildVersioningStrategy({
+          github,
           type: type,
         });
         expect(versioningStrategy).to.not.be.undefined;
@@ -43,6 +53,7 @@ describe('VersioningStrategyFactory', () => {
     it('should throw for unknown type', () => {
       expect(() =>
         buildVersioningStrategy({
+          github,
           type: 'non-existent',
         })
       ).to.throw();
@@ -70,6 +81,7 @@ describe('VersioningStrategyFactory', () => {
       );
 
       const versioningStrategyOptions = {
+        github,
         type: versioningStrategyType,
       };
       const strategy = await buildVersioningStrategy(versioningStrategyOptions);


### PR DESCRIPTION
If a repository has configured an invalid type, we now throw a ConfigurationError instead of a generic Error to allow integrations to handle this condition more easily.

Towards https://github.com/googleapis/repo-automation-bots/issues/3870
