### PR TITLE
fix: handle malformed manifest JSON and throw ConfigurationError

### DIFF
--- a/src/manifest.ts
+++ b/src/manifest.ts
@@ -1247,6 +1247,12 @@ async function fetchManifestConfig(
         'base',
         `${github.repository.owner}/${github.repository.repo}`
       );
+    } else if (e instanceof SyntaxError) {
+      throw new ConfigurationError(
+        `Failed to parse manifest config JSON: ${configFile}\n${e.message}`,
+        'base',
+        `${github.repository.owner}/${github.repository.repo}`
+      );
     }
     throw e;
   }
@@ -1299,6 +1305,12 @@ async function fetchReleasedVersions(
     if (e instanceof FileNotFoundError) {
       throw new ConfigurationError(
         `Missing required manifest versions: ${manifestFile}`,
+        'base',
+        `${github.repository.owner}/${github.repository.repo}`
+      );
+    } else if (e instanceof SyntaxError) {
+      throw new ConfigurationError(
+        `Failed to parse manifest versions JSON: ${manifestFile}\n${e.message}`,
         'base',
         `${github.repository.owner}/${github.repository.repo}`
       );

--- a/test/manifest.ts
+++ b/test/manifest.ts
@@ -628,6 +628,55 @@ describe('Manifest', () => {
         await Manifest.fromManifest(github, github.repository.defaultBranch);
       }, ConfigurationError);
     });
+
+    it('should throw a configuration error for a malformed manifest config', async () => {
+      const getFileContentsStub = sandbox.stub(
+        github,
+        'getFileContentsOnBranch'
+      );
+      getFileContentsStub
+        .withArgs('release-please-config.json', 'main')
+        .resolves(buildGitHubFileRaw('{"malformed json"'))
+        .withArgs('.release-please-manifest.json', 'main')
+        .resolves(
+          buildGitHubFileContent(
+            fixturesPath,
+            'manifest/versions/versions.json'
+          )
+        );
+      await assert.rejects(
+        async () => {
+          await Manifest.fromManifest(github, github.repository.defaultBranch);
+        },
+        e => {
+          console.log(e);
+          return e instanceof ConfigurationError && e.message.includes('parse');
+        }
+      );
+    });
+
+    it('should throw a configuration error for a malformed manifest config', async () => {
+      const getFileContentsStub = sandbox.stub(
+        github,
+        'getFileContentsOnBranch'
+      );
+      getFileContentsStub
+        .withArgs('release-please-config.json', 'main')
+        .resolves(
+          buildGitHubFileContent(fixturesPath, 'manifest/config/config.json')
+        )
+        .withArgs('.release-please-manifest.json', 'main')
+        .resolves(buildGitHubFileRaw('{"malformed json"'));
+      await assert.rejects(
+        async () => {
+          await Manifest.fromManifest(github, github.repository.defaultBranch);
+        },
+        e => {
+          console.log(e);
+          return e instanceof ConfigurationError && e.message.includes('parse');
+        }
+      );
+    });
   });
 
   describe('fromConfig', () => {


### PR DESCRIPTION
This allows integrations to catch this case and log an error on the repository.

Towards https://github.com/googleapis/repo-automation-bots/issues/3867
