### PR TITLE
fix(go): hide unwanted changelog sections

### DIFF
--- a/src/strategies/go-yoshi.ts
+++ b/src/strategies/go-yoshi.ts
@@ -23,14 +23,32 @@ import {VersionGo} from '../updaters/go/version-go';
 import {logger} from '../util/logger';
 import {dirname} from 'path';
 
+const CHANGELOG_SECTIONS = [
+  {type: 'feat', section: 'Features'},
+  {type: 'fix', section: 'Bug Fixes'},
+  {type: 'perf', section: 'Performance Improvements'},
+  {type: 'revert', section: 'Reverts'},
+  {type: 'docs', section: 'Documentation'},
+  {type: 'style', section: 'Styles', hidden: true},
+  {type: 'chore', section: 'Miscellaneous Chores', hidden: true},
+  {type: 'refactor', section: 'Code Refactoring', hidden: true},
+  {type: 'test', section: 'Tests', hidden: true},
+  {type: 'build', section: 'Build System', hidden: true},
+  {type: 'ci', section: 'Continuous Integration', hidden: true},
+];
+
 const REGEN_PR_REGEX = /.*auto-regenerate.*/;
 const REGEN_ISSUE_REGEX = /(?<prefix>.*)\(#(?<pr>.*)\)(\n|$)/;
 
 export class GoYoshi extends BaseStrategy {
   constructor(options: BaseStrategyOptions) {
     options.changelogPath = options.changelogPath ?? 'CHANGES.md';
-    super(options);
+    super({
+      ...options,
+      changelogSections: CHANGELOG_SECTIONS,
+    });
   }
+
   protected async buildUpdates(
     options: BuildUpdatesOptions
   ): Promise<Update[]> {


### PR DESCRIPTION
google-cloud-go releases may contain a "Miscellaneous Chores" section in the changelog, which is not desired ([example](https://github.com/googleapis/google-cloud-go/releases/tag/talent%2Fv0.8.0)).