### PR TITLE
deps: temporarily pin `@octokit/types` to 6.37.0

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -16,13 +16,13 @@ jobs:
         with:
           node-version: ${{ matrix.node }}
       - run: node --version
+      - run: npm --version
       # The first installation step ensures that all of our production
       # dependencies work on the given Node.js version, this helps us find
       # dependencies that don't match our engines field:
       - run: npm install --production --engine-strict --ignore-scripts --no-package-lock
       # Clean up the production install, before installing dev/production:
       - run: rm -rf node_modules
-      - run: cat package-lock.json
       - run: npm install
       - run: npm test
         env:

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -22,6 +22,7 @@ jobs:
       - run: npm install --production --engine-strict --ignore-scripts --no-package-lock
       # Clean up the production install, before installing dev/production:
       - run: rm -rf node_modules
+      - run: cat package-lock.json
       - run: npm install
       - run: npm test
         env:

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -16,6 +16,7 @@ jobs:
         with:
           node-version: ${{ matrix.node }}
       - run: node --version
+      - run: npm i -g npm@latest
       - run: npm --version
       # The first installation step ensures that all of our production
       # dependencies work on the given Node.js version, this helps us find
@@ -34,6 +35,7 @@ jobs:
       - uses: actions/setup-node@v3
         with:
           node-version: 14
+      - run: npm i -g npm@latest
       - run: npm install
       - run: npm test
         env:
@@ -45,6 +47,7 @@ jobs:
       - uses: actions/setup-node@v3
         with:
           node-version: 14
+      - run: npm i -g npm@latest
       - run: npm install
       - run: npm run lint
   docs:
@@ -54,6 +57,7 @@ jobs:
       - uses: actions/setup-node@v3
         with:
           node-version: 14
+      - run: npm i -g npm@latest
       - run: npm install
       - run: npm run docs
       - uses: JustinBeckwith/linkinator-action@v1

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -17,7 +17,6 @@ jobs:
           node-version: ${{ matrix.node }}
       - run: node --version
       - run: npm i -g npm@latest
-      - run: npm --version
       # The first installation step ensures that all of our production
       # dependencies work on the given Node.js version, this helps us find
       # dependencies that don't match our engines field:

--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     }
   },
   "devDependencies": {
-    "@octokit/types": "^6.1.0",
+    "@octokit/types": "6.37.0",
     "@types/chai": "^4.1.7",
     "@types/diff": "^5.0.2",
     "@types/iarna__toml": "^2.0.1",

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "lint": "gts check",
     "compile": "tsc -p .",
     "fix": "gts fix",
+    "precompile": "npm ls @octokit/types",
     "pretest": "npm run compile"
   },
   "files": [

--- a/package.json
+++ b/package.json
@@ -13,7 +13,6 @@
     "lint": "gts check",
     "compile": "tsc -p .",
     "fix": "gts fix",
-    "precompile": "npm ls @octokit/types",
     "pretest": "npm run compile"
   },
   "files": [


### PR DESCRIPTION
There appears to be a regression in [6.37.1](https://github.com/octokit/types.ts/releases/tag/v6.37.1).

This is to unblock PRs. `@octokit/types` is a dev dependency.