### PR TITLE
fix: correctly parse the changelog-type from the manifest config

### DIFF
--- a/src/manifest.ts
+++ b/src/manifest.ts
@@ -1471,6 +1471,7 @@ function mergeReleaserConfig(
       pathConfig.changelogSections ?? defaultConfig.changelogSections,
     changelogPath: pathConfig.changelogPath ?? defaultConfig.changelogPath,
     changelogHost: pathConfig.changelogHost ?? defaultConfig.changelogHost,
+    changelogType: pathConfig.changelogType ?? defaultConfig.changelogType,
     releaseAs: pathConfig.releaseAs ?? defaultConfig.releaseAs,
     skipGithubRelease:
       pathConfig.skipGithubRelease ?? defaultConfig.skipGithubRelease,

--- a/test/fixtures/manifest/config/changelog-type.json
+++ b/test/fixtures/manifest/config/changelog-type.json
@@ -1,0 +1,13 @@
+{
+  "release-type": "simple",
+  "changelog-type": "github",
+  "packages": {
+    ".": {
+      "component": "root"
+    },
+    "packages/bot-config-utils": {
+      "component": "bot-config-utils",
+      "changelog-type": "default"
+    }
+  }
+}

--- a/test/manifest.ts
+++ b/test/manifest.ts
@@ -592,6 +592,36 @@ describe('Manifest', () => {
       ).to.eql('https://override.example.com');
     });
 
+    it('should read changelog type from manifest', async () => {
+      const getFileContentsStub = sandbox.stub(
+        github,
+        'getFileContentsOnBranch'
+      );
+      getFileContentsStub
+        .withArgs('release-please-config.json', 'main')
+        .resolves(
+          buildGitHubFileContent(
+            fixturesPath,
+            'manifest/config/changelog-type.json'
+          )
+        )
+        .withArgs('.release-please-manifest.json', 'main')
+        .resolves(
+          buildGitHubFileContent(
+            fixturesPath,
+            'manifest/versions/versions.json'
+          )
+        );
+      const manifest = await Manifest.fromManifest(
+        github,
+        github.repository.defaultBranch
+      );
+      expect(manifest.repositoryConfig['.'].changelogType).to.eql('github');
+      expect(
+        manifest.repositoryConfig['packages/bot-config-utils'].changelogType
+      ).to.eql('default');
+    });
+
     it('should throw a configuration error for a missing manifest config', async () => {
       const getFileContentsStub = sandbox.stub(
         github,


### PR DESCRIPTION
Fixes #1482
