### PR TITLE
fix: fix file tree listing for extremely large repositories

### DIFF
--- a/src/util/file-cache.ts
+++ b/src/util/file-cache.ts
@@ -214,13 +214,15 @@ export class BranchFileCache {
    */
   private async fetchTree(sha: string): Promise<TreeEntry[]> {
     const {
-      data: {tree},
+      data: {tree, truncated},
     } = await this.octokit.git.getTree({
       owner: this.repository.owner,
       repo: this.repository.repo,
       tree_sha: sha,
-      recursive: 'false',
     });
+    if (truncated) {
+      logger.warn(`file list for tree sha ${sha} is truncated`);
+    }
     return tree;
   }
 


### PR DESCRIPTION
Apparently, setting `recursive` to `true` or `false` make the get tree API attempt to return all files recursively.

https://docs.github.com/en/rest/git/trees#get-a-tree
