### PR TITLE
docs(readme): remove synthtool warning

### DIFF
--- a/README.md
+++ b/README.md
@@ -206,12 +206,6 @@ This library follows [Semantic Versioning](http://semver.org/).
 
 Contributions welcome! See the [Contributing Guide](https://github.com/googleapis/release-please/blob/main/CONTRIBUTING.md).
 
-Please note that this `README.md`, the `samples/README.md`,
-and a variety of configuration files in this repository (including `.nycrc` and `tsconfig.json`)
-are generated from a central template. To edit one of these files, make an edit
-to its template in this
-[directory](https://github.com/googleapis/synthtool/tree/main/synthtool/gcp/templates/node_library).
-
 ## License
 
 Apache Version 2.0


### PR DESCRIPTION
Refs #1507 🦕

- - - - 

The Contributing README section about synthtool templating/manatement is not true.
- Readme is not managed
- There are no samples (broken link)
- .nycrc is not managed
- tsconfig is probably not explicitly excluded, but observing history shows it's being worked on here locally…
- The template link is broken (and unnecessary)