### PR TITLE
chore: remove generated-files-bot warnings for README.md

### DIFF
--- a/.github/generated-files-bot.yml
+++ b/.github/generated-files-bot.yml
@@ -3,10 +3,6 @@ generatedFiles:
   message: '`.kokoro` files are templated and should be updated in [`synthtool`](https://github.com/googleapis/synthtool)'
 - path: '.github/CODEOWNERS'
   message: 'CODEOWNERS should instead be modified via the `codeowner_team` property in .repo-metadata.json'
-- path: '.github/workflows/ci.yaml'
-  message: '`.github/workflows/ci.yaml` (GitHub Actions) should be updated in [`synthtool`](https://github.com/googleapis/synthtool)'
-- path: '.github/generated-files-bot.+(yml|yaml)'
-  message: '`.github/generated-files-bot.(yml|yaml)` should be updated in [`synthtool`](https://github.com/googleapis/synthtool)'
 ignoreAuthors:
 - 'gcf-owl-bot[bot]'
 - 'yoshi-automation'

--- a/.github/generated-files-bot.yml
+++ b/.github/generated-files-bot.yml
@@ -7,10 +7,6 @@ generatedFiles:
   message: '`.github/workflows/ci.yaml` (GitHub Actions) should be updated in [`synthtool`](https://github.com/googleapis/synthtool)'
 - path: '.github/generated-files-bot.+(yml|yaml)'
   message: '`.github/generated-files-bot.(yml|yaml)` should be updated in [`synthtool`](https://github.com/googleapis/synthtool)'
-- path: 'README.md'
-  message: '`README.md` is managed by [`synthtool`](https://github.com/googleapis/synthtool). However, a partials file can be used to update the README, e.g.: https://github.com/googleapis/nodejs-storage/blob/main/.readme-partials.yaml'
-- path: 'samples/README.md'
-  message: '`samples/README.md` is managed by [`synthtool`](https://github.com/googleapis/synthtool). However, a partials file can be used to update the README, e.g.: https://github.com/googleapis/nodejs-storage/blob/main/.readme-partials.yaml'
 ignoreAuthors:
 - 'gcf-owl-bot[bot]'
 - 'yoshi-automation'

--- a/owlbot.py
+++ b/owlbot.py
@@ -28,6 +28,7 @@ node.owlbot_main(templates_excludes=[
   '.kokoro/continuous/node10/system-test.cfg',
   '.kokoro/system-test.sh',
   '.mocharc.js',
+  '.github/generated-files-bot.yml',
   '.github/release-please.yml',
   '.github/sync-repo-settings.yaml',
   '.github/workflows/ci.yaml',


### PR DESCRIPTION
Stops extra warnings for files that aren't actually managed by owlbot

Fixes #1507 