### PR TITLE
fix: convert ReleaserConfig JSON keys when bootstrapping

### DIFF
--- a/__snapshots__/bootstrapper.js
+++ b/__snapshots__/bootstrapper.js
@@ -1,0 +1,9 @@
+exports['Bootstrapper should open a PR 1'] = `
+{
+  "packages": {
+    ".": {
+      "release-type": "node"
+    }
+  }
+}
+`

--- a/src/manifest.ts
+++ b/src/manifest.ts
@@ -91,6 +91,8 @@ export interface ReleaserConfig {
   pullRequestTitlePattern?: string;
   tagSeparator?: string;
   separatePullRequests?: boolean;
+  labels?: string[];
+  releaseLabels?: string[];
 
   // Changelog options
   changelogSections?: ChangelogSection[];
@@ -137,7 +139,7 @@ interface ReleaserConfigJson {
   'pull-request-title-pattern'?: string;
   'separate-pull-requests'?: boolean;
   'tag-separator'?: string;
-  'extra-files'?: string[];
+  'extra-files'?: ExtraFile[];
   'version-file'?: string;
   'snapshot-label'?: string; // Java-only
 }
@@ -164,7 +166,7 @@ export interface ManifestOptions {
   commitSearchDepth?: number;
 }
 
-interface ReleaserPackageConfig extends ReleaserConfigJson {
+export interface ReleaserPackageConfig extends ReleaserConfigJson {
   'package-name'?: string;
   component?: string;
   'changelog-path'?: string;
@@ -1169,6 +1171,8 @@ function extractReleaserConfig(
     pullRequestTitlePattern: config['pull-request-title-pattern'],
     tagSeparator: config['tag-separator'],
     separatePullRequests: config['separate-pull-requests'],
+    labels: config['label']?.split(','),
+    releaseLabels: config['release-label']?.split(','),
   };
 }
 
@@ -1212,11 +1216,9 @@ async function parseConfig(
     separatePullRequests: config['separate-pull-requests'],
     groupPullRequestTitlePattern: config['group-pull-request-title-pattern'],
     plugins: config['plugins'],
-    labels: configLabel === undefined ? undefined : [configLabel],
-    releaseLabels:
-      configReleaseLabel === undefined ? undefined : [configReleaseLabel],
-    snapshotLabels:
-      configSnapshotLabel === undefined ? undefined : [configSnapshotLabel],
+    labels: configLabel?.split(','),
+    releaseLabels: configReleaseLabel?.split(','),
+    snapshotLabels: configSnapshotLabel?.split(','),
     releaseSearchDepth: config['release-search-depth'],
     commitSearchDepth: config['commit-search-depth'],
     sequentialCalls: config['sequential-calls'],

--- a/src/updaters/release-please-config.ts
+++ b/src/updaters/release-please-config.ts
@@ -14,7 +14,11 @@
 
 import {jsonStringify} from '../util/json-stringify';
 import {Updater} from '../update';
-import {ReleaserConfig, ManifestConfig} from '../manifest';
+import {
+  ReleaserConfig,
+  ManifestConfig,
+  ReleaserPackageConfig,
+} from '../manifest';
 
 export class ReleasePleaseConfig implements Updater {
   path: string;
@@ -30,11 +34,43 @@ export class ReleasePleaseConfig implements Updater {
     } else {
       parsed = {packages: {}};
     }
-    parsed.packages[this.path] = this.config;
+    parsed.packages[this.path] = releaserConfigToJsonConfig(this.config);
     if (content) {
       return jsonStringify(parsed, content);
     } else {
       return JSON.stringify(parsed, null, 2);
     }
   }
+}
+
+function releaserConfigToJsonConfig(
+  config: ReleaserConfig
+): ReleaserPackageConfig {
+  const jsonConfig: ReleaserPackageConfig = {
+    'package-name': config.packageName,
+    component: config.component,
+    'changelog-path': config.changelogPath,
+    'release-type': config.releaseType,
+    'bump-minor-pre-major': config.bumpMinorPreMajor,
+    'bump-patch-for-minor-pre-major': config.bumpPatchForMinorPreMajor,
+    'changelog-sections': config.changelogSections,
+    'release-as': config.releaseAs,
+    'skip-github-release': config.skipGithubRelease,
+    draft: config.draft,
+    prerelease: config.prerelease,
+    'draft-pull-request': config.draftPullRequest,
+    label: config.labels?.join(','),
+    'release-label': config.releaseLabels?.join(','),
+    'include-component-in-tag': config.includeComponentInTag,
+    'include-v-in-tag': config.includeVInTag,
+    'changelog-type': config.changelogType,
+    'changelog-host': config.changelogHost,
+    'pull-request-title-pattern': config.pullRequestTitlePattern,
+    'separate-pull-requests': config.separatePullRequests,
+    'tag-separator': config.tagSeparator,
+    'extra-files': config.extraFiles,
+    'version-file': config.versionFile,
+    'snapshot-label': config.snapshotLabels?.join(','), // Java-only
+  };
+  return jsonConfig;
 }

--- a/test/bootstrapper.ts
+++ b/test/bootstrapper.ts
@@ -20,6 +20,7 @@ import {GitHub} from '../src/github';
 import {assertHasUpdate} from './helpers';
 import {ReleasePleaseManifest} from '../src/updaters/release-please-manifest';
 import {ReleasePleaseConfig} from '../src/updaters/release-please-config';
+import * as snapshot from 'snap-shot-it';
 
 const sandbox = sinon.createSandbox();
 
@@ -73,6 +74,13 @@ describe('Bootstrapper', () => {
       '.release-please-manifest.json',
       ReleasePleaseManifest
     );
-    assertHasUpdate(updates, 'release-please-config.json', ReleasePleaseConfig);
+    const update = assertHasUpdate(
+      updates,
+      'release-please-config.json',
+      ReleasePleaseConfig
+    );
+    expect(update.createIfMissing).to.be.true;
+    const newContent = update.updater.updateContent(undefined);
+    snapshot(newContent);
   });
 });


### PR DESCRIPTION
We were directly writing the ReleaserConfig to the `release-please-config.json`, but the keys are actually dasherized.

Fixes #1522
