### PR TITLE
fix: skip component when manifest release does not include component

### DIFF
--- a/src/strategies/base.ts
+++ b/src/strategies/base.ts
@@ -488,7 +488,9 @@ export abstract class BaseStrategy implements Strategy {
       }
       releaseData = pullRequestBody.releaseData[0];
     } else {
-      // manifest release with multiple components
+      // manifest release with multiple components - find the release notes
+      // for the component to see if it was included in this release (parsed
+      // from the release pull request body)
       releaseData = pullRequestBody.releaseData.find(datum => {
         return (
           this.normalizeComponent(datum.component) ===

--- a/src/strategies/base.ts
+++ b/src/strategies/base.ts
@@ -489,13 +489,21 @@ export abstract class BaseStrategy implements Strategy {
       releaseData = pullRequestBody.releaseData[0];
     } else {
       // manifest release with multiple components
-      releaseData = pullRequestBody.releaseData.find(releaseData => {
+      releaseData = pullRequestBody.releaseData.find(datum => {
         return (
-          this.normalizeComponent(releaseData.component) ===
+          this.normalizeComponent(datum.component) ===
           this.normalizeComponent(component)
         );
       });
+
+      if (!releaseData && pullRequestBody.releaseData.length > 0) {
+        logger.info(
+          `Pull request contains releases, but not for component: ${component}`
+        );
+        return;
+      }
     }
+
     const notes = releaseData?.notes;
     if (notes === undefined) {
       logger.warn('Failed to find release notes');

--- a/test/fixtures/release-notes/grouped.txt
+++ b/test/fixtures/release-notes/grouped.txt
@@ -1,0 +1,26 @@
+:robot: I have created a release *beep* *boop*
+---
+
+
+<details><summary>1.0.1</summary>
+
+## [1.0.1](https://github.com/testOwner/testRepo/compare/v1.0.0...v1.0.1) (2022-07-16)
+
+
+### Bug Fixes
+
+* **chat:** add missing ellipsis to start log message ([00a2995](https://github.com/testOwner/testRepo/commit/00a299552dcee16479b987043beadbf846097126))
+</details>
+
+<details><summary>chat: 1.0.1</summary>
+
+## [1.0.1](https://github.com/testOwner/testRepo/compare/chat-v1.0.0...chat-v1.0.1) (2022-07-16)
+
+
+### Bug Fixes
+
+* **chat:** add missing ellipsis to start log message ([00a2995](https://github.com/testOwner/testRepo/commit/00a299552dcee16479b987043beadbf846097126))
+</details>
+
+---
+This PR was generated with [Release Please](https://github.com/googleapis/release-please). See [documentation](https://github.com/googleapis/release-please#release-please).

--- a/test/manifest.ts
+++ b/test/manifest.ts
@@ -4653,6 +4653,65 @@ describe('Manifest', () => {
       expect(releases[0].notes).to.be.a('string');
       expect(releases[0].path).to.eql('.');
     });
+
+    it('should find the correct number of releases with a componentless tag', async () => {
+      mockPullRequests(
+        github,
+        [],
+        [
+          {
+            headBranchName: 'release-please--branches--main',
+            baseBranchName: 'main',
+            number: 2,
+            title: 'chore: release v1.0.1',
+            body: pullRequestBody('release-notes/grouped.txt'),
+            labels: ['autorelease: pending'],
+            files: [],
+            sha: 'abc123',
+          },
+        ]
+      );
+      const manifest = new Manifest(
+        github,
+        'main',
+        {
+          '.': {
+            releaseType: 'simple',
+            pullRequestTitlePattern: 'chore: release v${version}',
+            component: 'base',
+            includeComponentInTag: false,
+          },
+          api: {
+            releaseType: 'simple',
+            component: 'api',
+          },
+          chat: {
+            releaseType: 'simple',
+            component: 'chat',
+          },
+          cmds: {
+            releaseType: 'simple',
+            component: 'cmds',
+          },
+          presence: {
+            releaseType: 'simple',
+            component: 'presence',
+          },
+        },
+        {
+          '.': Version.parse('1.0.0'),
+          api: Version.parse('1.0.0'),
+          chat: Version.parse('1.0.0'),
+          cmds: Version.parse('1.0.0'),
+          presence: Version.parse('1.0.0'),
+        },
+        {
+          groupPullRequestTitlePattern: 'chore: release v${version}',
+        }
+      );
+      const releases = await manifest.buildReleases();
+      expect(releases).lengthOf(2);
+    });
   });
 
   describe('createReleases', () => {


### PR DESCRIPTION
When a multi-component release PR was merged, we were rejecting untouched components only because we didn't find a version. However, if the group pull request title pattern was overridden and provided a version, we would not reject the release.

Now, we reject components if we do not find release data for them in the pull request.

Fixes #1527 
Fixes #1536 