### PR TITLE
feat: allow plugins to skip merging in-scope pull requests

### DIFF
--- a/__snapshots__/cargo-workspace.js
+++ b/__snapshots__/cargo-workspace.js
@@ -31,6 +31,58 @@ Release notes for path: packages/rustA, releaseType: rust
 This PR was generated with [Release Please](https://github.com/googleapis/release-please). See [documentation](https://github.com/googleapis/release-please#release-please).
 `
 
+exports['CargoWorkspace plugin run can skip merging rust packages 1'] = `
+:robot: I have created a release *beep* *boop*
+---
+
+
+Release notes for path: packages/rustA, releaseType: rust
+
+---
+This PR was generated with [Release Please](https://github.com/googleapis/release-please). See [documentation](https://github.com/googleapis/release-please#release-please).
+`
+
+exports['CargoWorkspace plugin run can skip merging rust packages 2'] = `
+:robot: I have created a release *beep* *boop*
+---
+
+
+### Dependencies
+
+* The following workspace dependencies were updated
+  * dependencies
+    * pkgA bumped from 1.1.1 to 1.1.2
+
+---
+This PR was generated with [Release Please](https://github.com/googleapis/release-please). See [documentation](https://github.com/googleapis/release-please#release-please).
+`
+
+exports['CargoWorkspace plugin run can skip merging rust packages 3'] = `
+:robot: I have created a release *beep* *boop*
+---
+
+
+### Dependencies
+
+* The following workspace dependencies were updated
+  * dependencies
+    * pkgB bumped from 2.2.2 to 2.2.3
+
+---
+This PR was generated with [Release Please](https://github.com/googleapis/release-please). See [documentation](https://github.com/googleapis/release-please#release-please).
+`
+
+exports['CargoWorkspace plugin run can skip merging rust packages 4'] = `
+:robot: I have created a release *beep* *boop*
+---
+
+
+Release notes for path: packages/rustD, releaseType: rust
+
+---
+This PR was generated with [Release Please](https://github.com/googleapis/release-please). See [documentation](https://github.com/googleapis/release-please#release-please).
+`
+
 exports['CargoWorkspace plugin run combines rust packages 1'] = `
 :robot: I have created a release *beep* *boop*
 ---

--- a/__snapshots__/linked-versions-workspace.js
+++ b/__snapshots__/linked-versions-workspace.js
@@ -1,0 +1,35 @@
+exports['Plugin compatibility linked-versions and workspace should version bump dependencies together 1'] = `
+:robot: I have created a release *beep* *boop*
+---
+
+
+<details><summary>pkgA: 1.1.0</summary>
+
+## [1.1.0](https://github.com/fake-owner/fake-repo/compare/pkgA-v1.0.0...pkgA-v1.1.0) (1983-10-10)
+
+
+### Features
+
+* some feature ([aaaaaa](https://github.com/fake-owner/fake-repo/commit/aaaaaa))
+</details>
+
+<details><summary>pkgB: 1.1.0</summary>
+
+## [1.1.0](https://github.com/fake-owner/fake-repo/compare/pkgB-v1.0.0...pkgB-v1.1.0) (1983-10-10)
+
+
+### Miscellaneous Chores
+
+* **pkgB:** Synchronize my group versions
+
+
+### Dependencies
+
+* The following workspace dependencies were updated
+  * dependencies
+    * pkgA bumped from 1.0.0 to 1.1.0
+</details>
+
+---
+This PR was generated with [Release Please](https://github.com/googleapis/release-please). See [documentation](https://github.com/googleapis/release-please#release-please).
+`

--- a/__snapshots__/linked-versions.js
+++ b/__snapshots__/linked-versions.js
@@ -1,3 +1,48 @@
+exports['LinkedVersions plugin can skip grouping pull requests 1'] = `
+:robot: I have created a release *beep* *boop*
+---
+
+
+## [1.0.1](https://github.com/fake-owner/fake-repo/compare/pkg1-v1.0.0...pkg1-v1.0.1) (1983-10-10)
+
+
+### Bug Fixes
+
+* some bugfix ([aaaaaa](https://github.com/fake-owner/fake-repo/commit/aaaaaa))
+
+---
+This PR was generated with [Release Please](https://github.com/googleapis/release-please). See [documentation](https://github.com/googleapis/release-please#release-please).
+`
+
+exports['LinkedVersions plugin can skip grouping pull requests 2'] = `
+:robot: I have created a release *beep* *boop*
+---
+
+
+<details><summary>pkg2: 0.2.4</summary>
+
+## [0.2.4](https://github.com/fake-owner/fake-repo/compare/pkg2-v0.2.3...pkg2-v0.2.4) (1983-10-10)
+
+
+### Bug Fixes
+
+* some bugfix ([bbbbbb](https://github.com/fake-owner/fake-repo/commit/bbbbbb))
+</details>
+
+<details><summary>pkg3: 0.2.4</summary>
+
+## [0.2.4](https://github.com/fake-owner/fake-repo/compare/pkg3-v0.2.3...pkg3-v0.2.4) (1983-10-10)
+
+
+### Miscellaneous Chores
+
+* **pkg3:** Synchronize group name versions
+</details>
+
+---
+This PR was generated with [Release Please](https://github.com/googleapis/release-please). See [documentation](https://github.com/googleapis/release-please#release-please).
+`
+
 exports['LinkedVersions plugin should group pull requests 1'] = `
 :robot: I have created a release *beep* *boop*
 ---

--- a/docs/manifest-releaser.md
+++ b/docs/manifest-releaser.md
@@ -477,3 +477,43 @@ The `maven-workspace` plugin operates similarly to the `node-workspace` plugin,
 but on a multi-artifact Maven workspace. It builds a dependency graph of all
 discovered `pom.xml` files that are configured in the manifest config and updates
 any packages that were directly bumped by release-please.
+
+### linked-versions
+
+The `linked-versions` plugin allows you to "link" the versions of multiple
+components in your monorepo. When any component in the specified group is
+updated, we pick the highest version amongst the components and update all
+group components to the same version (keeping them in sync).
+
+Note: when combining the `linked-versions` plugin with a `workspace` plugin,
+you will need to tell the `workspace` plugin to skip its own internal merge.
+See #1457 for context.
+
+Example:
+
+```json
+{
+  "release-type": "rust",
+  "packages": {
+    "packages/rustA": {
+      "component": "pkgA"
+    },
+    "packages/rustB": {
+      "component": "pkgB"
+    }
+  },
+  "plugins": [
+    {
+      "type": "cargo-workspace",
+      "merge": false
+    },
+    {
+      "type": "linked-versions",
+      "group-name": "my group",
+      "components": [
+        "pkgA", "pkgB"
+      ]
+    }
+  ]
+}
+```

--- a/schemas/config.json
+++ b/schemas/config.json
@@ -228,9 +228,32 @@
                     "items": {
                       "type": "string"
                     }
+                  },
+                  "merge": {
+                    "description": "Whether to merge in-scope pull requests into a combined release pull request. Defaults to `true`.",
+                    "type": "boolean"
                   }
                 },
                 "required": ["type", "groupName", "components"]
+              },
+              {
+                "description": "Configuration for various `workspace` plugins.",
+                "type": "object",
+                "properties": {
+                  "type": {
+                    "description": "The name of the plugin.",
+                    "type": "string",
+                    "enum": ["cargo-workspace", "maven-workspace", "node-workspace"]
+                  },
+                  "updateAllPackages": {
+                    "description": "Whether to force updating all packages regardless of the dependency tree. Defaults to `false`.",
+                    "type": "boolean"
+                  },
+                  "merge": {
+                    "description": "Whether to merge in-scope pull requests into a combined release pull request. Defaults to `true`.",
+                    "type": "boolean"
+                  }
+                }
               },
               {
                 "description": "Other plugins",

--- a/src/factories/plugin-factory.ts
+++ b/src/factories/plugin-factory.ts
@@ -78,7 +78,10 @@ export function buildPlugin(options: PluginFactoryOptions): ManifestPlugin {
   if (typeof options.type === 'object') {
     const builder = pluginFactories[options.type.type];
     if (builder) {
-      return builder(options);
+      return builder({
+        ...options.type,
+        ...options,
+      });
     }
     throw new ConfigurationError(
       `Unknown plugin type: ${options.type.type}`,

--- a/src/manifest.ts
+++ b/src/manifest.ts
@@ -180,11 +180,16 @@ export interface LinkedVersionPluginConfig extends ConfigurablePluginType {
   type: 'linked-versions';
   groupName: string;
   components: string[];
+  merge?: boolean;
+}
+export interface WorkspacePluginConfig extends ConfigurablePluginType {
+  merge?: boolean;
 }
 export type PluginType =
   | DirectPluginType
   | ConfigurablePluginType
-  | LinkedVersionPluginConfig;
+  | LinkedVersionPluginConfig
+  | WorkspacePluginConfig;
 
 /**
  * This is the schema of the manifest config json
@@ -691,6 +696,7 @@ export class Manifest {
     }
 
     for (const plugin of plugins) {
+      logger.debug(`running plugin: ${plugin.constructor.name}`);
       newReleasePullRequests = await plugin.run(newReleasePullRequests);
     }
 

--- a/src/plugins/cargo-workspace.ts
+++ b/src/plugins/cargo-workspace.ts
@@ -271,11 +271,17 @@ export class CargoWorkspace extends WorkspacePlugin<CrateInfo> {
     candidates: CandidateReleasePullRequest[],
     updatedVersions: VersionsMap
   ): CandidateReleasePullRequest[] {
-    const rootCandidate = candidates.find(c => c.path === ROOT_PROJECT_PATH);
+    let rootCandidate = candidates.find(c => c.path === ROOT_PROJECT_PATH);
     if (!rootCandidate) {
-      throw Error('Unable to find root candidate pull request');
+      logger.warn('Unable to find root candidate pull request');
+      rootCandidate = candidates.find(c => c.config.releaseType === 'rust');
+    }
+    if (!rootCandidate) {
+      logger.warn('Unable to find a rust candidate pull request');
+      return candidates;
     }
 
+    // Update the root Cargo.lock if it exists
     rootCandidate.pullRequest.updates.push({
       path: 'Cargo.lock',
       createIfMissing: false,

--- a/src/plugins/linked-versions.ts
+++ b/src/plugins/linked-versions.ts
@@ -23,6 +23,10 @@ import {Version} from '../version';
 import {buildStrategy} from '../factory';
 import {Merge} from './merge';
 
+interface LinkedVersionsPluginOptions {
+  merge?: boolean;
+}
+
 /**
  * This plugin reconfigures strategies by linking multiple components
  * together.
@@ -32,17 +36,20 @@ import {Merge} from './merge';
 export class LinkedVersions extends ManifestPlugin {
   private groupName: string;
   private components: Set<string>;
+  private merge: boolean;
 
   constructor(
     github: GitHub,
     targetBranch: string,
     repositoryConfig: RepositoryConfig,
     groupName: string,
-    components: string[]
+    components: string[],
+    options: LinkedVersionsPluginOptions = {}
   ) {
     super(github, targetBranch, repositoryConfig);
     this.groupName = groupName;
     this.components = new Set(components);
+    this.merge = options.merge ?? true;
   }
 
   /**
@@ -138,6 +145,10 @@ export class LinkedVersions extends ManifestPlugin {
   async run(
     candidates: CandidateReleasePullRequest[]
   ): Promise<CandidateReleasePullRequest[]> {
+    if (!this.merge) {
+      return candidates;
+    }
+
     const [inScopeCandidates, outOfScopeCandidates] = candidates.reduce(
       (collection, candidate) => {
         if (!candidate.pullRequest.version) {

--- a/src/plugins/workspace.ts
+++ b/src/plugins/workspace.ts
@@ -66,9 +66,7 @@ export abstract class WorkspacePlugin<T> extends ManifestPlugin {
     super(github, targetBranch, repositoryConfig);
     this.manifestPath = options.manifestPath ?? DEFAULT_RELEASE_PLEASE_MANIFEST;
     this.updateAllPackages = options.updateAllPackages ?? false;
-    console.log(options);
     this.merge = options.merge ?? true;
-    console.log(this.merge);
   }
   async run(
     candidates: CandidateReleasePullRequest[]

--- a/test/plugins/compatibility/linked-versions-workspace.ts
+++ b/test/plugins/compatibility/linked-versions-workspace.ts
@@ -147,7 +147,7 @@ describe('Plugin compatibility', () => {
         },
         {
           plugins: [
-            {type: 'cargo-workspace'},
+            {type: 'cargo-workspace', merge: false},
             {
               type: 'linked-versions',
               groupName: 'my group',

--- a/test/plugins/compatibility/linked-versions-workspace.ts
+++ b/test/plugins/compatibility/linked-versions-workspace.ts
@@ -1,0 +1,199 @@
+// Copyright 2022 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import {describe, it, afterEach, beforeEach} from 'mocha';
+import * as sinon from 'sinon';
+import {GitHub} from '../../../src/github';
+import {Manifest} from '../../../src/manifest';
+import {Update} from '../../../src/update';
+import {
+  buildGitHubFileContent,
+  mockReleases,
+  mockCommits,
+  safeSnapshot,
+  stubFilesFromFixtures,
+  assertHasUpdates,
+  assertHasUpdate,
+} from '../../helpers';
+import {Version} from '../../../src/version';
+import {CargoToml} from '../../../src/updaters/rust/cargo-toml';
+import {parseCargoManifest} from '../../../src/updaters/rust/common';
+import {expect} from 'chai';
+import {Changelog} from '../../../src/updaters/changelog';
+import {ReleasePleaseManifest} from '../../../src/updaters/release-please-manifest';
+import {CompositeUpdater} from '../../../src/updaters/composite';
+
+const sandbox = sinon.createSandbox();
+const fixturesPath = './test/fixtures/plugins/cargo-workspace';
+
+export function buildMockPackageUpdate(
+  path: string,
+  fixtureName: string
+): Update {
+  const cachedFileContents = buildGitHubFileContent(fixturesPath, fixtureName);
+  const manifest = parseCargoManifest(cachedFileContents.parsedContent);
+  return {
+    path,
+    createIfMissing: false,
+    cachedFileContents,
+    updater: new CargoToml({
+      version: Version.parse(manifest.package?.version || 'FIXME'),
+    }),
+  };
+}
+
+describe('Plugin compatibility', () => {
+  let github: GitHub;
+  beforeEach(async () => {
+    github = await GitHub.create({
+      owner: 'fake-owner',
+      repo: 'fake-repo',
+      defaultBranch: 'main',
+    });
+  });
+  afterEach(() => {
+    sandbox.restore();
+  });
+  describe('linked-versions and workspace', () => {
+    it('should version bump dependencies together', async () => {
+      // Scenario:
+      //   - package b depends on a
+      //   - package a receives a new feature
+      //   - package b version bumps its dependency on a
+      //   - package a and b should both use a minor version bump
+      mockReleases(sandbox, github, [
+        {
+          sha: 'abc123',
+          tagName: 'pkgA-v1.0.0',
+          url: 'https://github.com/fake-owner/fake-repo/releases/tag/pkgA-v1.0.0',
+        },
+        {
+          sha: 'abc123',
+          tagName: 'pkgB-v1.0.0',
+          url: 'https://github.com/fake-owner/fake-repo/releases/tag/pkgB-v1.0.0',
+        },
+      ]);
+      mockCommits(sandbox, github, [
+        {
+          sha: 'aaaaaa',
+          message: 'feat: some feature',
+          files: ['packages/rustA/foo'],
+        },
+        {
+          sha: 'abc123',
+          message: 'chore: release main',
+          files: [],
+          pullRequest: {
+            headBranchName: 'release-please/branches/main',
+            baseBranchName: 'main',
+            number: 123,
+            title: 'chore: release main',
+            body: '',
+            labels: [],
+            files: [],
+            sha: 'abc123',
+          },
+        },
+      ]);
+      stubFilesFromFixtures({
+        sandbox,
+        github,
+        fixturePath: fixturesPath,
+        files: [],
+        flatten: false,
+        targetBranch: 'main',
+        inlineFiles: [
+          [
+            'Cargo.toml',
+            '[workspace]\nmembers = ["packages/rustA", "packages/rustB"]',
+          ],
+          [
+            'packages/rustA/Cargo.toml',
+            '[package]\nname = "pkgA"\nversion = "1.0.0"',
+          ],
+          [
+            'packages/rustB/Cargo.toml',
+            '[package]\nname = "pkgB"\nversion = "1.0.0"\n\n[dependencies]\npkgA = { version = "1.0.0", path = "../pkgA" }',
+          ],
+        ],
+      });
+      const manifest = new Manifest(
+        github,
+        'main',
+        {
+          'packages/rustA': {
+            releaseType: 'rust',
+            component: 'pkgA',
+          },
+          'packages/rustB': {
+            releaseType: 'rust',
+            component: 'pkgB',
+          },
+        },
+        {
+          'packages/rustA': Version.parse('1.0.0'),
+          'packages/rustB': Version.parse('1.0.0'),
+        },
+        {
+          plugins: [
+            {type: 'cargo-workspace'},
+            {
+              type: 'linked-versions',
+              groupName: 'my group',
+              components: ['pkgA', 'pkgB'],
+            },
+          ],
+        }
+      );
+      const pullRequests = await manifest.buildPullRequests();
+      expect(pullRequests).lengthOf(1);
+      const pullRequest = pullRequests[0];
+      safeSnapshot(pullRequest.body.toString());
+      const updater = (
+        assertHasUpdates(
+          pullRequest.updates,
+          'packages/rustA/CHANGELOG.md',
+          Changelog
+        ) as Update
+      ).updater as Changelog;
+      expect(updater.version.toString()).to.eql('1.1.0');
+      const updaterB = (
+        assertHasUpdates(
+          pullRequest.updates,
+          'packages/rustB/CHANGELOG.md',
+          Changelog
+        ) as Update
+      ).updater as Changelog;
+      expect(updaterB.version.toString()).to.eql('1.1.0');
+      const manifestUpdate = assertHasUpdate(
+        pullRequest.updates,
+        '.release-please-manifest.json',
+        CompositeUpdater
+      );
+      expect(manifestUpdate.updater).instanceOf(CompositeUpdater);
+      const manifestUpdaters = (manifestUpdate.updater as CompositeUpdater)
+        .updaters;
+      expect(manifestUpdaters).not.empty;
+      for (const manifestUpdater of manifestUpdaters) {
+        expect(manifestUpdater).instanceOf(ReleasePleaseManifest);
+        const versionsMap = (manifestUpdater as ReleasePleaseManifest)
+          .versionsMap;
+        expect(versionsMap).to.not.be.undefined;
+        for (const [path, version] of versionsMap!.entries()) {
+          expect(version.toString(), `${path} version`).to.eql('1.1.0');
+        }
+      }
+    });
+  });
+});

--- a/test/plugins/linked-versions.ts
+++ b/test/plugins/linked-versions.ts
@@ -222,4 +222,44 @@ describe('LinkedVersions plugin', () => {
     expect(packageData2?.version).to.eql(packageData3?.version);
     safeSnapshot(pullRequest.body.toString());
   });
+  it('can skip grouping pull requests', async () => {
+    const manifest = new Manifest(
+      github,
+      'target-branch',
+      {
+        'path/a': {
+          releaseType: 'simple',
+          component: 'pkg1',
+        },
+        'path/b': {
+          releaseType: 'simple',
+          component: 'pkg2',
+        },
+        'path/c': {
+          releaseType: 'simple',
+          component: 'pkg3',
+        },
+      },
+      {
+        'path/a': Version.parse('1.0.0'),
+        'path/b': Version.parse('0.2.3'),
+        'path/c': Version.parse('0.2.3'),
+      },
+      {
+        separatePullRequests: true,
+        plugins: [
+          {
+            type: 'linked-versions',
+            groupName: 'group name',
+            components: ['pkg2', 'pkg3'],
+            merge: false,
+          },
+        ],
+      }
+    );
+    const pullRequests = await manifest.buildPullRequests();
+    for (const pullRequest of pullRequests) {
+      safeSnapshot(pullRequest.body.toString());
+    }
+  });
 });


### PR DESCRIPTION
By default, plugins that act across multiple candidate releases merge them together because they should be released together. This feature allows configuring the plugins so that they can skip this merge. This allows further plugins to see each modified candidate release.

Fixes #1457
