### PR TITLE
chore: remove extraneous snapshot entries

### DIFF
--- a/__snapshots__/php-composer-update-packages.js
+++ b/__snapshots__/php-composer-update-packages.js
@@ -6,10 +6,6 @@ exports['PHPComposer updateContent update all versions in composer.json 1'] = `
 {"version":"1.0.0","replace":{"version":"1.0.0"}}
 `
 
-exports['PHPComposer updateContent update replace version in composer.json 1'] = `
-{"replace":{"version":"1.0.0"}}
-`
-
 exports['PHPComposer updateContent update replace version in composer.json when version is missing 1'] = `
 {"replace":{"version":"1.0.0"}}
 `
@@ -20,11 +16,4 @@ exports['PHPComposer updateContent update replace version in composer.json when 
 
 exports['PHPComposer updateContent update root version in composer.json 1'] = `
 {"version":"1.0.0"}
-`
-
-exports['PHPComposer updateContent update version in composer.json 1'] = `
-{
-  "version": "1.0.0"
-}
-
 `


### PR DESCRIPTION
Running `npm test` removes these extraneous snapshot entries
