### PR TITLE
fix: throw underlying API error when the manifest fetch commits when determining the latest released version

### DIFF
--- a/src/github.ts
+++ b/src/github.ts
@@ -528,11 +528,11 @@ export class GitHub {
             logger.warn('ran out of retries and response is required');
             throw err;
           }
-          logger.warn(`received 502 error, ${maxRetries} attempts remaining`);
+          logger.info(`received 502 error, ${maxRetries} attempts remaining`);
         }
         maxRetries -= 1;
         if (maxRetries >= 0) {
-          logger.warn(`sleeping ${seconds} seconds`);
+          logger.trace(`sleeping ${seconds} seconds`);
           await sleepInMs(1000 * seconds);
           seconds = Math.min(seconds * 2, MAX_SLEEP_SECONDS);
         }

--- a/src/manifest.ts
+++ b/src/manifest.ts
@@ -1373,7 +1373,10 @@ async function latestReleaseVersion(
   // only look at the last 250 or so commits to find the latest tag - we
   // don't want to scan the entire repository history if this repo has never
   // been released
-  const generator = github.mergeCommitIterator(targetBranch, {maxResults: 250});
+  const generator = github.mergeCommitIterator(targetBranch, {
+    maxResults: 250,
+    requireResponse: true,
+  });
   for await (const commitWithPullRequest of generator) {
     commitShas.add(commitWithPullRequest.sha);
     const mergedPullRequest = commitWithPullRequest.pullRequest;

--- a/src/manifest.ts
+++ b/src/manifest.ts
@@ -1375,7 +1375,6 @@ async function latestReleaseVersion(
   // been released
   const generator = github.mergeCommitIterator(targetBranch, {
     maxResults: 250,
-    requireResponse: true,
   });
   for await (const commitWithPullRequest of generator) {
     commitShas.add(commitWithPullRequest.sha);


### PR DESCRIPTION
Occasionally, GitHub's GraphQL endpoint throws 502s when it takes too long to execute a query. We usually silently retry these requests (with exponential backoff). Previously, if too many attempts are made, we return an empty response. We introduce a new `requireResponse` option which will tell our GraphQL executor to throw the underlying API error if a response is required.

Fixes #1567