### PR TITLE
feat(node-workspace): Allow to specify version prefix in config

### DIFF
--- a/__snapshots__/cli.js
+++ b/__snapshots__/cli.js
@@ -177,6 +177,8 @@ Options:
                                     the minor for non-breaking changes prior to
                                     the first major release
                                                       [boolean] [default: false]
+  --version-prefix                  prefix linked package version updates with
+                                    this string                         [string]
   --extra-files                     extra files for the strategy to consider
                                                                         [string]
   --version-file                    path to version file to update, e.g.,

--- a/__snapshots__/node-workspace.js
+++ b/__snapshots__/node-workspace.js
@@ -85,6 +85,28 @@ Release notes for path: node1, releaseType: node
 This PR was generated with [Release Please](https://github.com/googleapis/release-please). See [documentation](https://github.com/googleapis/release-please#release-please).
 `
 
+exports['NodeWorkspace plugin run respects empty version prefix 1'] = `
+{
+  "name": "@here/pkgB",
+  "version": "2.2.2",
+  "dependencies": {
+    "@here/pkgA": "3.3.4",
+    "anotherExternal": "^4.3.1"
+  }
+}
+`
+
+exports['NodeWorkspace plugin run respects version prefix 1'] = `
+{
+  "name": "@here/pkgB",
+  "version": "2.2.2",
+  "dependencies": {
+    "@here/pkgA": "~3.3.4",
+    "anotherExternal": "^4.3.1"
+  }
+}
+`
+
 exports['NodeWorkspace plugin run should ignore peer dependencies 1'] = `
 :robot: I have created a release *beep* *boop*
 ---

--- a/docs/manifest-releaser.md
+++ b/docs/manifest-releaser.md
@@ -172,6 +172,10 @@ defaults (those are documented in comments)
   // absence defaults to false
   "bump-patch-for-minor-pre-major": true,
 
+  // prefix linked package version updates with this string
+  // absence defaults to `^`
+  "version-prefix": true,
+
   // set default conventional commit => changelog sections mapping/appearance.
   // absence defaults to https://git.io/JqCZL
   "changelog-sections": [...],
@@ -239,7 +243,7 @@ defaults (those are documented in comments)
   // large numbers of packages at once.
   // absence defaults to false, causing calls to be issued concurrently.
   "sequential-calls": false,
-  
+
 
   // per package configuration: at least one entry required.
   // the key is the relative path from the repo root to the folder that contains

--- a/schemas/config.json
+++ b/schemas/config.json
@@ -20,6 +20,10 @@
           "description": "Feature changes only bump semver patch if version < 1.0.0",
           "type": "boolean"
         },
+        "version-prefix": {
+          "description": "Version bumps of linked packages will be prefixed with this. Defaults to `^`",
+          "type": "string"
+        },
         "versioning": {
           "description": "Versioning strategy. Defaults to `default`",
           "type": "string"

--- a/src/bin/release-please.ts
+++ b/src/bin/release-please.ts
@@ -63,6 +63,7 @@ interface ManifestArgs {
 interface VersioningArgs {
   bumpMinorPreMajor?: boolean;
   bumpPatchForMinorPreMajor?: boolean;
+  versionPrefix?: string;
   releaseAs?: string;
 
   // only for Ruby: TODO replace with generic bootstrap option
@@ -273,6 +274,10 @@ function pullRequestStrategyOptions(yargs: yargs.Argv): yargs.Argv {
       default: false,
       type: 'boolean',
     })
+    .option('version-prefix', {
+      describe: 'prefix linked package version updates with this string',
+      type: 'string',
+    })
     .option('extra-files', {
       describe: 'extra files for the strategy to consider',
       type: 'string',
@@ -441,6 +446,7 @@ const createReleasePullRequestCommand: yargs.CommandModule<
           draftPullRequest: argv.draftPullRequest,
           bumpMinorPreMajor: argv.bumpMinorPreMajor,
           bumpPatchForMinorPreMajor: argv.bumpPatchForMinorPreMajor,
+          versionPrefix: argv.versionPrefix,
           changelogPath: argv.changelogPath,
           changelogType: argv.changelogType,
           changelogHost: argv.changelogHost,

--- a/src/manifest.ts
+++ b/src/manifest.ts
@@ -77,6 +77,7 @@ export interface ReleaserConfig {
   versioning?: VersioningStrategyType;
   bumpMinorPreMajor?: boolean;
   bumpPatchForMinorPreMajor?: boolean;
+  versionPrefix?: string;
 
   // Strategy options
   releaseAs?: string;
@@ -126,6 +127,7 @@ interface ReleaserConfigJson {
   versioning?: VersioningStrategyType;
   'bump-minor-pre-major'?: boolean;
   'bump-patch-for-minor-pre-major'?: boolean;
+  'version-prefix'?: string;
   'changelog-sections'?: ChangelogSection[];
   'release-as'?: string;
   'skip-github-release'?: boolean;
@@ -1162,6 +1164,7 @@ function extractReleaserConfig(
     releaseType: config['release-type'],
     bumpMinorPreMajor: config['bump-minor-pre-major'],
     bumpPatchForMinorPreMajor: config['bump-patch-for-minor-pre-major'],
+    versionPrefix: config['version-prefix'],
     versioning: config['versioning'],
     changelogSections: config['changelog-sections'],
     changelogPath: config['changelog-path'],

--- a/src/plugins/node-workspace.ts
+++ b/src/plugins/node-workspace.ts
@@ -172,10 +172,11 @@ export class NodeWorkspace extends WorkspacePlugin<Package> {
     for (const [depName, resolved] of graphPackage.localDependencies) {
       const depVersion = updatedVersions.get(depName);
       if (depVersion && resolved.type !== 'directory') {
+        const config = this.repositoryConfig[existingCandidate.path];
         updatedPackage.updateLocalDependency(
           resolved,
           depVersion.toString(),
-          '^'
+          config.versionPrefix ?? '^'
         );
         logger.info(
           `${pkg.name}.${depName} updated to ^${depVersion.toString()}`

--- a/src/updaters/release-please-config.ts
+++ b/src/updaters/release-please-config.ts
@@ -53,6 +53,7 @@ function releaserConfigToJsonConfig(
     'release-type': config.releaseType,
     'bump-minor-pre-major': config.bumpMinorPreMajor,
     'bump-patch-for-minor-pre-major': config.bumpPatchForMinorPreMajor,
+    'version-prefix': config.versionPrefix,
     'changelog-sections': config.changelogSections,
     'release-as': config.releaseAs,
     'skip-github-release': config.skipGithubRelease,

--- a/test/cli.ts
+++ b/test/cli.ts
@@ -838,6 +838,32 @@ describe('CLI', () => {
         sinon.assert.calledOnce(createPullRequestsStub);
       });
 
+      it('handles --version-prefix', async () => {
+        await parser.parseAsync(
+          'release-pr --repo-url=googleapis/release-please-cli --release-type=java-yoshi --version-prefix "~"'
+        );
+
+        sinon.assert.calledOnceWithExactly(gitHubCreateStub, {
+          owner: 'googleapis',
+          repo: 'release-please-cli',
+          token: undefined,
+          apiUrl: 'https://api.github.com',
+          graphqlUrl: 'https://api.github.com',
+        });
+        sinon.assert.calledOnceWithExactly(
+          fromConfigStub,
+          fakeGitHub,
+          'main',
+          sinon.match({
+            releaseType: 'java-yoshi',
+            versionPrefix: '~',
+          }),
+          sinon.match.any,
+          undefined
+        );
+        sinon.assert.calledOnce(createPullRequestsStub);
+      });
+
       it('handles java --extra-files', async () => {
         await parser.parseAsync(
           'release-pr --repo-url=googleapis/release-please-cli --release-type=java-yoshi --extra-files=foo/bar.java,asdf/qwer.java'


### PR DESCRIPTION
This allows a `versionPrefix` config option that can be set to a string (like `~`, `^`, ` `, `>=`) that will be used when updating linked local dependencies in a package.


- [ ] Make sure to open an issue as a [bug/issue](https://github.com/googleapis/release-please/issues/new/choose) before writing your code!  That way we can discuss the change, evaluate designs, and agree on the general idea
- [x] Ensure the tests and linter pass
- [x] Code coverage does not decrease (if any source code was changed)
- [ ] Appropriate docs were updated (if necessary)
