### PR TITLE
fix: use git-file-utils' cache for file search

### DIFF
--- a/package.json
+++ b/package.json
@@ -68,7 +68,7 @@
   },
   "dependencies": {
     "@conventional-commits/parser": "^0.4.1",
-    "@google-automations/git-file-utils": "^1.0.0",
+    "@google-automations/git-file-utils": "^1.1.0",
     "@iarna/toml": "^2.2.5",
     "@lerna/collect-updates": "^4.0.0",
     "@lerna/package": "^4.0.0",

--- a/src/github.ts
+++ b/src/github.ts
@@ -862,32 +862,7 @@ export class GitHub {
       logger.debug(
         `finding files by filename: ${filename}, ref: ${ref}, prefix: ${prefix}`
       );
-      const response = await this.octokit.git.getTree({
-        owner: this.repository.owner,
-        repo: this.repository.repo,
-        tree_sha: ref,
-        recursive: 'true',
-      });
-      return response.data.tree
-        .filter(file => {
-          const path = file.path;
-          return (
-            path &&
-            // match the filename
-            path.endsWith(filename) &&
-            // match the prefix if provided
-            (!prefix || path.startsWith(`${prefix}/`))
-          );
-        })
-        .map(file => {
-          let path = file.path!;
-          // strip the prefix if provided
-          if (prefix) {
-            const pfix = new RegExp(`^${prefix}[/\\\\]`);
-            path = path.replace(pfix, '');
-          }
-          return path;
-        });
+      return await this.fileCache.findFilesByFilename(filename, ref, prefix);
     }
   );
 
@@ -1126,32 +1101,7 @@ export class GitHub {
       if (prefix) {
         prefix = normalizePrefix(prefix);
       }
-      const response = await this.octokit.git.getTree({
-        owner: this.repository.owner,
-        repo: this.repository.repo,
-        tree_sha: ref,
-        recursive: 'true',
-      });
-      return response.data.tree
-        .filter(file => {
-          const path = file.path;
-          return (
-            path &&
-            // match the file extension
-            path.endsWith(`.${extension}`) &&
-            // match the prefix if provided
-            (!prefix || path.startsWith(`${prefix}/`))
-          );
-        })
-        .map(file => {
-          let path = file.path!;
-          // strip the prefix if provided
-          if (prefix) {
-            const pfix = new RegExp(`^${prefix}[/\\\\]`);
-            path = path.replace(pfix, '');
-          }
-          return path;
-        });
+      return this.fileCache.findFilesByExtension(extension, ref, prefix);
     }
   );
 


### PR DESCRIPTION
Towards https://github.com/googleapis/repo-automation-bots/issues/4157

fix(deps): update git-file-utils to 1.1.0