### PR TITLE
fix: Allow $schema key in manifest config schema

### DIFF
--- a/schemas/config.json
+++ b/schemas/config.json
@@ -196,7 +196,7 @@
         "$schema": {
           "description": "Path to the release-please manifest config schema",
           "type": "string",
-          "format": "uri"
+          "format": "uri-reference"
         },
         "packages": {
           "description": "Per-path component configuration.",
@@ -306,6 +306,7 @@
     }
   ],
   "properties": {
+    "$schema": true,
     "packages": true,
     "bootstrap-sha": true,
     "last-release-sha": true,


### PR DESCRIPTION
Did some additional testing on #1584 and noticed a couple issues:
1) `$schema` needed to be added to the properties array for it to be picked up
2) If you want to reference the schema via a relative (local) path, you need to use uri-reference instead of uri