### PR TITLE
fix: convert `MissingFileError` thrown by `git-file-utils`

### DIFF
--- a/src/github.ts
+++ b/src/github.ts
@@ -43,6 +43,7 @@ import {
   RepositoryFileCache,
   GitHubFileContents,
   DEFAULT_FILE_MODE,
+  FileNotFoundError as MissingFileError,
 } from '@google-automations/git-file-utils';
 
 // Extract some types from the `request` package.
@@ -809,7 +810,14 @@ export class GitHub {
     branch: string
   ): Promise<GitHubFileContents> {
     logger.debug(`Fetching ${path} from branch ${branch}`);
-    return await this.fileCache.getFileContents(path, branch);
+    try {
+      return await this.fileCache.getFileContents(path, branch);
+    } catch (e) {
+      if (e instanceof MissingFileError) {
+        throw new FileNotFoundError(path);
+      }
+      throw e;
+    }
   }
 
   async getFileJson<T>(path: string, branch: string): Promise<T> {

--- a/test/github.ts
+++ b/test/github.ts
@@ -201,7 +201,7 @@ describe('GitHub', () => {
       req = req
         .get('/repos/fake/fake/git/trees/main?recursive=true')
         .reply(200, dataAPITreesResponse);
-    })
+    });
     it('should support Github Data API in case of a big file', async () => {
       const dataAPIBlobResponse = JSON.parse(
         readFileSync(

--- a/test/github.ts
+++ b/test/github.ts
@@ -187,7 +187,7 @@ describe('GitHub', () => {
   });
 
   describe('getFileContents', () => {
-    it('should support Github Data API in case of a big file', async () => {
+    beforeEach(() => {
       const dataAPITreesResponse = JSON.parse(
         readFileSync(
           resolve(
@@ -198,6 +198,11 @@ describe('GitHub', () => {
           'utf8'
         )
       );
+      req = req
+        .get('/repos/fake/fake/git/trees/main?recursive=true')
+        .reply(200, dataAPITreesResponse);
+    })
+    it('should support Github Data API in case of a big file', async () => {
       const dataAPIBlobResponse = JSON.parse(
         readFileSync(
           resolve(
@@ -209,9 +214,7 @@ describe('GitHub', () => {
         )
       );
 
-      req
-        .get('/repos/fake/fake/git/trees/main?recursive=true')
-        .reply(200, dataAPITreesResponse)
+      req = req
         .get(
           '/repos/fake/fake/git/blobs/2f3d2c47bf49f81aca0df9ffc49524a213a2dc33'
         )
@@ -225,6 +228,12 @@ describe('GitHub', () => {
         .equal('2f3d2c47bf49f81aca0df9ffc49524a213a2dc33');
       snapshot(fileContents);
       req.done();
+    });
+
+    it('should throw a missing file error', async () => {
+      await assert.rejects(async () => {
+        await github.getFileContents('non-existent-file');
+      }, FileNotFoundError);
     });
   });
 


### PR DESCRIPTION
Unreleased #1585 started using the extracted `RepositoryFileCache` from `git-file-utils`. As part of the extraction, a separate `MissingFileError` was introduced and is thrown from the cache. To preserve the interface of our `GitHub` class, we need to catch this new error and throw our own.
