### PR TITLE
fix: add REST API call to fetch pull requests without files

### DIFF
--- a/__snapshots__/github.js
+++ b/__snapshots__/github.js
@@ -1227,3 +1227,32 @@ exports['GitHub pullRequestIterator handles merged pull requests without files 1
     ]
   }
 ]
+
+exports['GitHub pullRequestIterator uses REST API if files are not needed 1'] = [
+  {
+    "headBranchName": "feature-branch",
+    "baseBranchName": "main",
+    "number": 123,
+    "title": "some title",
+    "body": "some body",
+    "labels": [
+      "label 1",
+      "label 2"
+    ],
+    "files": [],
+    "sha": "abc123"
+  },
+  {
+    "headBranchName": "feature-branch",
+    "baseBranchName": "main",
+    "number": 124,
+    "title": "merged title 2 ",
+    "body": "merged body 2",
+    "labels": [
+      "label 1",
+      "label 2"
+    ],
+    "files": [],
+    "sha": "abc123"
+  }
+]

--- a/src/manifest.ts
+++ b/src/manifest.ts
@@ -810,7 +810,9 @@ export class Manifest {
     const openPullRequests: PullRequest[] = [];
     const generator = this.github.pullRequestIterator(
       this.targetBranch,
-      'OPEN'
+      'OPEN',
+      Number.MAX_SAFE_INTEGER,
+      false
     );
     for await (const openPullRequest of generator) {
       if (
@@ -831,7 +833,9 @@ export class Manifest {
     const snoozedPullRequests: PullRequest[] = [];
     const closedGenerator = this.github.pullRequestIterator(
       this.targetBranch,
-      'CLOSED'
+      'CLOSED',
+      200,
+      false
     );
     for await (const closedPullRequest of closedGenerator) {
       if (
@@ -938,7 +942,8 @@ export class Manifest {
     const pullRequestGenerator = this.github.pullRequestIterator(
       this.targetBranch,
       'MERGED',
-      200
+      200,
+      false
     );
     for await (const pullRequest of pullRequestGenerator) {
       if (!hasAllLabels(this.labels, pullRequest.labels)) {

--- a/test/github.ts
+++ b/test/github.ts
@@ -273,6 +273,56 @@ describe('GitHub', () => {
       snapshot(pullRequests!);
       req.done();
     });
+    it('uses REST API if files are not needed', async () => {
+      req.get('/repos/fake/fake/pulls?base=main&state=closed').reply(200, [
+        {
+          head: {
+            ref: 'feature-branch',
+          },
+          base: {
+            ref: 'main',
+          },
+          number: 123,
+          title: 'some title',
+          body: 'some body',
+          labels: [{name: 'label 1'}, {name: 'label 2'}],
+          merge_commit_sha: 'abc123',
+        },
+        {
+          head: {
+            ref: 'feature-branch',
+          },
+          base: {
+            ref: 'main',
+          },
+          number: 124,
+          title: 'merged title 2 ',
+          body: 'merged body 2',
+          labels: [{name: 'label 1'}, {name: 'label 2'}],
+          merge_commit_sha: 'abc123',
+        },
+        {
+          head: {
+            ref: 'feature-branch',
+          },
+          base: {
+            ref: 'main',
+          },
+          number: 125,
+          title: 'closed title',
+          body: 'closed body',
+          labels: [{name: 'label 1'}, {name: 'label 2'}],
+        },
+      ]);
+      const generator = github.pullRequestIterator('main', 'MERGED', 30, false);
+      const pullRequests: PullRequest[] = [];
+      for await (const pullRequest of generator) {
+        pullRequests.push(pullRequest);
+      }
+      expect(pullRequests).lengthOf(2);
+      snapshot(pullRequests!);
+      req.done();
+    });
   });
 
   describe('commitsSince', () => {


### PR DESCRIPTION
The GraphQL API returns 502 for some repositories when iterating over pull requests with files.

This PR adds a new option to the `pullRequestIterator` allowing you to skip fetching files. If you do not need the list of files, we can use the REST API which is much more responsive.
