### PR TITLE
fix: allow providing logger to GitHub.create

### DIFF
--- a/src/github.ts
+++ b/src/github.ts
@@ -71,6 +71,7 @@ interface GitHubCreateOptions {
   graphqlUrl?: string;
   octokitAPIs?: OctokitAPIs;
   token?: string;
+  logger?: Logger;
 }
 
 type CommitFilter = (commit: Commit) => boolean;
@@ -253,6 +254,7 @@ export class GitHub {
           )),
       },
       octokitAPIs: apis,
+      logger: options.logger,
     };
     return new GitHub(opts);
   }


### PR DESCRIPTION
We added support for a custom logger instance in the GitHub API wrapper, but the constructor is private. This adds the option as a `GitHub.create` option.
