### PR TITLE
fix: dont filter out root package in node workspace candidate filtering

### DIFF
--- a/__snapshots__/node-workspace.js
+++ b/__snapshots__/node-workspace.js
@@ -67,6 +67,19 @@ Release notes for path: node1, releaseType: node
 Release notes for path: node4, releaseType: node
 </details>
 
+<details><summary>@here/root: 5.5.6</summary>
+
+Release notes for path: ., releaseType: node
+
+
+### Dependencies
+
+* The following workspace dependencies were updated
+  * dependencies
+    * @here/pkgA bumped from ^3.3.3 to ^3.3.4
+    * @here/pkgD bumped from ^4.4.4 to ^4.4.5
+</details>
+
 ---
 This PR was generated with [Release Please](https://github.com/googleapis/release-please). See [documentation](https://github.com/googleapis/release-please#release-please).
 `

--- a/src/plugins/node-workspace.ts
+++ b/src/plugins/node-workspace.ts
@@ -18,11 +18,7 @@ import {
   RawManifest as PackageJson,
 } from '@lerna/package';
 import {GitHub} from '../github';
-import {
-  CandidateReleasePullRequest,
-  RepositoryConfig,
-  ROOT_PROJECT_PATH,
-} from '../manifest';
+import {CandidateReleasePullRequest, RepositoryConfig} from '../manifest';
 import {Version, VersionsMap} from '../version';
 import {RawContent} from '../updaters/raw-content';
 import {PullRequestTitle} from '../util/pull-request-title';
@@ -337,10 +333,7 @@ export class NodeWorkspace extends WorkspacePlugin<Package> {
   }
 
   protected inScope(candidate: CandidateReleasePullRequest): boolean {
-    return (
-      candidate.config.releaseType === 'node' &&
-      candidate.path !== ROOT_PROJECT_PATH
-    );
+    return candidate.config.releaseType === 'node';
   }
 
   protected packageNameFromPackage(pkg: Package): string {

--- a/test/fixtures/plugins/node-workspace/package.json
+++ b/test/fixtures/plugins/node-workspace/package.json
@@ -1,0 +1,8 @@
+{
+  "name": "@here/root",
+  "version": "5.5.5",
+  "dependencies": {
+    "@here/pkgA": "^3.3.3",
+    "@here/pkgD": "^4.4.4"
+  }
+}

--- a/test/plugins/node-workspace.ts
+++ b/test/plugins/node-workspace.ts
@@ -142,6 +142,9 @@ describe('NodeWorkspace plugin', () => {
     });
     it('combines node packages', async () => {
       const candidates: CandidateReleasePullRequest[] = [
+        buildMockCandidatePullRequest('.', 'node', '5.5.6', '@here/root', [
+          buildMockPackageUpdate('package.json', 'package.json'),
+        ]),
         buildMockCandidatePullRequest('node1', 'node', '3.3.4', '@here/pkgA', [
           buildMockPackageUpdate('node1/package.json', 'node1/package.json'),
         ]),
@@ -149,7 +152,18 @@ describe('NodeWorkspace plugin', () => {
           buildMockPackageUpdate('node4/package.json', 'node4/package.json'),
         ]),
       ];
+      stubFilesFromFixtures({
+        sandbox,
+        github,
+        fixturePath: fixturesPath,
+        files: ['package.json', 'node1/package.json', 'node4/package.json'],
+        flatten: false,
+        targetBranch: 'main',
+      });
       plugin = new NodeWorkspace(github, 'main', {
+        '.': {
+          releaseType: 'node',
+        },
         node1: {
           releaseType: 'node',
         },
@@ -164,6 +178,7 @@ describe('NodeWorkspace plugin', () => {
       );
       expect(nodeCandidate).to.not.be.undefined;
       const updates = nodeCandidate!.pullRequest.updates;
+      assertHasUpdate(updates, 'package.json');
       assertHasUpdate(updates, 'node1/package.json');
       assertHasUpdate(updates, 'node4/package.json');
       snapshot(dateSafe(nodeCandidate!.pullRequest.body.toString()));


### PR DESCRIPTION
Here is a simple fix for #1605. All it does is remove the `candidate.path !== ROOT_PROJECT_PATH` check so the root package is considered `inScope` when collecting candidate pull requests with the `node-workspace` plugin.

Like I mentioned in the issue, I'm not sure if this is the correct approach. I did notice that both the maven and cargo plugins do not have this check, so that led me to believe that it might be.

I only have knowledge of the npm ecosystem, where I've seen both monorepos where the root is only used for configuration and where the root is a publishable package.

My assumption here, without a deep knowledge of the codebase, is that if the root package is included in the manifest via the `'.'` key, it should always be considered in scope when generating candidate PRs.

Fixes #1605
