### PR TITLE
fix: prepend release notes to non-conforming changelog

### DIFF
--- a/__snapshots__/changelog.js
+++ b/__snapshots__/changelog.js
@@ -152,3 +152,20 @@ exports['ChangelogUpdater updateContent populates a new CHANGELOG if none exists
 * added a new foo to bar.
 
 `
+
+exports['ChangelogUpdater updateContent prepends CHANGELOG entries if a different style is found 1'] = `
+# Changelog
+
+## 1.0.0
+
+* added a new foo to bar.
+
+## Version 1.0.0-alpha01, released 2022-06-25
+
+Second alpha release.
+
+## Version 1.0.0-alpha00, released 2022-06-24
+
+Initial release.
+
+`

--- a/src/updaters/changelog.ts
+++ b/src/updaters/changelog.ts
@@ -39,7 +39,13 @@ export class Changelog extends DefaultUpdater {
     // Handle both H2 (features/BREAKING CHANGES) and H3 (fixes).
     const lastEntryIndex = content.search(this.versionHeaderRegex);
     if (lastEntryIndex === -1) {
-      return `${this.header()}\n${this.changelogEntry}\n`;
+      if (content) {
+        return `${this.header()}\n${this.changelogEntry}\n\n${adjustHeaders(
+          content
+        ).trim()}\n`;
+      } else {
+        return `${this.header()}\n${this.changelogEntry}\n`;
+      }
     } else {
       const before = content.slice(0, lastEntryIndex);
       const after = content.slice(lastEntryIndex);
@@ -51,4 +57,9 @@ export class Changelog extends DefaultUpdater {
 # Changelog
 `;
   }
+}
+
+// Helper to increase markdown H1 headers to H2
+function adjustHeaders(content: string): string {
+  return content.replace(/^#(\s)/gm, '##$1');
 }

--- a/test/updaters/changelog.ts
+++ b/test/updaters/changelog.ts
@@ -84,5 +84,18 @@ describe('ChangelogUpdater', () => {
       const newContent = changelog.updateContent(oldContent);
       snapshot(newContent);
     });
+
+    it('prepends CHANGELOG entries if a different style is found', async () => {
+      const oldContent = readFileSync(
+        resolve(fixturesPath, './CHANGELOG-non-conforming.md'),
+        'utf8'
+      ).replace(/\r\n/g, '\n');
+      const changelog = new Changelog({
+        changelogEntry: '## 1.0.0\n\n* added a new foo to bar.',
+        version: Version.parse('1.0.0'),
+      });
+      const newContent = changelog.updateContent(oldContent);
+      snapshot(newContent);
+    });
   });
 });

--- a/test/updaters/fixtures/CHANGELOG-non-conforming.md
+++ b/test/updaters/fixtures/CHANGELOG-non-conforming.md
@@ -1,0 +1,7 @@
+# Version 1.0.0-alpha01, released 2022-06-25
+
+Second alpha release.
+
+# Version 1.0.0-alpha00, released 2022-06-24
+
+Initial release.


### PR DESCRIPTION
Rather than overwriting the existing release notes that do not conform to the expected release-please format, prepend the new changelog entry. Also, downgrade any existing H1s to H2s.

This will help us on-board new repositories with existing changelogs that do not match our style.

Fixes #1478
