### PR TITLE
feat: allow specifying glob option for extra-files

### DIFF
--- a/package.json
+++ b/package.json
@@ -68,7 +68,7 @@
   },
   "dependencies": {
     "@conventional-commits/parser": "^0.4.1",
-    "@google-automations/git-file-utils": "^1.1.0",
+    "@google-automations/git-file-utils": "^1.2.0",
     "@iarna/toml": "^2.2.5",
     "@lerna/collect-updates": "^4.0.0",
     "@lerna/package": "^4.0.0",

--- a/schemas/config.json
+++ b/schemas/config.json
@@ -133,7 +133,7 @@
                     "type": "string"
                   },
                   "glob": {
-                    "description": "Whether tp treat the path as a glob. Defaults to `false`.",
+                    "description": "Whether to treat the path as a glob. Defaults to `false`.",
                     "type": "boolean"
                   },
                   "jsonpath": {
@@ -156,7 +156,7 @@
                     "type": "string"
                   },
                   "glob": {
-                    "description": "Whether tp treat the path as a glob. Defaults to `false`.",
+                    "description": "Whether to treat the path as a glob. Defaults to `false`.",
                     "type": "boolean"
                   },
                   "xpath": {
@@ -179,7 +179,7 @@
                     "type": "string"
                   },
                   "glob": {
-                    "description": "Whether tp treat the path as a glob. Defaults to `false`.",
+                    "description": "Whether to treat the path as a glob. Defaults to `false`.",
                     "type": "boolean"
                   }
                 },

--- a/schemas/config.json
+++ b/schemas/config.json
@@ -132,6 +132,10 @@
                     "description": "The path to the file.",
                     "type": "string"
                   },
+                  "glob": {
+                    "description": "Whether tp treat the path as a glob. Defaults to `false`.",
+                    "type": "boolean"
+                  },
                   "jsonpath": {
                     "description": "The jsonpath to the version entry in the file.",
                     "type": "string"
@@ -151,6 +155,10 @@
                     "description": "The path to the file.",
                     "type": "string"
                   },
+                  "glob": {
+                    "description": "Whether tp treat the path as a glob. Defaults to `false`.",
+                    "type": "boolean"
+                  },
                   "xpath": {
                     "description": "The xpath to the version entry in the file.",
                     "type": "string"
@@ -169,6 +177,10 @@
                   "path": {
                     "description": "The path to the file.",
                     "type": "string"
+                  },
+                  "glob": {
+                    "description": "Whether tp treat the path as a glob. Defaults to `false`.",
+                    "type": "boolean"
                   }
                 },
                 "required": ["type", "path"]

--- a/src/github.ts
+++ b/src/github.ts
@@ -969,6 +969,47 @@ export class GitHub {
   );
 
   /**
+   * Returns a list of paths to all files matching a glob pattern.
+   *
+   * If a prefix is specified, only return paths that match
+   * the provided prefix.
+   *
+   * @param glob The glob to match
+   * @param prefix Optional path prefix used to filter results
+   * @returns {string[]} List of file paths
+   * @throws {GitHubAPIError} on an API error
+   */
+  async findFilesByGlob(glob: string, prefix?: string): Promise<string[]> {
+    return this.findFilesByGlobAndRef(
+      glob,
+      this.repository.defaultBranch,
+      prefix
+    );
+  }
+  /**
+   * Returns a list of paths to all files matching a glob pattern.
+   *
+   * If a prefix is specified, only return paths that match
+   * the provided prefix.
+   *
+   * @param glob The glob to match
+   * @param ref Git reference to search files in
+   * @param prefix Optional path prefix used to filter results
+   * @throws {GitHubAPIError} on an API error
+   */
+  findFilesByGlobAndRef = wrapAsync(
+    async (glob: string, ref: string, prefix?: string): Promise<string[]> => {
+      if (prefix) {
+        prefix = normalizePrefix(prefix);
+      }
+      this.logger.debug(
+        `finding files by glob: ${glob}, ref: ${ref}, prefix: ${prefix}`
+      );
+      return await this.fileCache.findFilesByGlob(glob, ref, prefix);
+    }
+  );
+
+  /**
    * Open a pull request
    *
    * @param {ReleasePullRequest} releasePullRequest Pull request data to update

--- a/src/manifest.ts
+++ b/src/manifest.ts
@@ -46,20 +46,24 @@ type ExtraJsonFile = {
   type: 'json';
   path: string;
   jsonpath: string;
+  glob?: boolean;
 };
 type ExtraYamlFile = {
   type: 'yaml';
   path: string;
   jsonpath: string;
+  glob?: boolean;
 };
 type ExtraXmlFile = {
   type: 'xml';
   path: string;
   xpath: string;
+  glob?: boolean;
 };
 type ExtraPomFile = {
   type: 'pom';
   path: string;
+  glob?: boolean;
 };
 export type ExtraFile =
   | string

--- a/src/strategies/base.ts
+++ b/src/strategies/base.ts
@@ -352,6 +352,12 @@ export abstract class BaseStrategy implements Strategy {
           this.targetBranch
         )
       ).map(file => `/${file}`);
+    } else if (this.path === ROOT_PROJECT_PATH) {
+      // root component, ignore path prefix
+      return this.github.findFilesByGlobAndRef(
+        extraFile.path,
+        this.targetBranch
+      );
     } else {
       // glob is relative to current path
       return this.github.findFilesByGlobAndRef(

--- a/src/strategies/java.ts
+++ b/src/strategies/java.ts
@@ -137,7 +137,7 @@ export class Java extends BaseStrategy {
       isSnapshot: true,
     });
     const updatesWithExtras = mergeUpdates(
-      updates.concat(...this.extraFileUpdates(newVersion, versionsMap))
+      updates.concat(...(await this.extraFileUpdates(newVersion, versionsMap)))
     );
     return {
       title: pullRequestTitle,

--- a/test/fixtures/manifest/config/extra-files-glob.json
+++ b/test/fixtures/manifest/config/extra-files-glob.json
@@ -1,0 +1,30 @@
+{
+  "release-type": "simple",
+  "tag-separator": "/",
+  "extra-files": [
+    "default.txt",
+    {
+      "type": "json",
+      "path": "path/default.json",
+      "jsonpath": "$.version"
+    }
+  ],
+  "packages": {
+    ".": {
+      "component": "root",
+      "tag-separator": "-"
+    },
+    "packages/bot-config-utils": {
+      "component": "bot-config-utils",
+      "extra-files": [
+        "foo.txt",
+        {
+          "type": "json",
+          "path": "**/*.json",
+          "glob": true,
+          "jsonpath": "$.version"
+        }
+      ]
+    }
+  }
+}

--- a/test/strategies/base.ts
+++ b/test/strategies/base.ts
@@ -165,6 +165,35 @@ describe('Strategy', () => {
       assertHasUpdate(updates!, '0', Generic);
       assertHasUpdate(updates!, '3.xml', PomXml);
     });
+    it('updates extra glob files', async () => {
+      const findFilesStub = sandbox
+        .stub(github, 'findFilesByGlobAndRef')
+        .resolves(['3.xml']);
+      const strategy = new TestStrategy({
+        targetBranch: 'main',
+        github,
+        component: 'google-cloud-automl',
+        extraFiles: [
+          '0',
+          {
+            type: 'xml',
+            path: '**/*.xml',
+            xpath: '//project/version',
+            glob: true,
+          },
+        ],
+      });
+      const pullRequest = await strategy.buildReleasePullRequest(
+        [{sha: 'aaa', message: 'fix: a bugfix'}],
+        undefined
+      );
+      expect(pullRequest).to.exist;
+      const updates = pullRequest?.updates;
+      expect(updates).to.be.an('array');
+      assertHasUpdate(updates!, '0', Generic);
+      assertHasUpdate(updates!, '3.xml', GenericXml);
+      sinon.assert.calledOnceWithExactly(findFilesStub, '**/*.xml', 'main');
+    });
     it('should pass changelogHost to default buildNotes', async () => {
       const strategy = new TestStrategy({
         targetBranch: 'main',


### PR DESCRIPTION
When specifying `extra-files` in a manifest, you can add a `glob: true` entry and the `path` specified will be treated as a file glob.

Fixes #1619 
