### PR TITLE
fix(sentence-case): handle multiple : in subject

### DIFF
--- a/src/plugins/sentence-case.ts
+++ b/src/plugins/sentence-case.ts
@@ -49,9 +49,10 @@ export class SentenceCase extends ManifestPlugin {
       // Check whether commit is in conventional commit format, if it is
       // we'll split the string by type and description:
       if (commit.message.includes(':')) {
-        let [prefix, suffix] = commit.message.split(':');
+        const splitMessage = commit.message.split(':');
+        let prefix = splitMessage[0];
         prefix += ': ';
-        suffix = suffix.trim();
+        let suffix = splitMessage.slice(1).join(':').trim();
         // Extract the first word from the rest of the string:
         const match = /\s|$/.exec(suffix);
         if (match) {

--- a/test/plugins/sentence-case.ts
+++ b/test/plugins/sentence-case.ts
@@ -88,4 +88,14 @@ describe('SentenceCase Plugin', () => {
     expect(commits[0].message).to.equal('fix: hello world');
     expect(commits[1].message).to.equal('fix: Goodnight moon');
   });
+  it('handles subject with multiple : characters', async () => {
+    const plugin = new SentenceCase(github, 'main', {}, []);
+    const commits = await plugin.processCommits([
+      {
+        sha: 'abc123',
+        message: 'fix: hello world:goodnight moon',
+      },
+    ]);
+    expect(commits[0].message).to.equal('fix: Hello world:goodnight moon');
+  });
 });

--- a/test/plugins/sentence-case.ts
+++ b/test/plugins/sentence-case.ts
@@ -98,4 +98,17 @@ describe('SentenceCase Plugin', () => {
     ]);
     expect(commits[0].message).to.equal('fix: Hello world:goodnight moon');
   });
+  it('handles commit with no :', async () => {
+    const plugin = new SentenceCase(github, 'main', {}, []);
+    const commits = await plugin.processCommits([
+      {
+        sha: 'abc123',
+        message: 'hello world goodnight moon',
+      },
+    ]);
+    // Ensure there's no exception, a commit without a <type> is not
+    // a conventional commit, and will not show up in CHANGELOG. We
+    // Do not bother sentence-casing:
+    expect(commits[0].message).to.equal('hello world goodnight moon');
+  });
 });


### PR DESCRIPTION
Address bug with sentence case plugin when a commit has multiple `:` characters.
