### PR TITLE
fix: detect overlaping prefixes

### DIFF
--- a/src/util/commit-split.ts
+++ b/src/util/commit-split.ts
@@ -72,7 +72,7 @@ export class CommitSplit {
         for (let exPath of paths) {
           exPath = exPath.replace(/$/, '/');
           exPath = exPath.replace(/^/, '/');
-          if (newPath.indexOf(exPath) >= 0 || exPath.indexOf(newPath) >= 0) {
+          if (newPath.startsWith(exPath) || exPath.startsWith(newPath)) {
             throw new Error(
               `Path prefixes must be unique: ${newPath}, ${exPath}`
             );

--- a/test/util/commit-split.ts
+++ b/test/util/commit-split.ts
@@ -34,10 +34,27 @@ describe('CommitSplit', () => {
       message: 'empty files',
       files: [],
     },
+    {
+      sha: 'hij',
+      message: 'path prefixes',
+      files: ['pkg5/foo.txt', 'pkg6/pkg5/foo.txt'],
+    },
   ];
   it('defaults to excluding empty commits', () => {
     const commitSplit = new CommitSplit();
     expect(commitSplit.includeEmpty).to.be.false;
+  });
+  it('uses path prefixes', () => {
+    const commitSplit = new CommitSplit({
+      packagePaths: ['pkg5', 'pkg6/pkg5'],
+    });
+    const splitCommits = commitSplit.split(commits);
+    expect(splitCommits['pkg1']).to.be.undefined;
+    expect(splitCommits['pkg2']).to.be.undefined;
+    expect(splitCommits['pkg3']).to.be.undefined;
+    expect(splitCommits['pkg4']).to.be.undefined;
+    expect(splitCommits['pkg5']).lengthOf(1);
+    expect(splitCommits['pkg6/pkg5']).lengthOf(1);
   });
   describe('including empty commits', () => {
     it('should separate commits', () => {


### PR DESCRIPTION
Previously two prefixes were considered overlapping if one was contained in the other. For example `/config/` and `/aws/config/` would fail even though the prefix is unique.

Fixes: #1637

Thank you for opening a Pull Request! Before submitting your PR, there are a few things you can do to make sure it goes smoothly:
- [x] Make sure to open an issue as a [bug/issue](https://github.com/googleapis/release-please/issues/new/choose) before writing your code!  That way we can discuss the change, evaluate designs, and agree on the general idea
- [x] Ensure the tests and linter pass
- [x] Code coverage does not decrease (if any source code was changed)
- [ ] Appropriate docs were updated (if necessary)

Fixes #1637
