### PR TITLE
feat: add optional group attribute for candidate release PRs

### DIFF
--- a/__snapshots__/merge.js
+++ b/__snapshots__/merge.js
@@ -54,3 +54,36 @@ Release notes for path: node, releaseType: node
 ---
 This PR was generated with [Release Please](https://github.com/googleapis/release-please). See [documentation](https://github.com/googleapis/release-please#release-please).
 `
+
+exports['Merge plugin run separates pull requests by scope 1'] = `
+:robot: I have created a release *beep* *boop*
+---
+
+
+<details><summary>@here/pkgA: 3.3.4</summary>
+
+Release notes for path: node, releaseType: node
+</details>
+
+<details><summary>@here/pkgB: 4.4.5</summary>
+
+Release notes for path: node, releaseType: node
+</details>
+
+---
+This PR was generated with [Release Please](https://github.com/googleapis/release-please). See [documentation](https://github.com/googleapis/release-please#release-please).
+`
+
+exports['Merge plugin run separates pull requests by scope 2'] = `
+:robot: I have created a release *beep* *boop*
+---
+
+
+<details><summary>python-pkg: 1.0.0</summary>
+
+Release notes for path: python, releaseType: python
+</details>
+
+---
+This PR was generated with [Release Please](https://github.com/googleapis/release-please). See [documentation](https://github.com/googleapis/release-please#release-please).
+`

--- a/src/plugins/merge.ts
+++ b/src/plugins/merge.ts
@@ -119,6 +119,7 @@ export class Merge extends ManifestPlugin {
       labels: Array.from(labels),
       headRefName,
       draft: !inScopeCandidates.some(candidate => !candidate.pullRequest.draft),
+      group,
     };
 
     const releaseTypes = new Set(

--- a/src/release-pull-request.ts
+++ b/src/release-pull-request.ts
@@ -24,5 +24,6 @@ export interface ReleasePullRequest {
   readonly headRefName: string;
   readonly version?: Version;
   readonly draft: boolean;
+  readonly group?: string;
   updates: Update[];
 }

--- a/src/strategies/java.ts
+++ b/src/strategies/java.ts
@@ -147,6 +147,7 @@ export class Java extends BaseStrategy {
       headRefName: branchName.toString(),
       version: newVersion,
       draft: draft ?? false,
+      group: 'snapshot',
     };
   }
 

--- a/src/util/branch-name.ts
+++ b/src/util/branch-name.ts
@@ -29,6 +29,7 @@ function getAllResourceNames(): BranchNameType[] {
     AutoreleaseBranchName,
     ComponentBranchName,
     DefaultBranchName,
+    GroupedBranchName,
     V12ComponentBranchName,
     V12DefaultBranchName,
   ];
@@ -76,6 +77,14 @@ export class BranchName {
   ): BranchName {
     return new ComponentBranchName(
       `${RELEASE_PLEASE}--branches--${targetBranch}--components--${component}`
+    );
+  }
+  static ofGroupedTargetBranch(
+    targetBranch: string,
+    group: string
+  ): BranchName {
+    return new GroupedBranchName(
+      `${RELEASE_PLEASE}--branches--${targetBranch}--group--${group}`
     );
   }
   constructor(_branchName: string) {}
@@ -209,5 +218,24 @@ class ComponentBranchName extends BranchName {
   }
   toString(): string {
     return `${RELEASE_PLEASE}--branches--${this.targetBranch}--components--${this.component}`;
+  }
+}
+
+const GROUPED_SCOPE_PATTERN = `^${RELEASE_PLEASE}--branches--(?<branch>.+)--group--(?<group>.+)$`;
+class GroupedBranchName extends BranchName {
+  group?: string;
+  static matches(branchName: string): boolean {
+    return !!branchName.match(GROUPED_SCOPE_PATTERN);
+  }
+  constructor(branchName: string) {
+    super(branchName);
+    const match = branchName.match(GROUPED_SCOPE_PATTERN);
+    if (match?.groups) {
+      this.targetBranch = match.groups['branch'];
+      this.group = match.groups['group'];
+    }
+  }
+  toString(): string {
+    return `${RELEASE_PLEASE}--branches--${this.targetBranch}--group--${this.group}`;
   }
 }

--- a/test/helpers.ts
+++ b/test/helpers.ts
@@ -301,7 +301,8 @@ export function buildMockCandidatePullRequest(
   updates: Update[] = [],
   notes?: string,
   draft?: boolean,
-  labels: string[] = []
+  labels: string[] = [],
+  group?: string
 ): CandidateReleasePullRequest {
   const version = Version.parse(versionString);
   return {
@@ -322,6 +323,7 @@ export function buildMockCandidatePullRequest(
       headRefName: BranchName.ofTargetBranch('main').toString(),
       version,
       draft: draft ?? false,
+      group,
     },
     config: {
       releaseType,

--- a/test/plugins/merge.ts
+++ b/test/plugins/merge.ts
@@ -201,5 +201,83 @@ describe('Merge plugin', () => {
       ]);
       snapshot(dateSafe(candidate.pullRequest.body.toString()));
     });
+
+    it('separates pull requests by scope', async () => {
+      const candidates: CandidateReleasePullRequest[] = [
+        buildMockCandidatePullRequest(
+          'python',
+          'python',
+          '1.0.0',
+          'python-pkg',
+          [
+            {
+              path: 'path1/foo',
+              createIfMissing: false,
+              updater: new RawContent('foo'),
+            },
+          ]
+        ),
+        buildMockCandidatePullRequest(
+          'node',
+          'node',
+          '3.3.4',
+          '@here/pkgA',
+          [
+            {
+              path: 'path1/foo',
+              createIfMissing: false,
+              updater: new RawContent('bar'),
+            },
+            {
+              path: 'path2/foo',
+              createIfMissing: false,
+              updater: new RawContent('asdf'),
+            },
+          ],
+          undefined,
+          undefined,
+          undefined,
+          'snapshot'
+        ),
+
+        buildMockCandidatePullRequest(
+          'node',
+          'node',
+          '4.4.5',
+          '@here/pkgB',
+          [
+            {
+              path: 'path3/foo',
+              createIfMissing: false,
+              updater: new RawContent('bar'),
+            },
+            {
+              path: 'path4/foo',
+              createIfMissing: false,
+              updater: new RawContent('asdf'),
+            },
+          ],
+          undefined,
+          undefined,
+          undefined,
+          'snapshot'
+        ),
+      ];
+      const plugin = new Merge(github, 'main', {});
+      const newCandidates = await plugin.run(candidates);
+      expect(newCandidates).lengthOf(2);
+
+      const snapshotCandidate = newCandidates[0];
+      expect(snapshotCandidate!.pullRequest.headRefName).to.eql(
+        'release-please--branches--main--group--snapshot'
+      );
+      snapshot(dateSafe(snapshotCandidate!.pullRequest.body.toString()));
+
+      const candidate = newCandidates[1];
+      expect(candidate!.pullRequest.headRefName).to.eql(
+        'release-please--branches--main'
+      );
+      snapshot(dateSafe(candidate!.pullRequest.body.toString()));
+    });
   });
 });


### PR DESCRIPTION
Strategies can specify an optional `group` that a release pull request belongs to. The `merge` plugin will merge candidate release PRs by those `group` attributes.

Java strategies now mark the snapshot bump PRs with the `snapshot` group which should separate those from non-snapshot releases.

Fixes #1657
