### PR TITLE
feat: add `group-priority` plugin

### DIFF
--- a/docs/manifest-releaser.md
+++ b/docs/manifest-releaser.md
@@ -536,3 +536,39 @@ Bug Fixes:
 
 * Patch issues in OpenSSL`
 ```
+
+### group-priority
+
+This plugin allows you to configure pull request by priority. If enabled and if a pull request of a
+prioritized group is found, `release-please` will limit the proposed release pull requests to the
+prioritized group only.
+
+
+Example:
+
+```json
+{
+  "release-type": "java",
+  "packages": {
+    "packages/rustA": {
+      "component": "pkgA"
+    },
+    "packages/rustB": {
+      "component": "pkgB"
+    }
+  },
+  "plugins": [
+    {
+      "type": "group-priority",
+      "groups": ["snapshot"]
+    }
+  ]
+}
+```
+
+In the above example, java snapshot PRs are now marked as part of the snapshot group. If you
+configure the `group-priority` plugin with the group set to ['snapshot'], then `release-please`
+will only open pull requests for snapshot pull requests if there are any. This would avoid a
+mix/match of snapshot and non-snapshot version bumps.
+
+The `groups` option is a list of group names sorted with the highest priority first.

--- a/schemas/config.json
+++ b/schemas/config.json
@@ -296,6 +296,24 @@
                 }
               },
               {
+                "description": "Configuration for various `group-priority` plugin",
+                "type": "object",
+                "properties": {
+                  "type": {
+                    "description": "The name of the plugin.",
+                    "type": "string",
+                    "enum": ["group-priority"]
+                  },
+                  "groups": {
+                    "description": "Whether to force updating all packages regardless of the dependency tree. Defaults to `false`.",
+                    "type": "array",
+                    "items": {
+                      "type": "string"
+                    }
+                  }
+                }
+              },
+              {
                 "description": "Other plugins",
                 "type": "object",
                 "properties": {

--- a/schemas/config.json
+++ b/schemas/config.json
@@ -305,7 +305,7 @@
                     "enum": ["group-priority"]
                   },
                   "groups": {
-                    "description": "Whether to force updating all packages regardless of the dependency tree. Defaults to `false`.",
+                    "description": "Group names ordered with highest priority first.",
                     "type": "array",
                     "items": {
                       "type": "string"

--- a/src/factories/plugin-factory.ts
+++ b/src/factories/plugin-factory.ts
@@ -17,6 +17,7 @@ import {
   PluginType,
   RepositoryConfig,
   SentenceCasePluginConfig,
+  GroupPriorityPluginConfig,
 } from '../manifest';
 import {GitHub} from '../github';
 import {ManifestPlugin} from '../plugin';
@@ -27,6 +28,7 @@ import {VersioningStrategyType} from './versioning-strategy-factory';
 import {MavenWorkspace} from '../plugins/maven-workspace';
 import {ConfigurationError} from '../errors';
 import {SentenceCase} from '../plugins/sentence-case';
+import {GroupPriority} from '../plugins/group-priority';
 
 export interface PluginFactoryOptions {
   type: PluginType;
@@ -80,6 +82,13 @@ const pluginFactories: Record<string, PluginBuilder> = {
       options.targetBranch,
       options.repositoryConfig,
       (options.type as SentenceCasePluginConfig).specialWords
+    ),
+  'group-priority': options =>
+    new GroupPriority(
+      options.github,
+      options.targetBranch,
+      options.repositoryConfig,
+      (options.type as GroupPriorityPluginConfig).groups
     ),
 };
 

--- a/src/manifest.ts
+++ b/src/manifest.ts
@@ -198,9 +198,13 @@ export interface SentenceCasePluginConfig extends ConfigurablePluginType {
 export interface WorkspacePluginConfig extends ConfigurablePluginType {
   merge?: boolean;
 }
+export interface GroupPriorityPluginConfig extends ConfigurablePluginType {
+  groups: string[];
+}
 export type PluginType =
   | DirectPluginType
   | ConfigurablePluginType
+  | GroupPriorityPluginConfig
   | LinkedVersionPluginConfig
   | SentenceCasePluginConfig
   | WorkspacePluginConfig;

--- a/src/plugins/group-priority.ts
+++ b/src/plugins/group-priority.ts
@@ -1,0 +1,93 @@
+// Copyright 2022 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import {ManifestPlugin} from '../plugin';
+import {GitHub} from '../github';
+import {RepositoryConfig, CandidateReleasePullRequest} from '../manifest';
+
+/**
+ * This plugin allows configuring a priority of release groups. For example, you could
+ * prioritize Java snapshot pull requests over other releases.
+ */
+export class GroupPriority extends ManifestPlugin {
+  readonly groups: string[];
+  constructor(
+    github: GitHub,
+    targetBranch: string,
+    repositoryConfig: RepositoryConfig,
+    groups: string[]
+  ) {
+    super(github, targetBranch, repositoryConfig);
+    this.groups = groups;
+  }
+
+  /**
+   * Group candidate release PRs by grouping and check our list of preferred
+   * groups in order. If a preferred group is found, only return pull requests for
+   * that group.
+   * @param {CandidateReleasePullRequest[]} pullRequests Candidate pull requests
+   * @returns {CandidateReleasePullRequest[]} Possibly a subset of the candidate
+   *   pull requests if a preferred group is found.
+   */
+  async run(
+    pullRequests: CandidateReleasePullRequest[]
+  ): Promise<CandidateReleasePullRequest[]> {
+    this.logger.debug(
+      `Group priority plugin running with groups: ${this.groups}`
+    );
+    const groupedCandidates = groupCandidatesByType(pullRequests);
+    for (const group of this.groups) {
+      this.logger.debug(`Considering group: ${group}`);
+      const groupCandidates = groupedCandidates.get(group);
+      if (groupCandidates) {
+        this.logger.debug(
+          `Found preferred group: ${group} with ${groupCandidates.length} candidate pull requests`
+        );
+        return groupCandidates;
+      }
+    }
+
+    // fallback to returning all candidates
+    this.logger.debug('No preferred group found, returning full set.');
+    return pullRequests;
+  }
+}
+
+/**
+ * Helper to group candidates by their `type` field.
+ * @param {CandidateReleasePullRequest[]} inScopeCandidates The candidates to group.
+ * @returns {Map<string|undefined, CandidateReleasePullRequest[]>} The grouped
+ *   pull requests.
+ */
+function groupCandidatesByType(
+  inScopeCandidates: CandidateReleasePullRequest[]
+): Map<string | undefined, CandidateReleasePullRequest[]> {
+  const groupedCandidates: Map<
+    string | undefined,
+    CandidateReleasePullRequest[]
+  > = new Map();
+  for (const candidatePullRequest of inScopeCandidates) {
+    const candidates = groupedCandidates.get(
+      candidatePullRequest.pullRequest.group
+    );
+    if (candidates) {
+      candidates.push(candidatePullRequest);
+    } else {
+      groupedCandidates.set(candidatePullRequest.pullRequest.group, [
+        candidatePullRequest,
+      ]);
+    }
+  }
+  return groupedCandidates;
+}

--- a/src/plugins/group-priority.ts
+++ b/src/plugins/group-priority.ts
@@ -22,6 +22,16 @@ import {RepositoryConfig, CandidateReleasePullRequest} from '../manifest';
  */
 export class GroupPriority extends ManifestPlugin {
   readonly groups: string[];
+
+  /**
+   * Instantiate a new GroupPriority plugin.
+   *
+   * @param {GitHub} github GitHub client
+   * @param {string} targetBranch Release branch
+   * @param {RepositoryConfig} repositoryConfig Parsed configuration for the entire
+   *   repository. This allows plugins to know how components interact.
+   * @param {string[]} groups List of group names ordered with highest priority first
+   */
   constructor(
     github: GitHub,
     targetBranch: string,

--- a/src/release-pull-request.ts
+++ b/src/release-pull-request.ts
@@ -24,5 +24,6 @@ export interface ReleasePullRequest {
   readonly headRefName: string;
   readonly version?: Version;
   readonly draft: boolean;
+  readonly group?: string;
   updates: Update[];
 }

--- a/src/strategies/base.ts
+++ b/src/strategies/base.ts
@@ -582,6 +582,11 @@ export abstract class BaseStrategy implements Strategy {
       return;
     }
 
+    if (!this.isPublishedVersion(version)) {
+      this.logger.warn(`Skipping non-published version: ${version.toString()}`);
+      return;
+    }
+
     const tag = new TagName(
       version,
       this.includeComponentInTag ? component : undefined,
@@ -598,6 +603,10 @@ export abstract class BaseStrategy implements Strategy {
       notes: notes || '',
       sha: mergedPullRequest.sha,
     };
+  }
+
+  isPublishedVersion(_version: Version): boolean {
+    return true;
   }
 
   /**

--- a/src/strategies/java.ts
+++ b/src/strategies/java.ts
@@ -147,6 +147,7 @@ export class Java extends BaseStrategy {
       headRefName: branchName.toString(),
       version: newVersion,
       draft: draft ?? false,
+      group: 'snapshot',
     };
   }
 

--- a/test/factories/plugin-factory.ts
+++ b/test/factories/plugin-factory.ts
@@ -24,6 +24,7 @@ import {expect} from 'chai';
 import {LinkedVersions} from '../../src/plugins/linked-versions';
 import {ManifestPlugin} from '../../src/plugin';
 import {GitHub} from '../../src';
+import {GroupPriority} from '../../src/plugins/group-priority';
 
 describe('PluginFactory', () => {
   let github: GitHub;
@@ -80,6 +81,20 @@ describe('PluginFactory', () => {
       });
       expect(plugin).to.not.be.undefined;
       expect(plugin).instanceof(LinkedVersions);
+    });
+    it('should build a group-priority config', () => {
+      const plugin = buildPlugin({
+        github,
+        type: {
+          type: 'group-priority',
+          groups: ['snapshot'],
+        },
+        targetBranch: 'target-branch',
+        repositoryConfig,
+        manifestPath: '.manifest.json',
+      });
+      expect(plugin).to.not.be.undefined;
+      expect(plugin).instanceof(GroupPriority);
     });
   });
   describe('getPluginTypes', () => {

--- a/test/fixtures/manifest/config/group-priority.json
+++ b/test/fixtures/manifest/config/group-priority.json
@@ -1,0 +1,18 @@
+{
+  "release-type": "java",
+  "packages": {
+    ".": {
+      "component": "root",
+      "tag-separator": "-"
+    },
+    "packages/bot-config-utils": {
+      "component": "bot-config-utils"
+    }
+  },
+  "plugins": [
+    {
+      "type": "group-priority",
+      "groups": ["snapshot"]
+    }
+  ]
+}

--- a/test/helpers.ts
+++ b/test/helpers.ts
@@ -299,6 +299,7 @@ interface MockCandidatePullRequestOptions {
   notes?: string;
   draft?: boolean;
   labels?: string[];
+  group?: string;
 }
 export function buildMockCandidatePullRequest(
   path: string,
@@ -325,6 +326,7 @@ export function buildMockCandidatePullRequest(
       headRefName: BranchName.ofTargetBranch('main').toString(),
       version,
       draft: options.draft ?? false,
+      group: options.group,
     },
     config: {
       releaseType,

--- a/test/helpers.ts
+++ b/test/helpers.ts
@@ -293,15 +293,18 @@ export function buildCommitFromFixture(name: string): Commit {
   return buildMockCommit(message);
 }
 
+interface MockCandidatePullRequestOptions {
+  component?: string;
+  updates?: Update[];
+  notes?: string;
+  draft?: boolean;
+  labels?: string[];
+}
 export function buildMockCandidatePullRequest(
   path: string,
   releaseType: ReleaseType,
   versionString: string,
-  component?: string,
-  updates: Update[] = [],
-  notes?: string,
-  draft?: boolean,
-  labels: string[] = []
+  options: MockCandidatePullRequestOptions = {}
 ): CandidateReleasePullRequest {
   const version = Version.parse(versionString);
   return {
@@ -310,18 +313,18 @@ export function buildMockCandidatePullRequest(
       title: PullRequestTitle.ofTargetBranch('main'),
       body: new PullRequestBody([
         {
-          component,
+          component: options.component,
           version,
           notes:
-            notes ??
+            options.notes ??
             `Release notes for path: ${path}, releaseType: ${releaseType}`,
         },
       ]),
-      updates,
-      labels,
+      updates: options.updates ?? [],
+      labels: options.labels ?? [],
       headRefName: BranchName.ofTargetBranch('main').toString(),
       version,
-      draft: draft ?? false,
+      draft: options.draft ?? false,
     },
     config: {
       releaseType,

--- a/test/plugins/cargo-workspace.ts
+++ b/test/plugins/cargo-workspace.ts
@@ -91,18 +91,15 @@ describe('CargoWorkspace plugin', () => {
     it('handles a single rust package', async () => {
       const candidates: CandidateReleasePullRequest[] = [
         buildMockCandidatePullRequest('python', 'python', '1.0.0'),
-        buildMockCandidatePullRequest(
-          'packages/rustA',
-          'rust',
-          '1.1.2',
-          'pkgA',
-          [
+        buildMockCandidatePullRequest('packages/rustA', 'rust', '1.1.2', {
+          component: 'pkgA',
+          updates: [
             buildMockPackageUpdate(
               'packages/rustA/Cargo.toml',
               'packages/rustA/Cargo.toml'
             ),
-          ]
-        ),
+          ],
+        }),
       ];
       stubFilesFromFixtures({
         sandbox,
@@ -136,30 +133,24 @@ describe('CargoWorkspace plugin', () => {
     });
     it('combines rust packages', async () => {
       const candidates: CandidateReleasePullRequest[] = [
-        buildMockCandidatePullRequest(
-          'packages/rustA',
-          'rust',
-          '1.1.2',
-          '@here/pkgA',
-          [
+        buildMockCandidatePullRequest('packages/rustA', 'rust', '1.1.2', {
+          component: '@here/pkgA',
+          updates: [
             buildMockPackageUpdate(
               'packages/rustA/Cargo.toml',
               'packages/rustA/Cargo.toml'
             ),
-          ]
-        ),
-        buildMockCandidatePullRequest(
-          'packages/rustD',
-          'rust',
-          '4.4.5',
-          '@here/pkgD',
-          [
+          ],
+        }),
+        buildMockCandidatePullRequest('packages/rustD', 'rust', '4.4.5', {
+          component: '@here/pkgD',
+          updates: [
             buildMockPackageUpdate(
               'packages/rustD/Cargo.toml',
               'packages/rustD/Cargo.toml'
             ),
-          ]
-        ),
+          ],
+        }),
       ];
       stubFilesFromFixtures({
         sandbox,
@@ -196,30 +187,24 @@ describe('CargoWorkspace plugin', () => {
     });
     it('walks dependency tree and updates previously untouched packages', async () => {
       const candidates: CandidateReleasePullRequest[] = [
-        buildMockCandidatePullRequest(
-          'packages/rustA',
-          'rust',
-          '1.1.2',
-          '@here/pkgA',
-          [
+        buildMockCandidatePullRequest('packages/rustA', 'rust', '1.1.2', {
+          component: '@here/pkgA',
+          updates: [
             buildMockPackageUpdate(
               'packages/rustA/Cargo.toml',
               'packages/rustA/Cargo.toml'
             ),
-          ]
-        ),
-        buildMockCandidatePullRequest(
-          'packages/rustD',
-          'rust',
-          '4.4.5',
-          '@here/pkgD',
-          [
+          ],
+        }),
+        buildMockCandidatePullRequest('packages/rustD', 'rust', '4.4.5', {
+          component: '@here/pkgD',
+          updates: [
             buildMockPackageUpdate(
               'packages/rustD/Cargo.toml',
               'packages/rustD/Cargo.toml'
             ),
-          ]
-        ),
+          ],
+        }),
       ];
       stubFilesFromFixtures({
         sandbox,
@@ -251,30 +236,24 @@ describe('CargoWorkspace plugin', () => {
     it('can skip merging rust packages', async () => {
       // This is the same setup as 'walks dependency tree and updates previously untouched packages'
       const candidates: CandidateReleasePullRequest[] = [
-        buildMockCandidatePullRequest(
-          'packages/rustA',
-          'rust',
-          '1.1.2',
-          '@here/pkgA',
-          [
+        buildMockCandidatePullRequest('packages/rustA', 'rust', '1.1.2', {
+          component: '@here/pkgA',
+          updates: [
             buildMockPackageUpdate(
               'packages/rustA/Cargo.toml',
               'packages/rustA/Cargo.toml'
             ),
-          ]
-        ),
-        buildMockCandidatePullRequest(
-          'packages/rustD',
-          'rust',
-          '4.4.5',
-          '@here/pkgD',
-          [
+          ],
+        }),
+        buildMockCandidatePullRequest('packages/rustD', 'rust', '4.4.5', {
+          component: '@here/pkgD',
+          updates: [
             buildMockPackageUpdate(
               'packages/rustD/Cargo.toml',
               'packages/rustD/Cargo.toml'
             ),
-          ]
-        ),
+          ],
+        }),
       ];
       stubFilesFromFixtures({
         sandbox,
@@ -315,31 +294,25 @@ describe('CargoWorkspace plugin', () => {
       const existingNotes =
         '### Dependencies\n\n* update dependency foo/bar to 1.2.3';
       const candidates: CandidateReleasePullRequest[] = [
-        buildMockCandidatePullRequest(
-          'packages/rustA',
-          'rust',
-          '1.1.2',
-          '@here/pkgA',
-          [
+        buildMockCandidatePullRequest('packages/rustA', 'rust', '1.1.2', {
+          component: '@here/pkgA',
+          updates: [
             buildMockPackageUpdate(
               'packages/rustA/Cargo.toml',
               'packages/rustA/Cargo.toml'
             ),
-          ]
-        ),
-        buildMockCandidatePullRequest(
-          'packages/rustB',
-          'rust',
-          '2.2.3',
-          '@here/pkgB',
-          [
+          ],
+        }),
+        buildMockCandidatePullRequest('packages/rustB', 'rust', '2.2.3', {
+          component: '@here/pkgB',
+          updates: [
             buildMockPackageUpdate(
               'packages/rustB/Cargo.toml',
               'packages/rustB/Cargo.toml'
             ),
           ],
-          existingNotes
-        ),
+          notes: existingNotes,
+        }),
       ];
       stubFilesFromFixtures({
         sandbox,
@@ -369,18 +342,15 @@ describe('CargoWorkspace plugin', () => {
     });
     it('skips component if not touched', async () => {
       const candidates: CandidateReleasePullRequest[] = [
-        buildMockCandidatePullRequest(
-          'packages/rustB',
-          'rust',
-          '2.3.0',
-          'pkgB',
-          [
+        buildMockCandidatePullRequest('packages/rustB', 'rust', '2.3.0', {
+          component: 'pkgB',
+          updates: [
             buildMockPackageUpdate(
               'packages/rustB/Cargo.toml',
               'packages/rustB/Cargo.toml'
             ),
-          ]
-        ),
+          ],
+        }),
       ];
       stubFilesFromFixtures({
         sandbox,

--- a/test/plugins/group-priority.ts
+++ b/test/plugins/group-priority.ts
@@ -1,0 +1,68 @@
+// Copyright 2022 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+import {describe, it, beforeEach} from 'mocha';
+import {expect} from 'chai';
+import {GitHub} from '../../src/github';
+import {GroupPriority} from '../../src/plugins/group-priority';
+import {CandidateReleasePullRequest} from '../../src/manifest';
+import {buildMockCandidatePullRequest} from '../helpers';
+
+describe('GroupPriority plugin', () => {
+  let github: GitHub;
+  beforeEach(async () => {
+    github = await GitHub.create({
+      owner: 'googleapis',
+      repo: 'node-test-repo',
+      defaultBranch: 'main',
+    });
+  });
+  describe('run', () => {
+    it('prioritizes a group', async () => {
+      const plugin = new GroupPriority(github, 'main', {}, ['snapshot']);
+      const candidates: CandidateReleasePullRequest[] = [
+        buildMockCandidatePullRequest('path1', 'java', '1.2.3-SNAPSHOT', {
+          component: 'component1',
+          group: 'snapshot',
+        }),
+        buildMockCandidatePullRequest('path2', 'java', '2.3.4', {
+          component: 'component2',
+        }),
+        buildMockCandidatePullRequest('path3', 'java', '3.4.5', {
+          component: 'component3',
+        }),
+      ];
+      const newCandidates = await plugin.run(candidates);
+      expect(newCandidates).lengthOf(1);
+      expect(newCandidates[0].path).to.eql('path1');
+    });
+    it('falls back to all pull requests if prioritized group not found', async () => {
+      const plugin = new GroupPriority(github, 'main', {}, ['snapshot']);
+      const candidates: CandidateReleasePullRequest[] = [
+        buildMockCandidatePullRequest('path1', 'java', '1.2.3', {
+          component: 'component1',
+          group: 'group1',
+        }),
+        buildMockCandidatePullRequest('path2', 'java', '2.3.4', {
+          component: 'component2',
+          group: 'group2',
+        }),
+        buildMockCandidatePullRequest('path3', 'java', '3.4.5', {
+          component: 'component3',
+        }),
+      ];
+      const newCandidates = await plugin.run(candidates);
+      expect(newCandidates).lengthOf(3);
+    });
+  });
+});

--- a/test/plugins/maven-workspace.ts
+++ b/test/plugins/maven-workspace.ts
@@ -62,9 +62,12 @@ describe('MavenWorkspace plugin', () => {
   describe('run', () => {
     it('handles a single maven package', async () => {
       const candidates: CandidateReleasePullRequest[] = [
-        buildMockCandidatePullRequest('maven4', 'maven', '4.4.5', 'maven4', [
-          buildMockPackageUpdate('maven4/pom.xml', 'maven4/pom.xml', '4.4.5'),
-        ]),
+        buildMockCandidatePullRequest('maven4', 'maven', '4.4.5', {
+          component: 'maven4',
+          updates: [
+            buildMockPackageUpdate('maven4/pom.xml', 'maven4/pom.xml', '4.4.5'),
+          ],
+        }),
       ];
       stubFilesFromFixtures({
         sandbox,
@@ -95,17 +98,19 @@ describe('MavenWorkspace plugin', () => {
     });
     it('appends to existing candidate', async () => {
       const candidates: CandidateReleasePullRequest[] = [
-        buildMockCandidatePullRequest('maven3', 'maven', '3.3.4', 'maven3', [
-          buildMockPackageUpdate('maven3/pom.xml', 'maven3/pom.xml', '3.3.4'),
-        ]),
-        buildMockCandidatePullRequest(
-          'maven4',
-          'maven',
-          '4.4.5',
-          'maven4',
-          [buildMockPackageUpdate('maven4/pom.xml', 'maven4/pom.xml', '4.4.5')],
-          '### Dependencies\n\n* Updated foo to v3'
-        ),
+        buildMockCandidatePullRequest('maven3', 'maven', '3.3.4', {
+          component: 'maven3',
+          updates: [
+            buildMockPackageUpdate('maven3/pom.xml', 'maven3/pom.xml', '3.3.4'),
+          ],
+        }),
+        buildMockCandidatePullRequest('maven4', 'maven', '4.4.5', {
+          component: 'maven4',
+          updates: [
+            buildMockPackageUpdate('maven4/pom.xml', 'maven4/pom.xml', '4.4.5'),
+          ],
+          notes: '### Dependencies\n\n* Updated foo to v3',
+        }),
       ];
       stubFilesFromFixtures({
         sandbox,
@@ -136,9 +141,12 @@ describe('MavenWorkspace plugin', () => {
     });
     it('walks dependency tree and updates previously untouched packages', async () => {
       const candidates: CandidateReleasePullRequest[] = [
-        buildMockCandidatePullRequest('maven1', 'maven', '1.1.2', 'maven1', [
-          buildMockPackageUpdate('maven1/pom.xml', 'maven1/pom.xml', '1.1.2'),
-        ]),
+        buildMockCandidatePullRequest('maven1', 'maven', '1.1.2', {
+          component: 'maven1',
+          updates: [
+            buildMockPackageUpdate('maven1/pom.xml', 'maven1/pom.xml', '1.1.2'),
+          ],
+        }),
       ];
       stubFilesFromFixtures({
         sandbox,
@@ -179,9 +187,12 @@ describe('MavenWorkspace plugin', () => {
           'extra/pom.xml',
         ]);
       const candidates: CandidateReleasePullRequest[] = [
-        buildMockCandidatePullRequest('maven1', 'maven', '1.1.2', 'maven1', [
-          buildMockPackageUpdate('maven1/pom.xml', 'maven1/pom.xml', '1.1.2'),
-        ]),
+        buildMockCandidatePullRequest('maven1', 'maven', '1.1.2', {
+          component: 'maven1',
+          updates: [
+            buildMockPackageUpdate('maven1/pom.xml', 'maven1/pom.xml', '1.1.2'),
+          ],
+        }),
       ];
       stubFilesFromFixtures({
         sandbox,

--- a/test/plugins/merge.ts
+++ b/test/plugins/merge.ts
@@ -62,31 +62,31 @@ describe('Merge plugin', () => {
 
     it('merges multiple pull requests into an aggregate', async () => {
       const candidates: CandidateReleasePullRequest[] = [
-        buildMockCandidatePullRequest(
-          'python',
-          'python',
-          '1.0.0',
-          'python-pkg',
-          [
+        buildMockCandidatePullRequest('python', 'python', '1.0.0', {
+          component: 'python-pkg',
+          updates: [
             {
               path: 'path1/foo',
               createIfMissing: false,
               updater: new RawContent('foo'),
             },
-          ]
-        ),
-        buildMockCandidatePullRequest('node', 'node', '3.3.4', '@here/pkgA', [
-          {
-            path: 'path1/foo',
-            createIfMissing: false,
-            updater: new RawContent('bar'),
-          },
-          {
-            path: 'path2/foo',
-            createIfMissing: false,
-            updater: new RawContent('asdf'),
-          },
-        ]),
+          ],
+        }),
+        buildMockCandidatePullRequest('node', 'node', '3.3.4', {
+          component: '@here/pkgA',
+          updates: [
+            {
+              path: 'path1/foo',
+              createIfMissing: false,
+              updater: new RawContent('bar'),
+            },
+            {
+              path: 'path2/foo',
+              createIfMissing: false,
+              updater: new RawContent('asdf'),
+            },
+          ],
+        }),
       ];
       const plugin = new Merge(github, 'main', {});
       const newCandidates = await plugin.run(candidates);
@@ -101,27 +101,21 @@ describe('Merge plugin', () => {
 
     it('merges multiple pull requests as a draft', async () => {
       const candidates: CandidateReleasePullRequest[] = [
-        buildMockCandidatePullRequest(
-          'python',
-          'python',
-          '1.0.0',
-          'python-pkg',
-          [
+        buildMockCandidatePullRequest('python', 'python', '1.0.0', {
+          component: 'python-pkg',
+          updates: [
             {
               path: 'path1/foo',
               createIfMissing: false,
               updater: new RawContent('foo'),
             },
           ],
-          'python notes',
-          true
-        ),
-        buildMockCandidatePullRequest(
-          'node',
-          'node',
-          '3.3.4',
-          '@here/pkgA',
-          [
+          notes: 'python notes',
+          draft: true,
+        }),
+        buildMockCandidatePullRequest('node', 'node', '3.3.4', {
+          component: '@here/pkgA',
+          updates: [
             {
               path: 'path1/foo',
               createIfMissing: false,
@@ -133,9 +127,9 @@ describe('Merge plugin', () => {
               updater: new RawContent('asdf'),
             },
           ],
-          'some notes',
-          true
-        ),
+          notes: 'some notes',
+          draft: true,
+        }),
       ];
       const plugin = new Merge(github, 'main', {});
       const newCandidates = await plugin.run(candidates);
@@ -151,28 +145,20 @@ describe('Merge plugin', () => {
 
     it('merges all labels for pull requests', async () => {
       const candidates: CandidateReleasePullRequest[] = [
-        buildMockCandidatePullRequest(
-          'python',
-          'python',
-          '1.0.0',
-          'python-pkg',
-          [
+        buildMockCandidatePullRequest('python', 'python', '1.0.0', {
+          component: 'python-pkg',
+          updates: [
             {
               path: 'path1/foo',
               createIfMissing: false,
               updater: new RawContent('foo'),
             },
           ],
-          undefined,
-          undefined,
-          ['label-a', 'label-b']
-        ),
-        buildMockCandidatePullRequest(
-          'node',
-          'node',
-          '3.3.4',
-          '@here/pkgA',
-          [
+          labels: ['label-a', 'label-b'],
+        }),
+        buildMockCandidatePullRequest('node', 'node', '3.3.4', {
+          component: '@here/pkgA',
+          updates: [
             {
               path: 'path1/foo',
               createIfMissing: false,
@@ -184,10 +170,8 @@ describe('Merge plugin', () => {
               updater: new RawContent('asdf'),
             },
           ],
-          undefined,
-          undefined,
-          ['label-a', 'label-c']
-        ),
+          labels: ['label-a', 'label-c'],
+        }),
       ];
       const plugin = new Merge(github, 'main', {});
       const newCandidates = await plugin.run(candidates);

--- a/test/plugins/node-workspace.ts
+++ b/test/plugins/node-workspace.ts
@@ -118,9 +118,12 @@ describe('NodeWorkspace plugin', () => {
     it('handles a single node package', async () => {
       const candidates: CandidateReleasePullRequest[] = [
         buildMockCandidatePullRequest('python', 'python', '1.0.0'),
-        buildMockCandidatePullRequest('node1', 'node', '3.3.4', '@here/pkgA', [
-          buildMockPackageUpdate('node1/package.json', 'node1/package.json'),
-        ]),
+        buildMockCandidatePullRequest('node1', 'node', '3.3.4', {
+          component: '@here/pkgA',
+          updates: [
+            buildMockPackageUpdate('node1/package.json', 'node1/package.json'),
+          ],
+        }),
       ];
       plugin = new NodeWorkspace(github, 'main', {
         python: {
@@ -142,15 +145,22 @@ describe('NodeWorkspace plugin', () => {
     });
     it('combines node packages', async () => {
       const candidates: CandidateReleasePullRequest[] = [
-        buildMockCandidatePullRequest('.', 'node', '5.5.6', '@here/root', [
-          buildMockPackageUpdate('package.json', 'package.json'),
-        ]),
-        buildMockCandidatePullRequest('node1', 'node', '3.3.4', '@here/pkgA', [
-          buildMockPackageUpdate('node1/package.json', 'node1/package.json'),
-        ]),
-        buildMockCandidatePullRequest('node4', 'node', '4.4.5', '@here/pkgD', [
-          buildMockPackageUpdate('node4/package.json', 'node4/package.json'),
-        ]),
+        buildMockCandidatePullRequest('.', 'node', '5.5.6', {
+          component: '@here/root',
+          updates: [buildMockPackageUpdate('package.json', 'package.json')],
+        }),
+        buildMockCandidatePullRequest('node1', 'node', '3.3.4', {
+          component: '@here/pkgA',
+          updates: [
+            buildMockPackageUpdate('node1/package.json', 'node1/package.json'),
+          ],
+        }),
+        buildMockCandidatePullRequest('node4', 'node', '4.4.5', {
+          component: '@here/pkgD',
+          updates: [
+            buildMockPackageUpdate('node4/package.json', 'node4/package.json'),
+          ],
+        }),
       ];
       stubFilesFromFixtures({
         sandbox,
@@ -185,12 +195,18 @@ describe('NodeWorkspace plugin', () => {
     });
     it('walks dependency tree and updates previously untouched packages', async () => {
       const candidates: CandidateReleasePullRequest[] = [
-        buildMockCandidatePullRequest('node1', 'node', '3.3.4', '@here/pkgA', [
-          buildMockPackageUpdate('node1/package.json', 'node1/package.json'),
-        ]),
-        buildMockCandidatePullRequest('node4', 'node', '4.4.5', '@here/pkgD', [
-          buildMockPackageUpdate('node4/package.json', 'node4/package.json'),
-        ]),
+        buildMockCandidatePullRequest('node1', 'node', '3.3.4', {
+          component: '@here/pkgA',
+          updates: [
+            buildMockPackageUpdate('node1/package.json', 'node1/package.json'),
+          ],
+        }),
+        buildMockCandidatePullRequest('node4', 'node', '4.4.5', {
+          component: '@here/pkgD',
+          updates: [
+            buildMockPackageUpdate('node4/package.json', 'node4/package.json'),
+          ],
+        }),
       ];
       stubFilesFromFixtures({
         sandbox,
@@ -241,20 +257,20 @@ describe('NodeWorkspace plugin', () => {
       const existingNotes =
         '### Dependencies\n\n* update dependency foo/bar to 1.2.3';
       const candidates: CandidateReleasePullRequest[] = [
-        buildMockCandidatePullRequest('node1', 'node', '3.3.4', '@here/pkgA', [
-          buildMockPackageUpdate('node1/package.json', 'node1/package.json'),
-          buildMockChangelogUpdate(
-            'node1/CHANGELOG.md',
-            '3.3.4',
-            'other notes'
-          ),
-        ]),
-        buildMockCandidatePullRequest(
-          'node2',
-          'node',
-          '2.2.3',
-          '@here/pkgB',
-          [
+        buildMockCandidatePullRequest('node1', 'node', '3.3.4', {
+          component: '@here/pkgA',
+          updates: [
+            buildMockPackageUpdate('node1/package.json', 'node1/package.json'),
+            buildMockChangelogUpdate(
+              'node1/CHANGELOG.md',
+              '3.3.4',
+              'other notes'
+            ),
+          ],
+        }),
+        buildMockCandidatePullRequest('node2', 'node', '2.2.3', {
+          component: '@here/pkgB',
+          updates: [
             buildMockPackageUpdate('node2/package.json', 'node2/package.json'),
             buildMockChangelogUpdate(
               'node2/CHANGELOG.md',
@@ -262,8 +278,8 @@ describe('NodeWorkspace plugin', () => {
               existingNotes
             ),
           ],
-          existingNotes
-        ),
+          notes: existingNotes,
+        }),
       ];
       stubFilesFromFixtures({
         sandbox,
@@ -308,9 +324,12 @@ describe('NodeWorkspace plugin', () => {
     });
     it('should ignore peer dependencies', async () => {
       const candidates: CandidateReleasePullRequest[] = [
-        buildMockCandidatePullRequest('node1', 'node', '3.3.4', '@here/pkgA', [
-          buildMockPackageUpdate('node1/package.json', 'node1/package.json'),
-        ]),
+        buildMockCandidatePullRequest('node1', 'node', '3.3.4', {
+          component: '@here/pkgA',
+          updates: [
+            buildMockPackageUpdate('node1/package.json', 'node1/package.json'),
+          ],
+        }),
       ];
       stubFilesFromFixtures({
         sandbox,


### PR DESCRIPTION
This plugin allows you to configure pull request by priority. If enabled and if a pull request of a prioritized group is found, release-please will limit the proposed release pull requests to the prioritized group only.

For example, java snapshot PRs are now marked as part of the `snapshot` group. If you configure the `group-priority` plugin with the group set to `['snapshot']`, then release-please will only open pull requests for `snapshot` pull requests if there are any.

Fixes #1657
