### PR TITLE
fix: escape html tags in release notes

### DIFF
--- a/__snapshots__/default-changelog-notes.js
+++ b/__snapshots__/default-changelog-notes.js
@@ -131,6 +131,15 @@ exports['DefaultChangelogNotes buildNotes with commit parsing should handle git 
 * some fix ([c538c97](https://github.com/googleapis/java-asset/commit/c538c973dc84b83ee6b699cf6433f0b3))
 `
 
+exports['DefaultChangelogNotes buildNotes with commit parsing should handle html tags 1'] = `
+## [1.2.3](https://github.com/googleapis/java-asset/compare/v1.2.2...v1.2.3) (1983-10-10)
+
+
+### Features
+
+* render all imagesets as &lt;picture&gt; ([ca4cdbd](https://github.com/googleapis/java-asset/commit/ca4cdbd75e4a93688c9c239802cf05dd))
+`
+
 exports['DefaultChangelogNotes buildNotes with commit parsing should handle meta commits 1'] = `
 ## [1.2.3](https://github.com/googleapis/java-asset/compare/v1.2.2...v1.2.3) (1983-10-10)
 

--- a/__snapshots__/default-changelog-notes.js
+++ b/__snapshots__/default-changelog-notes.js
@@ -137,7 +137,7 @@ exports['DefaultChangelogNotes buildNotes with commit parsing should handle html
 
 ### Features
 
-* render all imagesets as &lt;picture&gt; ([ca4cdbd](https://github.com/googleapis/java-asset/commit/ca4cdbd75e4a93688c9c239802cf05dd))
+* render all imagesets as &lt;picture&gt; ([383fb14](https://github.com/googleapis/java-asset/commit/383fb14708ae91f7bb7e64bf0bacab38))
 `
 
 exports['DefaultChangelogNotes buildNotes with commit parsing should handle meta commits 1'] = `

--- a/src/changelog-notes/default.ts
+++ b/src/changelog-notes/default.ts
@@ -72,7 +72,7 @@ export class DefaultChangelogNotes implements ChangelogNotes {
     const changelogCommits = commits.map(commit => {
       return {
         body: '', // commit.body,
-        subject: commit.bareMessage,
+        subject: htmlEscape(commit.bareMessage),
         type: commit.type,
         scope: commit.scope,
         notes: commit.notes.filter(note => note.title === 'BREAKING CHANGE'),
@@ -93,4 +93,8 @@ export class DefaultChangelogNotes implements ChangelogNotes {
       .parseArray(changelogCommits, context, preset.writerOpts)
       .trim();
   }
+}
+
+function htmlEscape(message: string): string {
+  return message.replace('<', '&lt;').replace('>', '&gt;');
 }

--- a/test/changelog-notes/default-changelog-notes.ts
+++ b/test/changelog-notes/default-changelog-notes.ts
@@ -242,6 +242,18 @@ describe('DefaultChangelogNotes', () => {
         expect(notes).to.is.string;
         safeSnapshot(notes);
       });
+      it('should handle html tags', async () => {
+        const commits = [
+          buildMockCommit('feat: render all imagesets as <picture>'),
+        ];
+        const changelogNotes = new DefaultChangelogNotes();
+        const notes = await changelogNotes.buildNotes(
+          parseConventionalCommits(commits),
+          notesOptions
+        );
+        expect(notes).to.is.string;
+        safeSnapshot(notes);
+      });
       // it('ignores reverted commits', async () => {
       //   const commits = [buildCommitFromFixture('multiple-messages')];
       //   const changelogNotes = new DefaultChangelogNotes();


### PR DESCRIPTION
The output of the `ChangelogNotes` interface is expected to be markdown content. We'll escape open/close angle brackets when we generate the notes.

Fixes #1659
