### PR TITLE
feat(maven-workspace): update all discovered pom.xml within the components

### DIFF
--- a/__snapshots__/maven-workspace.js
+++ b/__snapshots__/maven-workspace.js
@@ -21,6 +21,70 @@ Release notes for path: maven3, releaseType: maven
 This PR was generated with [Release Please](https://github.com/googleapis/release-please). See [documentation](https://github.com/googleapis/release-please#release-please).
 `
 
+exports['MavenWorkspace plugin run can consider all artifacts 1'] = `
+:robot: I have created a release *beep* *boop*
+---
+
+
+<details><summary>multi1: 1.1.2</summary>
+
+Release notes for path: multi1, releaseType: java-yoshi
+</details>
+
+<details><summary>com.google.example:my-bom: 1.2.4</summary>
+
+### Dependencies
+
+* The following workspace dependencies were updated
+    * com.google.example:multi1-bom bumped to 1.1.2,
+    * com.google.example:multi1-sub1 bumped to 2.2.3,
+    * com.google.example:multi1-sub2 bumped to 3.3.4
+</details>
+
+---
+This PR was generated with [Release Please](https://github.com/googleapis/release-please). See [documentation](https://github.com/googleapis/release-please#release-please).
+`
+
+exports['MavenWorkspace plugin run can consider all artifacts 2'] = `
+<?xml version="1.0" encoding="UTF-8"?>
+<project>
+  <groupId>com.google.example</groupId>
+  <artifactId>my-bom</artifactId>
+  <version>1.2.4</version>
+  <dependencyManagement>
+    <dependencies>
+      <dependency>
+        <groupId>com.google.example</groupId>
+        <artifactId>multi1-bom</artifactId>
+        <version>1.1.2</version>
+        <type>pom</type>
+        <scope>import</scope>
+      </dependency>
+      <dependency>
+        <groupId>com.google.example</groupId>
+        <artifactId>multi1-sub1</artifactId>
+        <version>2.2.3</version>
+      </dependency>
+      <dependency>
+        <groupId>com.google.example</groupId>
+        <artifactId>multi1-sub2</artifactId>
+        <version>3.3.4</version>
+      </dependency>
+      <dependency>
+        <groupId>com.google.example</groupId>
+        <artifactId>multi2-sub1</artifactId>
+        <version>5.5.5</version>
+      </dependency>
+      <dependency>
+        <groupId>com.google.example</groupId>
+        <artifactId>multi2-sub2</artifactId>
+        <version>6.6.6</version>
+      </dependency>
+    </dependencies>
+  </dependencyManagement>
+</project>
+`
+
 exports['MavenWorkspace plugin run handles a single maven package 1'] = `
 :robot: I have created a release *beep* *boop*
 ---

--- a/docs/manifest-releaser.md
+++ b/docs/manifest-releaser.md
@@ -478,13 +478,13 @@ way of managing a Rust monorepo with release-please.
 
 The `maven-workspace` plugin operates similarly to the `node-workspace` plugin,
 but on a multi-artifact Maven workspace. It builds a dependency graph of all
-discovered `pom.xml` files that are configured in the manifest config and updates
-any packages that were directly bumped by release-please.
+discovered `pom.xml` files and updates any packages that were directly bumped
+by release-please.
 
-If you have additional maven artifacts to consider for cross-component version
-bumping, you can set the `considerAllArtifacts` option to `true`. If you do so,
-the plugin will look at all `pom.xml` files and attempt to version bump
-artifacts within the repository.
+If you have additional `pom.xml` files that are not directly configured in your
+manifest and you want to skip updating them, then you can set the
+`considerAllArtifacts` option to `false`. If you do so, the plugin will only
+look at the `pom.xml` files configured in the manifest.
 
 ### linked-versions
 

--- a/docs/manifest-releaser.md
+++ b/docs/manifest-releaser.md
@@ -481,6 +481,11 @@ but on a multi-artifact Maven workspace. It builds a dependency graph of all
 discovered `pom.xml` files that are configured in the manifest config and updates
 any packages that were directly bumped by release-please.
 
+If you have additional maven artifacts to consider for cross-component version
+bumping, you can set the `considerAllArtifacts` option to `true`. If you do so,
+the plugin will look at all `pom.xml` files and attempt to version bump
+artifacts within the repository.
+
 ### linked-versions
 
 The `linked-versions` plugin allows you to "link" the versions of multiple

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "main": "./build/src/index.js",
   "bin": "./build/src/bin/release-please.js",
   "scripts": {
-    "test": "cross-env ENVIRONMENT=test LC_ALL=en c8 mocha --recursive --timeout=5000 build/test",
+    "test": "cross-env ENVIRONMENT=test LC_ALL=en mocha --recursive --timeout=5000 build/test",
     "docs": "echo add docs tests",
     "test:snap": "SNAPSHOT_UPDATE=1 LC_ALL=en npm test",
     "clean": "gts clean",

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "main": "./build/src/index.js",
   "bin": "./build/src/bin/release-please.js",
   "scripts": {
-    "test": "cross-env ENVIRONMENT=test LC_ALL=en mocha --recursive --timeout=5000 build/test",
+    "test": "cross-env ENVIRONMENT=test LC_ALL=en c8 mocha --recursive --timeout=5000 build/test",
     "docs": "echo add docs tests",
     "test:snap": "SNAPSHOT_UPDATE=1 LC_ALL=en npm test",
     "clean": "gts clean",

--- a/schemas/config.json
+++ b/schemas/config.json
@@ -292,6 +292,10 @@
                   "merge": {
                     "description": "Whether to merge in-scope pull requests into a combined release pull request. Defaults to `true`.",
                     "type": "boolean"
+                  },
+                  "considerAllArtifacts": {
+                    "description": "Whether to analyze all packages in the workspace for cross-component version bumping. This currently only works for the maven-workspace plugin.",
+                    "type": "boolean"
                   }
                 }
               },

--- a/schemas/config.json
+++ b/schemas/config.json
@@ -294,7 +294,7 @@
                     "type": "boolean"
                   },
                   "considerAllArtifacts": {
-                    "description": "Whether to analyze all packages in the workspace for cross-component version bumping. This currently only works for the maven-workspace plugin.",
+                    "description": "Whether to analyze all packages in the workspace for cross-component version bumping. This currently only works for the maven-workspace plugin. Defaults to `true`.",
                     "type": "boolean"
                   }
                 }

--- a/src/factories/plugin-factory.ts
+++ b/src/factories/plugin-factory.ts
@@ -29,6 +29,8 @@ import {MavenWorkspace} from '../plugins/maven-workspace';
 import {ConfigurationError} from '../errors';
 import {SentenceCase} from '../plugins/sentence-case';
 import {GroupPriority} from '../plugins/group-priority';
+import {Logger} from '../util/logger';
+import {WorkspacePluginOptions} from '../plugins/workspace';
 
 export interface PluginFactoryOptions {
   type: PluginType;
@@ -42,6 +44,9 @@ export interface PluginFactoryOptions {
 
   // workspace options
   updateAllPackages?: boolean;
+  considerAllArtifacts?: boolean;
+
+  logger?: Logger;
 }
 
 export type PluginBuilder = (options: PluginFactoryOptions) => ManifestPlugin;
@@ -60,21 +65,30 @@ const pluginFactories: Record<string, PluginBuilder> = {
       options.github,
       options.targetBranch,
       options.repositoryConfig,
-      options
+      {
+        ...options,
+        ...(options.type as WorkspacePluginOptions),
+      }
     ),
   'node-workspace': options =>
     new NodeWorkspace(
       options.github,
       options.targetBranch,
       options.repositoryConfig,
-      options
+      {
+        ...options,
+        ...(options.type as WorkspacePluginOptions),
+      }
     ),
   'maven-workspace': options =>
     new MavenWorkspace(
       options.github,
       options.targetBranch,
       options.repositoryConfig,
-      options
+      {
+        ...options,
+        ...(options.type as WorkspacePluginOptions),
+      }
     ),
   'sentence-case': options =>
     new SentenceCase(

--- a/src/manifest.ts
+++ b/src/manifest.ts
@@ -197,6 +197,7 @@ export interface SentenceCasePluginConfig extends ConfigurablePluginType {
 }
 export interface WorkspacePluginConfig extends ConfigurablePluginType {
   merge?: boolean;
+  considerAllArtifacts?: boolean;
 }
 export interface GroupPriorityPluginConfig extends ConfigurablePluginType {
   groups: string[];
@@ -644,6 +645,7 @@ export class Manifest {
         targetBranch: this.targetBranch,
         repositoryConfig: this.repositoryConfig,
         manifestPath: this.manifestPath,
+        logger: this.logger,
       })
     );
 

--- a/src/manifest.ts
+++ b/src/manifest.ts
@@ -650,18 +650,6 @@ export class Manifest {
       }
     }
 
-    // Build plugins
-    const plugins = this.plugins.map(pluginType =>
-      buildPlugin({
-        type: pluginType,
-        github: this.github,
-        targetBranch: this.targetBranch,
-        repositoryConfig: this.repositoryConfig,
-        manifestPath: this.manifestPath,
-        logger: this.logger,
-      })
-    );
-
     let strategies = strategiesByPath;
     for (const plugin of this.plugins) {
       strategies = await plugin.preconfigure(

--- a/src/plugins/maven-workspace.ts
+++ b/src/plugins/maven-workspace.ts
@@ -310,7 +310,7 @@ export class MavenWorkspace extends WorkspacePlugin<MavenArtifact> {
 
   protected bumpVersion(artifact: MavenArtifact): Version {
     const strategy = new JavaSnapshot(new AlwaysBumpPatch());
-    return strategy.bump(Version.parse(artifact.version), [fakeCommit]);
+    return strategy.bump(Version.parse(artifact.version), [FAKE_COMMIT]);
   }
 
   protected updateCandidate(
@@ -561,7 +561,11 @@ function parseMavenArtifact(
     pomContent,
   };
 }
-const fakeCommit: ConventionalCommit = {
+
+// We use a fake commit to leverage the Java versioning strategy
+// (it should be a patch version bump and potentially remove the
+// -SNAPSHOT portion of the version)
+const FAKE_COMMIT: ConventionalCommit = {
   message: 'fix: fake fix',
   type: 'fix',
   scope: null,

--- a/src/plugins/maven-workspace.ts
+++ b/src/plugins/maven-workspace.ts
@@ -79,7 +79,7 @@ export class MavenWorkspace extends WorkspacePlugin<MavenArtifact> {
     options: MavenWorkspacePluginOptions = {}
   ) {
     super(github, targetBranch, repositoryConfig, options);
-    this.considerAllArtifacts = options.considerAllArtifacts ?? false;
+    this.considerAllArtifacts = options.considerAllArtifacts ?? true;
   }
   private async fetchPom(path: string): Promise<MavenArtifact | undefined> {
     const content = await this.github.getFileContentsOnBranch(
@@ -184,7 +184,9 @@ export class MavenWorkspace extends WorkspacePlugin<MavenArtifact> {
       // Find artifacts that are in an existing candidate release
       return Array.from(graph.values())
         .filter(({value}) =>
-          candidatePaths.find(path => value.path.startsWith(`${path}/`))
+          candidatePaths.find(
+            path => value.path === path || value.path.startsWith(`${path}/`)
+          )
         )
         .map(({value}) => this.packageNameFromPackage(value));
     }
@@ -203,7 +205,7 @@ export class MavenWorkspace extends WorkspacePlugin<MavenArtifact> {
    *   map of all updated versions (component path => Version).
    */
   protected async buildUpdatedVersions(
-    graph: DependencyGraph<MavenArtifact>,
+    _graph: DependencyGraph<MavenArtifact>,
     orderedPackages: MavenArtifact[],
     candidatesByPackage: Record<string, CandidateReleasePullRequest>
   ): Promise<{updatedVersions: VersionsMap; updatedPathVersions: VersionsMap}> {
@@ -305,7 +307,6 @@ export class MavenWorkspace extends WorkspacePlugin<MavenArtifact> {
         value: mavenArtifact,
       });
     }
-    this.logger.debug('graph', graph);
     return graph;
   }
 

--- a/src/plugins/maven-workspace.ts
+++ b/src/plugins/maven-workspace.ts
@@ -70,7 +70,7 @@ const XPATH_PROJECT_DEPENDENCY_MANAGEMENT_DEPENDENCIES =
   '/*[local-name()="project"]/*[local-name()="dependencyManagement"]/*[local-name()="dependencies"]/*[local-name()="dependency"]';
 
 export class MavenWorkspace extends WorkspacePlugin<MavenArtifact> {
-  private considerAllArtifacts: boolean;
+  readonly considerAllArtifacts: boolean;
   constructor(
     github: GitHub,
     targetBranch: string,

--- a/src/plugins/workspace.ts
+++ b/src/plugins/workspace.ts
@@ -111,11 +111,12 @@ export abstract class WorkspacePlugin<T> extends ManifestPlugin {
     const orderedPackages = this.buildGraphOrder(graph, packageNamesToUpdate);
     this.logger.info(`Updating ${orderedPackages.length} packages`);
 
-    const {updatedVersions, updatedPathVersions} = await this.buildUpdatedVersions(
-      graph,
-      orderedPackages,
-      candidatesByPackage
-    );
+    const {updatedVersions, updatedPathVersions} =
+      await this.buildUpdatedVersions(
+        graph,
+        orderedPackages,
+        candidatesByPackage
+      );
 
     let newCandidates: CandidateReleasePullRequest[] = [];
     // In some cases, there are multiple packages within a single candidate. We
@@ -410,7 +411,6 @@ export abstract class WorkspacePlugin<T> extends ManifestPlugin {
 
     // invert the graph so it's dependency name => packages that depend on it
     const dependentGraph = this.invertGraph(graph);
-    this.logger.debug('dependent graph', dependentGraph);
     const visited: Set<T> = new Set();
 
     // we're iterating the `Map` in insertion order (as per ECMA262), but
@@ -420,7 +420,6 @@ export abstract class WorkspacePlugin<T> extends ManifestPlugin {
     for (const name of packageNamesToUpdate) {
       this.visitPostOrder(dependentGraph, name, visited, []);
     }
-    this.logger.debug('visited', visited);
 
     return Array.from(visited).sort((a, b) =>
       this.packageNameFromPackage(a).localeCompare(

--- a/src/plugins/workspace.ts
+++ b/src/plugins/workspace.ts
@@ -111,7 +111,7 @@ export abstract class WorkspacePlugin<T> extends ManifestPlugin {
     const orderedPackages = this.buildGraphOrder(graph, packageNamesToUpdate);
     this.logger.info(`Updating ${orderedPackages.length} packages`);
 
-    const {updatedVersions, updatedPathVersions} = this.buildUpdatedVersions(
+    const {updatedVersions, updatedPathVersions} = await this.buildUpdatedVersions(
       graph,
       orderedPackages,
       candidatesByPackage
@@ -246,11 +246,11 @@ export abstract class WorkspacePlugin<T> extends ManifestPlugin {
    * @returns A map of all updated versions (package name => Version) and a
    *   map of all updated versions (component path => Version).
    */
-  protected buildUpdatedVersions(
+  protected async buildUpdatedVersions(
     _graph: DependencyGraph<T>,
     orderedPackages: T[],
     candidatesByPackage: Record<string, CandidateReleasePullRequest>
-  ): {updatedVersions: VersionsMap; updatedPathVersions: VersionsMap} {
+  ): Promise<{updatedVersions: VersionsMap; updatedPathVersions: VersionsMap}> {
     const updatedVersions: VersionsMap = new Map();
     const updatedPathVersions: VersionsMap = new Map();
     for (const pkg of orderedPackages) {

--- a/src/util/logger.ts
+++ b/src/util/logger.ts
@@ -60,7 +60,7 @@ export class CheckpointLogger implements Logger {
 }
 /* eslint-enable @typescript-eslint/no-explicit-any */
 
-export let logger: Logger = new CheckpointLogger();
+export let logger: Logger = new CheckpointLogger(true);
 
 export function setLogger(userLogger: Logger) {
   logger = userLogger;

--- a/test/factories/plugin-factory.ts
+++ b/test/factories/plugin-factory.ts
@@ -39,6 +39,7 @@ describe('PluginFactory', () => {
   describe('buildPlugin', () => {
     const simplePluginTypes: PluginType[] = [
       'cargo-workspace',
+      'maven-workspace',
       'node-workspace',
     ];
     const repositoryConfig: RepositoryConfig = {

--- a/test/fixtures/manifest/config/maven-workspace-plugins.json
+++ b/test/fixtures/manifest/config/maven-workspace-plugins.json
@@ -1,0 +1,20 @@
+{
+  "release-type": "simple",
+  "plugins": [
+    {
+      "type": "maven-workspace",
+      "considerAllArtifacts": true
+    }
+  ],
+  "packages": {
+    "pkg1": {
+      "component": "pkg1"
+    },
+    "pkg2": {
+      "component": "pkg2"
+    },
+    "pkg3": {
+      "component": "pkg3"
+    }
+  }
+}

--- a/test/fixtures/plugins/maven-workspace/bom/pom.xml
+++ b/test/fixtures/plugins/maven-workspace/bom/pom.xml
@@ -1,0 +1,37 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project>
+  <groupId>com.google.example</groupId>
+  <artifactId>my-bom</artifactId>
+  <version>1.2.3</version>
+  <dependencyManagement>
+    <dependencies>
+      <dependency>
+        <groupId>com.google.example</groupId>
+        <artifactId>multi1-bom</artifactId>
+        <version>1.1.1</version>
+        <type>pom</type>
+        <scope>import</scope>
+      </dependency>
+      <dependency>
+        <groupId>com.google.example</groupId>
+        <artifactId>multi1-sub1</artifactId>
+        <version>2.2.2</version>
+      </dependency>
+      <dependency>
+        <groupId>com.google.example</groupId>
+        <artifactId>multi1-sub2</artifactId>
+        <version>3.3.3</version>
+      </dependency>
+      <dependency>
+        <groupId>com.google.example</groupId>
+        <artifactId>multi2-sub1</artifactId>
+        <version>5.5.5</version>
+      </dependency>
+      <dependency>
+        <groupId>com.google.example</groupId>
+        <artifactId>multi2-sub2</artifactId>
+        <version>6.6.6</version>
+      </dependency>
+    </dependencies>
+  </dependencyManagement>
+</project>

--- a/test/fixtures/plugins/maven-workspace/multi1/bom/pom.xml
+++ b/test/fixtures/plugins/maven-workspace/multi1/bom/pom.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project>
+  <groupId>com.google.example</groupId>
+  <artifactId>multi1-bom</artifactId>
+  <version>1.1.1</version>
+</project>

--- a/test/fixtures/plugins/maven-workspace/multi1/pom.xml
+++ b/test/fixtures/plugins/maven-workspace/multi1/pom.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project>
+  <groupId>com.google.example</groupId>
+  <artifactId>multi1-parent</artifactId>
+  <version>1.1.1</version>
+</project>

--- a/test/fixtures/plugins/maven-workspace/multi1/primary/pom.xml
+++ b/test/fixtures/plugins/maven-workspace/multi1/primary/pom.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project>
+  <groupId>com.google.example</groupId>
+  <artifactId>multi1</artifactId>
+  <version>1.1.1</version>
+</project>

--- a/test/fixtures/plugins/maven-workspace/multi1/sub1/pom.xml
+++ b/test/fixtures/plugins/maven-workspace/multi1/sub1/pom.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project>
+  <groupId>com.google.example</groupId>
+  <artifactId>multi1-sub1</artifactId>
+  <version>2.2.2</version>
+</project>

--- a/test/fixtures/plugins/maven-workspace/multi1/sub2/pom.xml
+++ b/test/fixtures/plugins/maven-workspace/multi1/sub2/pom.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project>
+  <groupId>com.google.example</groupId>
+  <artifactId>multi1-sub2</artifactId>
+  <version>3.3.3</version>
+</project>

--- a/test/fixtures/plugins/maven-workspace/multi2/bom/pom.xml
+++ b/test/fixtures/plugins/maven-workspace/multi2/bom/pom.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project>
+  <groupId>com.google.example</groupId>
+  <artifactId>multi2-bom</artifactId>
+  <version>4.4.4</version>
+</project>

--- a/test/fixtures/plugins/maven-workspace/multi2/pom.xml
+++ b/test/fixtures/plugins/maven-workspace/multi2/pom.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project>
+  <groupId>com.google.example</groupId>
+  <artifactId>multi2-parent</artifactId>
+  <version>4.4.4</version>
+</project>

--- a/test/fixtures/plugins/maven-workspace/multi2/primary/pom.xml
+++ b/test/fixtures/plugins/maven-workspace/multi2/primary/pom.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project>
+  <groupId>com.google.example</groupId>
+  <artifactId>multi2</artifactId>
+  <version>4.4.4</version>
+</project>

--- a/test/fixtures/plugins/maven-workspace/multi2/sub1/pom.xml
+++ b/test/fixtures/plugins/maven-workspace/multi2/sub1/pom.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project>
+  <groupId>com.google.example</groupId>
+  <artifactId>multi2-sub1</artifactId>
+  <version>5.5.5</version>
+</project>

--- a/test/fixtures/plugins/maven-workspace/multi2/sub2/pom.xml
+++ b/test/fixtures/plugins/maven-workspace/multi2/sub2/pom.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project>
+  <groupId>com.google.example</groupId>
+  <artifactId>multi2-sub2</artifactId>
+  <version>6.6.6</version>
+</project>

--- a/test/manifest.ts
+++ b/test/manifest.ts
@@ -53,6 +53,7 @@ import {
 import {RequestError} from '@octokit/request-error';
 import * as nock from 'nock';
 import {LinkedVersions} from '../src/plugins/linked-versions';
+import {MavenWorkspace} from '../src/plugins/maven-workspace';
 
 nock.disableNetConnect();
 
@@ -579,12 +580,10 @@ describe('Manifest', () => {
         github,
         github.repository.defaultBranch
       );
-      expect(manifest['plugins']).to.deep.equal([
-        {
-          type: 'maven-workspace',
-          considerAllArtifacts: true,
-        },
-      ]);
+      expect(manifest.plugins).lengthOf(1);
+      expect(manifest.plugins[0]).instanceOf(MavenWorkspace);
+      const plugin = manifest.plugins[0] as MavenWorkspace;
+      expect(plugin.considerAllArtifacts).to.be.true;
     });
     it('should configure search depth from manifest', async () => {
       const getFileContentsStub = sandbox.stub(

--- a/test/manifest.ts
+++ b/test/manifest.ts
@@ -538,6 +538,37 @@ describe('Manifest', () => {
         },
       ]);
     });
+    it('should build maven-workspace from manifest', async () => {
+      const getFileContentsStub = sandbox.stub(
+        github,
+        'getFileContentsOnBranch'
+      );
+      getFileContentsStub
+        .withArgs('release-please-config.json', 'main')
+        .resolves(
+          buildGitHubFileContent(
+            fixturesPath,
+            'manifest/config/maven-workspace-plugins.json'
+          )
+        )
+        .withArgs('.release-please-manifest.json', 'main')
+        .resolves(
+          buildGitHubFileContent(
+            fixturesPath,
+            'manifest/versions/versions.json'
+          )
+        );
+      const manifest = await Manifest.fromManifest(
+        github,
+        github.repository.defaultBranch
+      );
+      expect(manifest['plugins']).to.deep.equal([
+        {
+          type: 'maven-workspace',
+          considerAllArtifacts: true,
+        },
+      ]);
+    });
     it('should configure search depth from manifest', async () => {
       const getFileContentsStub = sandbox.stub(
         github,

--- a/test/plugins/maven-workspace.ts
+++ b/test/plugins/maven-workspace.ts
@@ -246,6 +246,30 @@ describe('MavenWorkspace plugin', () => {
       expect(newCandidates[0].pullRequest.body.releaseData).length(4);
     });
     it('skips pom files not configured for release', async () => {
+      plugin = new MavenWorkspace(
+        github,
+        'main',
+        {
+          bom: {
+            releaseType: 'maven',
+          },
+          maven1: {
+            releaseType: 'maven',
+          },
+          maven2: {
+            releaseType: 'maven',
+          },
+          maven3: {
+            releaseType: 'maven',
+          },
+          maven4: {
+            releaseType: 'maven',
+          },
+        },
+        {
+          considerAllArtifacts: false,
+        }
+      );
       sandbox
         .stub(github, 'findFilesByFilenameAndRef')
         .withArgs('pom.xml', 'main')

--- a/test/plugins/maven-workspace.ts
+++ b/test/plugins/maven-workspace.ts
@@ -23,6 +23,7 @@ import {
   buildGitHubFileContent,
   stubFilesFromFixtures,
   safeSnapshot,
+  assertHasUpdate,
 } from '../helpers';
 import {expect} from 'chai';
 import {Update} from '../../src/update';
@@ -42,6 +43,9 @@ describe('MavenWorkspace plugin', () => {
       defaultBranch: 'main',
     });
     plugin = new MavenWorkspace(github, 'main', {
+      bom: {
+        releaseType: 'maven',
+      },
       maven1: {
         releaseType: 'maven',
       },
@@ -212,6 +216,103 @@ describe('MavenWorkspace plugin', () => {
       safeSnapshot(newCandidates[0].pullRequest.body.toString());
       expect(newCandidates[0].pullRequest.body.releaseData).length(4);
     });
+    it('can consider all artifacts', async () => {
+      plugin = new MavenWorkspace(
+        github,
+        'main',
+        {
+          bom: {
+            component: 'my-bom',
+            releaseType: 'java-yoshi',
+          },
+          multi1: {
+            component: 'multi1',
+            releaseType: 'java-yoshi',
+          },
+          multi2: {
+            component: 'multi2',
+            releaseType: 'java-yoshi',
+          },
+        },
+        {
+          considerAllArtifacts: true,
+        }
+      );
+      const candidates: CandidateReleasePullRequest[] = [
+        buildMockCandidatePullRequest('multi1', 'java-yoshi', '1.1.2', {
+          component: 'multi1',
+          updates: [
+            buildMockPackageUpdate('multi1/pom.xml', 'multi1/pom.xml', '1.1.2'),
+            buildMockPackageUpdate(
+              'multi1/bom/pom.xml',
+              'multi1/bom/pom.xml',
+              '1.1.2'
+            ),
+            buildMockPackageUpdate(
+              'multi1/primary/pom.xml',
+              'multi1/primary/pom.xml',
+              '1.1.2'
+            ),
+            buildMockPackageUpdate(
+              'multi1/sub1/pom.xml',
+              'multi1/sub1/pom.xml',
+              '2.2.3'
+            ),
+            buildMockPackageUpdate(
+              'multi1/sub2/pom.xml',
+              'multi1/sub2/pom.xml',
+              '3.3.4'
+            ),
+          ],
+        }),
+      ];
+      stubFilesFromFixtures({
+        sandbox,
+        github,
+        fixturePath: fixturesPath,
+        files: [
+          'bom/pom.xml',
+          'multi1/pom.xml',
+          'multi1/bom/pom.xml',
+          'multi1/primary/pom.xml',
+          'multi1/sub1/pom.xml',
+          'multi1/sub2/pom.xml',
+          'multi2/pom.xml',
+          'multi2/bom/pom.xml',
+          'multi2/primary/pom.xml',
+          'multi2/sub1/pom.xml',
+          'multi2/sub2/pom.xml',
+        ],
+        flatten: false,
+        targetBranch: 'main',
+      });
+      sandbox
+        .stub(github, 'findFilesByFilenameAndRef')
+        .withArgs('pom.xml', 'main')
+        .resolves([
+          'bom/pom.xml',
+          'multi1/pom.xml',
+          'multi1/bom/pom.xml',
+          'multi1/primary/pom.xml',
+          'multi1/sub1/pom.xml',
+          'multi1/sub2/pom.xml',
+          'multi2/pom.xml',
+          'multi2/bom/pom.xml',
+          'multi2/primary/pom.xml',
+          'multi2/sub1/pom.xml',
+          'multi2/sub2/pom.xml',
+        ]);
+      const newCandidates = await plugin.run(candidates);
+      expect(newCandidates).length(1);
+      expect(newCandidates[0].pullRequest.body.releaseData).length(2);
+      safeSnapshot(newCandidates[0].pullRequest.body.toString());
+      const bomUpdate = assertHasUpdate(
+        newCandidates[0].pullRequest.updates,
+        'bom/pom.xml',
+        PomXml
+      );
+      safeSnapshot(await renderUpdate(github, bomUpdate));
+    });
   });
 });
 
@@ -227,4 +328,10 @@ function buildMockPackageUpdate(
     cachedFileContents,
     updater: new PomXml(Version.parse(newVersionString)),
   };
+}
+
+async function renderUpdate(github: GitHub, update: Update): Promise<string> {
+  const fileContents =
+    update.cachedFileContents || (await github.getFileContents(update.path));
+  return update.updater.updateContent(fileContents.parsedContent);
 }


### PR DESCRIPTION
Maven projects can have multiple artifacts within each component. When using the `maven-workspace` plugin, we would like to be able to version bump any of the artifacts in a released component.

Consider a repository with 3 components:
1. `bom`
2. `lib1`
3. `lib2`

The `bom` project is a bill of materials project that references the versions from libraries contained in `lib1` and `lib2`.

| pom file | artifact name | depends on |
| --- | --- | --- |
| bom/pom.xml | com.google.example:my-bom | com.google.example:lib1-bom, com.google.example:lib2-bom |
| lib1/pom.xml | com.google.example:lib1-parent | |
| lib1/bom/pom.xml | com.google.example:lib1-bom | |
| lib1/artifact1/pom.xml | com.google.example:lib1-artifact1 | |
| lib2/pom.xml | com.google.example:lib2-parent | |
| lib2/bom/pom.xml | com.google.example:lib2-bom | |
| lib2/artifact2/pom.xml | com.google.example:lib2-artifact2 | |

When `lib1` component is updated, we want to update the `bom` component. However, `bom` references `lib1-bom` and `lib1-artifact1` is the actual primary artifact name for that component.

With this PR, you can configure the `considerAllArtifacts` option for the `maven-workspace` plugin. If set, we actually look at every maven artifact declared in the repository and associate those artifacts with their component. It will update another component if any of those artifact versions has affected the other components.

Example config: https://github.com/chingor13/release-please-playground/blob/fd84c4a1c671812b9dbef736a00c083dc602b751/release-please-config.json#L1-L20
Example PR: https://github.com/chingor13/release-please-playground/pull/39

Fixes #1664
