### PR TITLE
feat: add ability to set extra labels on components

### DIFF
--- a/schemas/config.json
+++ b/schemas/config.json
@@ -66,12 +66,8 @@
           "description": "Open the release pull request in draft mode. Defaults to `false`.",
           "type": "boolean"
         },
-        "label": {
-          "description": "Comma-separated list of labels to add to newly opened pull request",
-          "type": "string"
-        },
-        "release-label": {
-          "description": "Comma-separated list of labels to add to a pull request that has been released/tagged",
+        "extra-label": {
+          "description": "Comma-separated list of labels to add to a newly opened pull request",
           "type": "string"
         },
         "include-component-in-tag": {
@@ -345,6 +341,14 @@
         "sequential-calls": {
           "description": "Whether to open pull requests/releases sequentially rather than concurrently. If you have many components, you may want to set this to avoid secondary rate limits.",
           "type": "boolean"
+        },
+        "label": {
+          "description": "Comma-separated list of labels to add to newly opened pull request. These are used to identify release pull requests.",
+          "type": "string"
+        },
+        "release-label": {
+          "description": "Comma-separated list of labels to add to a pull request that has been released/tagged",
+          "type": "string"
         }
       },
       "required": ["packages"]
@@ -373,6 +377,7 @@
     "draft-pull-request": true,
     "label": true,
     "release-label": true,
+    "extra-label": true,
     "include-component-in-tag": true,
     "include-v-in-tag": true,
     "changelog-type": true,

--- a/src/manifest.ts
+++ b/src/manifest.ts
@@ -98,6 +98,7 @@ export interface ReleaserConfig {
   separatePullRequests?: boolean;
   labels?: string[];
   releaseLabels?: string[];
+  extraLabels?: string[];
   initialVersion?: string;
 
   // Changelog options
@@ -140,6 +141,7 @@ interface ReleaserConfigJson {
   'draft-pull-request'?: boolean;
   label?: string;
   'release-label'?: string;
+  'extra-label'?: string;
   'include-component-in-tag'?: boolean;
   'include-v-in-tag'?: boolean;
   'changelog-type'?: ChangelogNotesType;
@@ -1222,6 +1224,7 @@ function extractReleaserConfig(
     separatePullRequests: config['separate-pull-requests'],
     labels: config['label']?.split(','),
     releaseLabels: config['release-label']?.split(','),
+    extraLabels: config['extra-label']?.split(','),
     skipSnapshot: config['skip-snapshot'],
     initialVersion: config['initial-version'],
   };
@@ -1260,6 +1263,7 @@ async function parseConfig(
   const configLabel = config['label'];
   const configReleaseLabel = config['release-label'];
   const configSnapshotLabel = config['snapshot-label'];
+  const configExtraLabel = config['extra-label'];
   const manifestOptions = {
     bootstrapSha: config['bootstrap-sha'],
     lastReleaseSha: config['last-release-sha'],
@@ -1270,6 +1274,7 @@ async function parseConfig(
     labels: configLabel?.split(','),
     releaseLabels: configReleaseLabel?.split(','),
     snapshotLabels: configSnapshotLabel?.split(','),
+    extraLabels: configExtraLabel?.split(','),
     releaseSearchDepth: config['release-search-depth'],
     commitSearchDepth: config['commit-search-depth'],
     sequentialCalls: config['sequential-calls'],
@@ -1555,6 +1560,7 @@ function mergeReleaserConfig(
       pathConfig.separatePullRequests ?? defaultConfig.separatePullRequests,
     skipSnapshot: pathConfig.skipSnapshot ?? defaultConfig.skipSnapshot,
     initialVersion: pathConfig.initialVersion ?? defaultConfig.initialVersion,
+    extraLabels: pathConfig.extraLabels ?? defaultConfig.extraLabels,
   };
 }
 

--- a/src/strategies/base.ts
+++ b/src/strategies/base.ts
@@ -79,6 +79,7 @@ export interface BaseStrategyOptions {
   skipSnapshot?: boolean; // Java-only
   logger?: Logger;
   initialVersion?: string;
+  extraLabels?: string[];
 }
 
 /**
@@ -105,6 +106,7 @@ export abstract class BaseStrategy implements Strategy {
   readonly pullRequestTitlePattern?: string;
   readonly pullRequestHeader?: string;
   readonly extraFiles: ExtraFile[];
+  readonly extraLabels: string[];
 
   readonly changelogNotes: ChangelogNotes;
 
@@ -137,6 +139,7 @@ export abstract class BaseStrategy implements Strategy {
     this.pullRequestHeader = options.pullRequestHeader;
     this.extraFiles = options.extraFiles || [];
     this.initialVersion = options.initialVersion;
+    this.extraLabels = options.extraLabels || [];
   }
 
   /**
@@ -329,7 +332,7 @@ export abstract class BaseStrategy implements Strategy {
       title: pullRequestTitle,
       body: pullRequestBody,
       updates: updatesWithExtras,
-      labels,
+      labels: [...labels, ...this.extraLabels],
       headRefName: branchName.toString(),
       version: newVersion,
       draft: draft ?? false,

--- a/src/strategies/java.ts
+++ b/src/strategies/java.ts
@@ -143,7 +143,7 @@ export class Java extends BaseStrategy {
       title: pullRequestTitle,
       body: pullRequestBody,
       updates: updatesWithExtras,
-      labels: labels,
+      labels: [...labels, ...this.extraLabels],
       headRefName: branchName.toString(),
       version: newVersion,
       draft: draft ?? false,

--- a/src/strategies/php-yoshi.ts
+++ b/src/strategies/php-yoshi.ts
@@ -194,7 +194,7 @@ export class PHPYoshi extends BaseStrategy {
       title: pullRequestTitle,
       body: pullRequestBody,
       updates,
-      labels,
+      labels: [...labels, ...this.extraLabels],
       headRefName: branchName.toString(),
       version: newVersion,
       draft: draft ?? false,

--- a/test/fixtures/manifest/config/extra-labels.json
+++ b/test/fixtures/manifest/config/extra-labels.json
@@ -1,0 +1,15 @@
+{
+  "release-type": "simple",
+  "label": "custom: pending",
+  "release-label": "custom: tagged",
+  "extra-label": "lang: java",
+  "packages": {
+    ".": {
+      "component": "root"
+    },
+    "node-lib": {
+      "component": "node-lib",
+      "extra-label": "lang: nodejs"
+    }
+  }
+}

--- a/test/manifest.ts
+++ b/test/manifest.ts
@@ -461,10 +461,25 @@ describe('Manifest', () => {
             'manifest/versions/versions.json'
           )
         );
+      const manifest = await Manifest.fromManifest(
+        github,
+        github.repository.defaultBranch
+      );
+      expect(manifest['labels']).to.deep.equal(['custom: pending']);
+      expect(manifest['releaseLabels']).to.deep.equal(['custom: tagged']);
+    });
+    it('should read extra labels from manifest', async () => {
+      const getFileContentsStub = sandbox.stub(
+        github,
+        'getFileContentsOnBranch'
+      );
       getFileContentsStub
         .withArgs('release-please-config.json', 'main')
         .resolves(
-          buildGitHubFileContent(fixturesPath, 'manifest/config/labels.json')
+          buildGitHubFileContent(
+            fixturesPath,
+            'manifest/config/extra-labels.json'
+          )
         )
         .withArgs('.release-please-manifest.json', 'main')
         .resolves(
@@ -477,8 +492,12 @@ describe('Manifest', () => {
         github,
         github.repository.defaultBranch
       );
-      expect(manifest['labels']).to.deep.equal(['custom: pending']);
-      expect(manifest['releaseLabels']).to.deep.equal(['custom: tagged']);
+      expect(manifest.repositoryConfig['.'].extraLabels).to.deep.equal([
+        'lang: java',
+      ]);
+      expect(manifest.repositoryConfig['node-lib'].extraLabels).to.deep.equal([
+        'lang: nodejs',
+      ]);
     });
     it('should build simple plugins from manifest', async () => {
       const getFileContentsStub = sandbox.stub(

--- a/test/strategies/base.ts
+++ b/test/strategies/base.ts
@@ -265,6 +265,20 @@ describe('Strategy', () => {
         }
       }
     });
+    it('handles extra labels', async () => {
+      const strategy = new TestStrategy({
+        targetBranch: 'main',
+        github,
+        component: 'google-cloud-automl',
+        extraLabels: ['foo', 'bar'],
+      });
+      const pullRequest = await strategy.buildReleasePullRequest(
+        [{sha: 'aaa', message: 'fix: a bugfix'}],
+        undefined
+      );
+      expect(pullRequest).to.exist;
+      expect(pullRequest?.labels).to.eql(['foo', 'bar']);
+    });
   });
   describe('buildRelease', () => {
     it('builds a release tag', async () => {


### PR DESCRIPTION
We are adding a new `extra-label` option which is non-load bearing (we use the existing `label` and `release-label` to indentify which PRs are release-please's and what state they are in).
This new option allows maintainers to organize their components (e.g. labeling with and API component label or perhaps a language)

Fixes #1624

BEGIN_NESTED_COMMIT
fix: fix schema definition for label and release-label

These fields are not actually configurable per-component.
END_NESTED_COMMIT
