### PR TITLE
fix: manifest config bootstrapper should include schema field

### DIFF
--- a/src/updaters/release-please-manifest.ts
+++ b/src/updaters/release-please-manifest.ts
@@ -15,7 +15,8 @@
 import {jsonStringify} from '../util/json-stringify';
 import {DefaultUpdater} from './default';
 
-const SCHEMA_URL = 'https://raw.githubusercontent.com/googleapis/release-please/main/schemas/config.json;'
+const SCHEMA_URL =
+  'https://raw.githubusercontent.com/googleapis/release-please/main/schemas/config.json;';
 
 export class ReleasePleaseManifest extends DefaultUpdater {
   updateContent(content: string): string {

--- a/src/updaters/release-please-manifest.ts
+++ b/src/updaters/release-please-manifest.ts
@@ -15,12 +15,15 @@
 import {jsonStringify} from '../util/json-stringify';
 import {DefaultUpdater} from './default';
 
+const SCHEMA_URL = 'https://raw.githubusercontent.com/googleapis/release-please/main/schemas/config.json;'
+
 export class ReleasePleaseManifest extends DefaultUpdater {
   updateContent(content: string): string {
     const parsed: Record<string, string> = content ? JSON.parse(content) : {};
     for (const [path, version] of this.versionsMap!) {
       parsed[path] = version.toString();
     }
+    parsed['$schema'] = SCHEMA_URL;
     if (content) {
       return jsonStringify(parsed, content);
     } else {


### PR DESCRIPTION
Add the `$schema` field to the bootstrapped manifest config file. This helps IDEs automatically lint the config schema as it's being edited.
Fixes the `--dry-run` argument for the bootstrap command to output what it would propose as a change

Fixes #1625
Fixes #1617

fix(cli): bootstrap command respects --dry-run argument