### PR TITLE
feat(cli): add debug command for loading a manifest config

### DIFF
--- a/src/plugins/linked-versions.ts
+++ b/src/plugins/linked-versions.ts
@@ -35,9 +35,9 @@ interface LinkedVersionsPluginOptions {
  * Release notes are broken up using `<summary>`/`<details>` blocks.
  */
 export class LinkedVersions extends ManifestPlugin {
-  private groupName: string;
-  private components: Set<string>;
-  private merge: boolean;
+  readonly groupName: string;
+  readonly components: Set<string>;
+  readonly merge: boolean;
 
   constructor(
     github: GitHub,

--- a/test/manifest.ts
+++ b/test/manifest.ts
@@ -52,6 +52,7 @@ import {
 } from '../src/errors';
 import {RequestError} from '@octokit/request-error';
 import * as nock from 'nock';
+import {LinkedVersions} from '../src/plugins/linked-versions';
 
 nock.disableNetConnect();
 
@@ -501,10 +502,9 @@ describe('Manifest', () => {
         github,
         github.repository.defaultBranch
       );
-      expect(manifest['plugins']).to.deep.equal([
-        'node-workspace',
-        'cargo-workspace',
-      ]);
+      expect(manifest.plugins).lengthOf(2);
+      expect(manifest.plugins[0]).instanceOf(NodeWorkspace);
+      expect(manifest.plugins[1]).instanceOf(CargoWorkspace);
     });
     it('should build complex plugins from manifest', async () => {
       const getFileContentsStub = sandbox.stub(
@@ -530,13 +530,11 @@ describe('Manifest', () => {
         github,
         github.repository.defaultBranch
       );
-      expect(manifest['plugins']).to.deep.equal([
-        {
-          type: 'linked-versions',
-          groupName: 'grouped components',
-          components: ['pkg2', 'pkg3'],
-        },
-      ]);
+      expect(manifest.plugins).lengthOf(1);
+      expect(manifest.plugins[0]).instanceOf(LinkedVersions);
+      const plugin = manifest.plugins[0] as LinkedVersions;
+      expect(plugin.groupName).to.eql('grouped components');
+      expect(plugin.components).to.eql(new Set(['pkg2', 'pkg3']));
     });
     it('should configure search depth from manifest', async () => {
       const getFileContentsStub = sandbox.stub(
@@ -2684,6 +2682,14 @@ describe('Manifest', () => {
       });
 
       it('should load and run a single plugins', async () => {
+        const mockPlugin = sandbox.createStubInstance(NodeWorkspace);
+        mockPlugin.run.returnsArg(0);
+        mockPlugin.preconfigure.returnsArg(0);
+        mockPlugin.processCommits.returnsArg(0);
+        sandbox
+          .stub(pluginFactory, 'buildPlugin')
+          .withArgs(sinon.match.has('type', 'node-workspace'))
+          .returns(mockPlugin);
         const manifest = new Manifest(
           github,
           'main',
@@ -2708,20 +2714,26 @@ describe('Manifest', () => {
             plugins: ['node-workspace'],
           }
         );
-        const mockPlugin = sandbox.createStubInstance(NodeWorkspace);
-        mockPlugin.run.returnsArg(0);
-        mockPlugin.preconfigure.returnsArg(0);
-        mockPlugin.processCommits.returnsArg(0);
-        sandbox
-          .stub(pluginFactory, 'buildPlugin')
-          .withArgs(sinon.match.has('type', 'node-workspace'))
-          .returns(mockPlugin);
         const pullRequests = await manifest.buildPullRequests();
         expect(pullRequests).not.empty;
         sinon.assert.calledOnce(mockPlugin.run);
       });
 
       it('should load and run multiple plugins', async () => {
+        const mockPlugin = sandbox.createStubInstance(NodeWorkspace);
+        mockPlugin.run.returnsArg(0);
+        mockPlugin.preconfigure.returnsArg(0);
+        mockPlugin.processCommits.returnsArg(0);
+        const mockPlugin2 = sandbox.createStubInstance(CargoWorkspace);
+        mockPlugin2.run.returnsArg(0);
+        mockPlugin2.preconfigure.returnsArg(0);
+        mockPlugin2.processCommits.returnsArg(0);
+        sandbox
+          .stub(pluginFactory, 'buildPlugin')
+          .withArgs(sinon.match.has('type', 'node-workspace'))
+          .returns(mockPlugin)
+          .withArgs(sinon.match.has('type', 'cargo-workspace'))
+          .returns(mockPlugin2);
         const manifest = new Manifest(
           github,
           'main',
@@ -2746,20 +2758,6 @@ describe('Manifest', () => {
             plugins: ['node-workspace', 'cargo-workspace'],
           }
         );
-        const mockPlugin = sandbox.createStubInstance(NodeWorkspace);
-        mockPlugin.run.returnsArg(0);
-        mockPlugin.preconfigure.returnsArg(0);
-        mockPlugin.processCommits.returnsArg(0);
-        const mockPlugin2 = sandbox.createStubInstance(CargoWorkspace);
-        mockPlugin2.run.returnsArg(0);
-        mockPlugin2.preconfigure.returnsArg(0);
-        mockPlugin2.processCommits.returnsArg(0);
-        sandbox
-          .stub(pluginFactory, 'buildPlugin')
-          .withArgs(sinon.match.has('type', 'node-workspace'))
-          .returns(mockPlugin)
-          .withArgs(sinon.match.has('type', 'cargo-workspace'))
-          .returns(mockPlugin2);
         const pullRequests = await manifest.buildPullRequests();
         expect(pullRequests).not.empty;
         sinon.assert.calledOnce(mockPlugin.run);
@@ -2767,6 +2765,14 @@ describe('Manifest', () => {
       });
 
       it('should apply plugin hook "processCommits"', async () => {
+        const mockPlugin = sandbox.createStubInstance(SentenceCase);
+        mockPlugin.run.returnsArg(0);
+        mockPlugin.preconfigure.returnsArg(0);
+        mockPlugin.processCommits.returnsArg(0);
+        sandbox
+          .stub(pluginFactory, 'buildPlugin')
+          .withArgs(sinon.match.has('type', 'sentence-case'))
+          .returns(mockPlugin);
         const manifest = new Manifest(
           github,
           'main',
@@ -2784,14 +2790,6 @@ describe('Manifest', () => {
             plugins: ['sentence-case'],
           }
         );
-        const mockPlugin = sandbox.createStubInstance(SentenceCase);
-        mockPlugin.run.returnsArg(0);
-        mockPlugin.preconfigure.returnsArg(0);
-        mockPlugin.processCommits.returnsArg(0);
-        sandbox
-          .stub(pluginFactory, 'buildPlugin')
-          .withArgs(sinon.match.has('type', 'sentence-case'))
-          .returns(mockPlugin);
         const pullRequests = await manifest.buildPullRequests();
         expect(pullRequests).not.empty;
         sinon.assert.calledOnce(mockPlugin.processCommits);


### PR DESCRIPTION
This will be useful for debugging manifest config files.

Example usage:
```bash
release-please debug-config \
  --token=${GITHUB_TOKEN} \
  --repo-url=googleapis/google-cloud-go \
  --config-file=release-please-config-yoshi-submodules.json \
  --manifest-file=.release-please-manifest-submodules.json \
  --debug
```
It will load the config and the latest versions and print the parsed configs to stdout.
