### PR TITLE
fix(maven-workspace): preserve original pom.xml updater when bumping dependencies

### DIFF
--- a/__snapshots__/maven-workspace.js
+++ b/__snapshots__/maven-workspace.js
@@ -21,6 +21,29 @@ Release notes for path: maven3, releaseType: maven
 This PR was generated with [Release Please](https://github.com/googleapis/release-please). See [documentation](https://github.com/googleapis/release-please#release-please).
 `
 
+exports['MavenWorkspace plugin run appends to existing candidate with special updater 1'] = `
+:robot: I have created a release *beep* *boop*
+---
+
+
+<details><summary>maven3: 3.3.4</summary>
+
+Release notes for path: maven3, releaseType: maven
+</details>
+
+<details><summary>maven4: 4.4.5</summary>
+
+### Dependencies
+
+* Updated foo to v3
+* The following workspace dependencies were updated
+    * com.google.example:maven3 bumped to 3.3.4
+</details>
+
+---
+This PR was generated with [Release Please](https://github.com/googleapis/release-please). See [documentation](https://github.com/googleapis/release-please#release-please).
+`
+
 exports['MavenWorkspace plugin run handles a single maven package 1'] = `
 :robot: I have created a release *beep* *boop*
 ---

--- a/src/plugins/maven-workspace.ts
+++ b/src/plugins/maven-workspace.ts
@@ -33,6 +33,7 @@ import {PullRequestTitle} from '../util/pull-request-title';
 import {PullRequestBody} from '../util/pull-request-body';
 import {BranchName} from '../util/branch-name';
 import {logger as defaultLogger, Logger} from '../util/logger';
+import {CompositeUpdater} from '../updaters/composite';
 
 interface Gav {
   groupId: string;
@@ -218,7 +219,7 @@ export class MavenWorkspace extends WorkspacePlugin<MavenArtifact> {
     existingCandidate.pullRequest.updates =
       existingCandidate.pullRequest.updates.map(update => {
         if (update.path === addPath(existingCandidate.path, 'pom.xml')) {
-          update.updater = updater;
+          update.updater = new CompositeUpdater(update.updater, updater);
         } else if (update.updater instanceof Changelog) {
           if (dependencyNotes) {
             update.updater.changelogEntry =

--- a/test/plugins/maven-workspace.ts
+++ b/test/plugins/maven-workspace.ts
@@ -23,11 +23,13 @@ import {
   buildGitHubFileContent,
   stubFilesFromFixtures,
   safeSnapshot,
+  assertHasUpdates,
 } from '../helpers';
 import {expect} from 'chai';
 import {Update} from '../../src/update';
 import {Version} from '../../src/version';
 import {PomXml} from '../../src/updaters/java/pom-xml';
+import {RawContent} from '../../src/updaters/raw-content';
 
 const sandbox = sinon.createSandbox();
 const fixturesPath = './test/fixtures/plugins/maven-workspace';
@@ -138,6 +140,70 @@ describe('MavenWorkspace plugin', () => {
       expect(newCandidates).length(1);
       safeSnapshot(newCandidates[0].pullRequest.body.toString());
       expect(newCandidates[0].pullRequest.body.releaseData).length(2);
+    });
+    it('appends to existing candidate with special updater', async () => {
+      const customUpdater = new RawContent('some content');
+      const candidates: CandidateReleasePullRequest[] = [
+        buildMockCandidatePullRequest('maven3', 'maven', '3.3.4', {
+          component: 'maven3',
+          updates: [
+            buildMockPackageUpdate('maven3/pom.xml', 'maven3/pom.xml', '3.3.4'),
+          ],
+        }),
+        buildMockCandidatePullRequest('maven4', 'maven', '4.4.5', {
+          component: 'maven4',
+          updates: [
+            {
+              path: 'maven4/pom.xml',
+              createIfMissing: false,
+              cachedFileContents: buildGitHubFileContent(
+                fixturesPath,
+                'maven4/pom.xml'
+              ),
+              updater: customUpdater,
+            },
+          ],
+          notes: '### Dependencies\n\n* Updated foo to v3',
+        }),
+      ];
+      stubFilesFromFixtures({
+        sandbox,
+        github,
+        fixturePath: fixturesPath,
+        files: [
+          'maven1/pom.xml',
+          'maven2/pom.xml',
+          'maven3/pom.xml',
+          'maven4/pom.xml',
+        ],
+        flatten: false,
+        targetBranch: 'main',
+      });
+      sandbox
+        .stub(github, 'findFilesByFilenameAndRef')
+        .withArgs('pom.xml', 'main')
+        .resolves([
+          'maven1/pom.xml',
+          'maven2/pom.xml',
+          'maven3/pom.xml',
+          'maven4/pom.xml',
+        ]);
+      const newCandidates = await plugin.run(candidates);
+      expect(newCandidates).length(1);
+      safeSnapshot(newCandidates[0].pullRequest.body.toString());
+      expect(newCandidates[0].pullRequest.body.releaseData).length(2);
+      assertHasUpdates(
+        newCandidates[0].pullRequest.updates,
+        'maven4/pom.xml',
+        RawContent,
+        PomXml
+      );
+      assertHasUpdates(
+        newCandidates[0].pullRequest.updates,
+        'maven3/pom.xml',
+        PomXml,
+        PomXml
+      );
     });
     it('walks dependency tree and updates previously untouched packages', async () => {
       const candidates: CandidateReleasePullRequest[] = [


### PR DESCRIPTION
When updating dependencies on a `pom.xml` in `maven-workspace` plugin, preserve the original `pom.xml` update -- do not assume it is a plain `PomXml` updater that can be overwritten.

Fixes #1676