### PR TITLE
feat: handle extremely large pull request body fields

### DIFF
--- a/__snapshots__/github.js
+++ b/__snapshots__/github.js
@@ -411,28 +411,6 @@ exports['GitHub commitsSince paginates through commits 1'] = [
   }
 ]
 
-exports['GitHub createFileOnNewBranch forks a new branch if the branch does not exist 1'] = {
-  "ref": "refs/heads/new-branch",
-  "sha": "abc123"
-}
-
-exports['GitHub createFileOnNewBranch forks a new branch if the branch does not exist 2'] = {
-  "content": "c29tZSBjb250ZW50cw==",
-  "message": "Saving release notes",
-  "branch": "new-branch"
-}
-
-exports['GitHub createFileOnNewBranch reuses an existing branch 1'] = {
-  "sha": "abc123",
-  "force": true
-}
-
-exports['GitHub createFileOnNewBranch reuses an existing branch 2'] = {
-  "content": "c29tZSBjb250ZW50cw==",
-  "message": "Saving release notes",
-  "branch": "new-branch"
-}
-
 exports['GitHub createRelease should create a draft release 1'] = {
   "tag_name": "v1.2.3",
   "body": "Some release notes",

--- a/__snapshots__/github.js
+++ b/__snapshots__/github.js
@@ -411,6 +411,28 @@ exports['GitHub commitsSince paginates through commits 1'] = [
   }
 ]
 
+exports['GitHub createFileOnNewBranch forks a new branch if the branch does not exist 1'] = {
+  "ref": "refs/heads/new-branch",
+  "sha": "abc123"
+}
+
+exports['GitHub createFileOnNewBranch forks a new branch if the branch does not exist 2'] = {
+  "content": "c29tZSBjb250ZW50cw==",
+  "message": "Saving release notes",
+  "branch": "new-branch"
+}
+
+exports['GitHub createFileOnNewBranch reuses an existing branch 1'] = {
+  "sha": "abc123",
+  "force": true
+}
+
+exports['GitHub createFileOnNewBranch reuses an existing branch 2'] = {
+  "content": "c29tZSBjb250ZW50cw==",
+  "message": "Saving release notes",
+  "branch": "new-branch"
+}
+
 exports['GitHub createRelease should create a draft release 1'] = {
   "tag_name": "v1.2.3",
   "body": "Some release notes",

--- a/__snapshots__/pull-request-overflow-handler.js
+++ b/__snapshots__/pull-request-overflow-handler.js
@@ -1,0 +1,77 @@
+exports['FilePullRequestOverflowHandler handleOverflow writes large pull request body contents to a file 1'] = `
+This release is too large to preview in the pull request body. View the full release notes here: https://github.com/test-owner/test-repo/blob/my-head-branch--release-notes/release-notes.md
+`
+
+exports['FilePullRequestOverflowHandler parseOverflow ignores small pull request body contents 1'] = `
+:robot: I have created a release \\*beep\\* \\*boop\\*
+---
+
+
+<details><summary>@google-automations/bot-config-utils: 3.2.0</summary>
+
+### Features
+
+* upgrade to gcf-utils@12 ([#2262](https://www.github.com/googleapis/repo-automation-bots/issues/2262)) ([bd04376](https://www.github.com/googleapis/repo-automation-bots/commit/bd043767ae59a4eed450f1d18741111dc4c3f8e8))
+</details>
+
+<details><summary>@google-automations/label-utils: 1.1.0</summary>
+
+### Features
+
+* upgrade to gcf-utils@12 ([#2262](https://www.github.com/googleapis/repo-automation-bots/issues/2262)) ([bd04376](https://www.github.com/googleapis/repo-automation-bots/commit/bd043767ae59a4eed450f1d18741111dc4c3f8e8))
+</details>
+
+<details><summary>@google-automations/object-selector: 1.1.0</summary>
+
+### Features
+
+* upgrade to gcf-utils@12 ([#2262](https://www.github.com/googleapis/repo-automation-bots/issues/2262)) ([bd04376](https://www.github.com/googleapis/repo-automation-bots/commit/bd043767ae59a4eed450f1d18741111dc4c3f8e8))
+</details>
+
+<details><summary>@google-automations/datastore-lock: 2.1.0</summary>
+
+### Features
+
+* upgrade to gcf-utils@12 ([#2262](https://www.github.com/googleapis/repo-automation-bots/issues/2262)) ([bd04376](https://www.github.com/googleapis/repo-automation-bots/commit/bd043767ae59a4eed450f1d18741111dc4c3f8e8))
+</details>
+
+---
+This PR was generated with [Release Please](https://github.com/googleapis/release-please). See [documentation](https://github.com/googleapis/release-please#release-please).
+`
+
+exports['FilePullRequestOverflowHandler parseOverflow parses overflow body and reads file contents 1'] = `
+:robot: I have created a release \\*beep\\* \\*boop\\*
+---
+
+
+<details><summary>@google-automations/bot-config-utils: 3.2.0</summary>
+
+### Features
+
+* upgrade to gcf-utils@12 ([#2262](https://www.github.com/googleapis/repo-automation-bots/issues/2262)) ([bd04376](https://www.github.com/googleapis/repo-automation-bots/commit/bd043767ae59a4eed450f1d18741111dc4c3f8e8))
+</details>
+
+<details><summary>@google-automations/label-utils: 1.1.0</summary>
+
+### Features
+
+* upgrade to gcf-utils@12 ([#2262](https://www.github.com/googleapis/repo-automation-bots/issues/2262)) ([bd04376](https://www.github.com/googleapis/repo-automation-bots/commit/bd043767ae59a4eed450f1d18741111dc4c3f8e8))
+</details>
+
+<details><summary>@google-automations/object-selector: 1.1.0</summary>
+
+### Features
+
+* upgrade to gcf-utils@12 ([#2262](https://www.github.com/googleapis/repo-automation-bots/issues/2262)) ([bd04376](https://www.github.com/googleapis/repo-automation-bots/commit/bd043767ae59a4eed450f1d18741111dc4c3f8e8))
+</details>
+
+<details><summary>@google-automations/datastore-lock: 2.1.0</summary>
+
+### Features
+
+* upgrade to gcf-utils@12 ([#2262](https://www.github.com/googleapis/repo-automation-bots/issues/2262)) ([bd04376](https://www.github.com/googleapis/repo-automation-bots/commit/bd043767ae59a4eed450f1d18741111dc4c3f8e8))
+</details>
+
+---
+This PR was generated with [Release Please](https://github.com/googleapis/release-please). See [documentation](https://github.com/googleapis/release-please#release-please).
+`

--- a/src/github.ts
+++ b/src/github.ts
@@ -1484,7 +1484,7 @@ export class GitHub {
     // create or update new branch to match base branch
     await this.forkBranch(newBranchName, baseBranchName);
 
-    // create/force update target branch name
+    // use the single file upload API
     const {
       data: {content},
     } = await this.octokit.repos.createOrUpdateFileContents({

--- a/src/github.ts
+++ b/src/github.ts
@@ -1479,10 +1479,8 @@ export class GitHub {
     newBranchName: string,
     baseBranchName: string
   ): Promise<string> {
-    const branchSha = await this.forkBranch(newBranchName, baseBranchName);
-    this.logger.debug(
-      `Forked ${newBranchName} from ${baseBranchName} at ${branchSha}`
-    );
+    // create or update new branch to match base branch
+    await this.forkBranch(newBranchName, baseBranchName);
 
     // create/force update target branch name
     const {
@@ -1562,10 +1560,24 @@ export class GitHub {
     // see if newBranchName exists
     if (await this.getBranchSha(targetBranchName)) {
       // branch already exists, update it to the match the base branch
-      return await this.updateBranchSha(targetBranchName, baseBranchSha);
+      const branchSha = await this.updateBranchSha(
+        targetBranchName,
+        baseBranchSha
+      );
+      this.logger.debug(
+        `Updated ${targetBranchName} to match ${baseBranchName} at ${branchSha}`
+      );
+      return branchSha;
     } else {
       // branch does not exist, create a new branch from the base branch
-      return await this.createNewBranch(targetBranchName, baseBranchSha);
+      const branchSha = await this.createNewBranch(
+        targetBranchName,
+        baseBranchSha
+      );
+      this.logger.debug(
+        `Forked ${targetBranchName} from ${baseBranchName} at ${branchSha}`
+      );
+      return branchSha;
     }
   }
 

--- a/src/manifest.ts
+++ b/src/manifest.ts
@@ -33,7 +33,6 @@ import {
 } from './factory';
 import {Release} from './release';
 import {Strategy} from './strategy';
-import {PullRequestBody} from './util/pull-request-body';
 import {Merge} from './plugins/merge';
 import {ReleasePleaseManifest} from './updaters/release-please-manifest';
 import {
@@ -1022,15 +1021,17 @@ export class Manifest {
         `Found pull request #${pullRequest.number}: '${pullRequest.title}'`
       );
 
-      const pullRequestBody = PullRequestBody.parse(
-        pullRequest.body,
-        this.logger
-      );
+      const pullRequestBody =
+        await this.pullRequestOverflowHandler.parseOverflow(pullRequest);
       if (!pullRequestBody) {
         this.logger.debug('could not parse pull request body as a release PR');
         continue;
       }
-      yield pullRequest;
+      // maybe replace with the complete fetched body
+      yield {
+        ...pullRequest,
+        body: pullRequestBody.toString(),
+      };
     }
   }
 

--- a/src/manifest.ts
+++ b/src/manifest.ts
@@ -42,6 +42,11 @@ import {
   ConfigurationError,
 } from './errors';
 import {ManifestPlugin} from './plugin';
+import {
+  PullRequestOverflowHandler,
+  FilePullRequestOverflowHandler,
+} from './util/pull-request-overflow-handler';
+import {signoffCommitMessage} from './util/signoff-commit-message';
 
 type ExtraJsonFile = {
   type: 'json';
@@ -281,6 +286,7 @@ export class Manifest {
   readonly releaseSearchDepth: number;
   readonly commitSearchDepth: number;
   readonly logger: Logger;
+  private pullRequestOverflowHandler: PullRequestOverflowHandler;
 
   /**
    * Create a Manifest from explicit config in code. This assumes that the
@@ -352,6 +358,10 @@ export class Manifest {
         repositoryConfig: this.repositoryConfig,
         manifestPath: this.manifestPath,
       })
+    );
+    this.pullRequestOverflowHandler = new FilePullRequestOverflowHandler(
+      this.github,
+      this.logger
     );
   }
 
@@ -842,12 +852,19 @@ export class Manifest {
     );
     for await (const openPullRequest of generator) {
       if (
-        (hasAllLabels(this.labels, openPullRequest.labels) ||
-          hasAllLabels(this.snapshotLabels, openPullRequest.labels)) &&
-        BranchName.parse(openPullRequest.headBranchName, this.logger) &&
-        PullRequestBody.parse(openPullRequest.body, this.logger)
+        hasAllLabels(this.labels, openPullRequest.labels) ||
+        hasAllLabels(this.snapshotLabels, openPullRequest.labels)
       ) {
-        openPullRequests.push(openPullRequest);
+        const body = await this.pullRequestOverflowHandler.parseOverflow(
+          openPullRequest
+        );
+        if (body) {
+          // maybe replace with overflow body
+          openPullRequests.push({
+            ...openPullRequest,
+            body: body.toString(),
+          });
+        }
       }
     }
     this.logger.info(
@@ -868,10 +885,18 @@ export class Manifest {
     for await (const closedPullRequest of closedGenerator) {
       if (
         hasAllLabels([SNOOZE_LABEL], closedPullRequest.labels) &&
-        BranchName.parse(closedPullRequest.headBranchName, this.logger) &&
-        PullRequestBody.parse(closedPullRequest.body, this.logger)
+        BranchName.parse(closedPullRequest.headBranchName, this.logger)
       ) {
-        snoozedPullRequests.push(closedPullRequest);
+        const body = await this.pullRequestOverflowHandler.parseOverflow(
+          closedPullRequest
+        );
+        if (body) {
+          // maybe replace with overflow body
+          snoozedPullRequests.push({
+            ...closedPullRequest,
+            body: body.toString(),
+          });
+        }
       }
     }
     this.logger.info(
@@ -903,15 +928,31 @@ export class Manifest {
       return await this.maybeUpdateSnoozedPullRequest(snoozed, pullRequest);
     }
 
-    const newPullRequest = await this.github.createReleasePullRequest(
-      pullRequest,
+    const body = await this.pullRequestOverflowHandler.handleOverflow(
+      pullRequest
+    );
+    const message = this.signoffUser
+      ? signoffCommitMessage(pullRequest.title.toString(), this.signoffUser)
+      : pullRequest.title.toString();
+    const newPullRequest = await this.github.createPullRequest(
+      {
+        headBranchName: pullRequest.headRefName,
+        baseBranchName: this.targetBranch,
+        number: -1,
+        title: pullRequest.title.toString(),
+        body,
+        labels: this.skipLabeling ? [] : pullRequest.labels,
+        files: [],
+      },
       this.targetBranch,
+      message,
+      pullRequest.updates,
       {
         fork: this.fork,
-        signoffUser: this.signoffUser,
-        skipLabeling: this.skipLabeling,
+        draft: pullRequest.draft,
       }
     );
+
     return newPullRequest;
   }
 

--- a/src/manifest.ts
+++ b/src/manifest.ts
@@ -1022,13 +1022,14 @@ export class Manifest {
         `Found pull request #${pullRequest.number}: '${pullRequest.title}'`
       );
 
+      // if the pull request body overflows, handle it
       const pullRequestBody =
         await this.pullRequestOverflowHandler.parseOverflow(pullRequest);
       if (!pullRequestBody) {
         this.logger.debug('could not parse pull request body as a release PR');
         continue;
       }
-      // maybe replace with the complete fetched body
+      // replace with the complete fetched body
       yield {
         ...pullRequest,
         body: pullRequestBody.toString(),

--- a/src/util/pull-request-body.ts
+++ b/src/util/pull-request-body.ts
@@ -51,8 +51,10 @@ export class PullRequestBody {
       return undefined;
     }
     let data = extractMultipleReleases(parts.content, logger);
+    let useComponents = true;
     if (data.length === 0) {
       data = extractSingleRelease(parts.content, logger);
+      useComponents = false;
       if (data.length === 0) {
         logger.warn('Failed to parse releases.');
       }
@@ -60,6 +62,7 @@ export class PullRequestBody {
     return new PullRequestBody(data, {
       header: parts.header,
       footer: parts.footer,
+      useComponents,
     });
   }
   notes(): string {

--- a/src/util/pull-request-overflow-handler.ts
+++ b/src/util/pull-request-overflow-handler.ts
@@ -1,0 +1,122 @@
+// Copyright 2022 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import {PullRequestBody} from './pull-request-body';
+import {GitHub} from '../github';
+import {PullRequest} from '../pull-request';
+import {Logger, logger as defaultLogger} from './logger';
+import {URL} from 'url';
+import {ReleasePullRequest} from '../release-pull-request';
+
+const MAX_ISSUE_BODY_SIZE = 65536;
+const OVERFLOW_MESSAGE =
+  'This release is too large to preview in the pull request body. View the full release notes here:';
+const OVERFLOW_MESSAGE_REGEX = new RegExp(`${OVERFLOW_MESSAGE} (<?url>.*)`);
+const RELEASE_NOTES_FILENAME = 'release-notes.md';
+const FILE_PATH_REGEX = new RegExp(
+  `blob/(<?branchName>.*)/${RELEASE_NOTES_FILENAME}`
+);
+
+/**
+ * Interface for managing the pull request body contents when the content
+ * is too large to fit into a pull request.
+ */
+export interface PullRequestOverflowHandler {
+  /**
+   * If a pull request's body is too big, store it somewhere and return
+   * a new pull request body with information about the new location.
+   * @param {ReleasePullRequest} pullRequest The candidate release pull request
+   * @returns {string} The new pull request body which may contain a link to
+   *   the full content.
+   */
+  handleOverflow(pullRequest: ReleasePullRequest): Promise<string>;
+
+  /**
+   * Given a pull request, parse the pull request body from the pull request
+   * or storage if the body was too big to store in the pull request body.
+   * @param {PullRequest} pullRequest The pull request from GitHub
+   * @return {PullRequestBody} The parsed pull request body
+   */
+  parseOverflow(pullRequest: PullRequest): Promise<PullRequestBody | undefined>;
+}
+
+/**
+ * This implementation of PullRequestOverflowHandler stores the full release
+ * notes on a new git branch. The branch name is derived from the head branch
+ * name of the release pull request.
+ */
+export class FilePullRequestOverflowHandler
+  implements PullRequestOverflowHandler
+{
+  private github: GitHub;
+  private logger: Logger;
+  constructor(github: GitHub, logger: Logger = defaultLogger) {
+    this.github = github;
+    this.logger = logger;
+  }
+
+  /**
+   * Optionally store the full release notes into `release-notes.md` file
+   * on a new branch if they do not fit into the body of a pull request.
+   *
+   * The new release notes will have a link to the GitHub UI for that file
+   * which should render the release notes nicely.
+   * @param {ReleasePullRequest} pullRequest The candidate release pull request
+   * @returns {string} The new pull request body which contains a link to
+   *   the full content.
+   */
+  async handleOverflow(pullRequest: ReleasePullRequest): Promise<string> {
+    const notes = pullRequest.body.toString();
+    if (notes.length > MAX_ISSUE_BODY_SIZE) {
+      const notesBranchName = `${pullRequest.headRefName}--release-notes`;
+      const url = await this.github.createFileOnNewBranch(
+        RELEASE_NOTES_FILENAME,
+        notes,
+        notesBranchName,
+        this.github.repository.defaultBranch
+      );
+      return `${OVERFLOW_MESSAGE} ${url}`;
+    }
+    return notes;
+  }
+
+  /**
+   * Given a pull request, retrieve the full release notes from the stored
+   * file if the body was too big to store in the pull request body.
+   * @param {PullRequest} pullRequest The pull request from GitHub
+   * @return {PullRequestBody} The parsed pull request body
+   */
+  async parseOverflow(
+    pullRequest: PullRequest
+  ): Promise<PullRequestBody | undefined> {
+    const match = pullRequest.body.match(OVERFLOW_MESSAGE_REGEX);
+    if (match?.groups?.url) {
+      this.logger.info(
+        `Pull request body overflows, parsing full body from: ${match.groups.url}`
+      );
+      const url = new URL(match.groups.url);
+      const pathMatch = url.pathname.match(FILE_PATH_REGEX);
+      if (pathMatch?.groups?.branchName) {
+        const fileContents = await this.github.getFileContentsOnBranch(
+          RELEASE_NOTES_FILENAME,
+          pathMatch.groups.branchName
+        );
+        return PullRequestBody.parse(fileContents.parsedContent);
+      }
+      this.logger.warn(`Could not parse branch from ${match.groups.url}`);
+      return PullRequestBody.parse(pullRequest.body, this.logger);
+    }
+    return PullRequestBody.parse(pullRequest.body, this.logger);
+  }
+}

--- a/test/fixtures/release-notes/overflow.txt
+++ b/test/fixtures/release-notes/overflow.txt
@@ -1,0 +1,1 @@
+This release is too large to preview in the pull request body. View the full release notes here: https://github.com/test-owner/test-repo/blob/my-head-branch--release-notes/release-notes.md

--- a/test/github.ts
+++ b/test/github.ts
@@ -1069,14 +1069,19 @@ describe('GitHub', () => {
         .get('/repos/fake/fake/git/ref/heads%2Fnew-branch')
         .reply(404)
         .post('/repos/fake/fake/git/refs', body => {
-          snapshot(body);
+          expect(body.ref).to.eql('refs/heads/new-branch');
+          expect(body.sha).to.eql('abc123');
           return body;
         })
         .reply(201, {
           object: {sha: 'abc123'},
         })
         .put('/repos/fake/fake/contents/new-file.txt', body => {
-          snapshot(body);
+          expect(body.message).to.eql('Saving release notes');
+          expect(body.branch).to.eql('new-branch');
+          expect(Buffer.from(body.content, 'base64').toString('utf-8')).to.eql(
+            'some contents'
+          );
           return body;
         })
         .reply(201, {
@@ -1107,14 +1112,19 @@ describe('GitHub', () => {
           },
         })
         .patch('/repos/fake/fake/git/refs/heads%2Fnew-branch', body => {
-          snapshot(body);
+          expect(body.force).to.be.true;
+          expect(body.sha).to.eql('abc123');
           return body;
         })
         .reply(200, {
           object: {sha: 'abc123'},
         })
         .put('/repos/fake/fake/contents/new-file.txt', body => {
-          snapshot(body);
+          expect(body.message).to.eql('Saving release notes');
+          expect(body.branch).to.eql('new-branch');
+          expect(Buffer.from(body.content, 'base64').toString('utf-8')).to.eql(
+            'some contents'
+          );
           return body;
         })
         .reply(201, {

--- a/test/manifest.ts
+++ b/test/manifest.ts
@@ -3401,10 +3401,13 @@ describe('Manifest', () => {
           files: [],
         });
       sandbox
-        .stub(github, 'createReleasePullRequest')
+        .stub(github, 'createPullRequest')
         .withArgs(
-          sinon.match.has('headRefName', 'release-please/branches/main'),
-          'main'
+          sinon.match.has('headBranchName', 'release-please/branches/main'),
+          'main',
+          sinon.match.string,
+          sinon.match.array,
+          sinon.match({fork: false, draft: false})
         )
         .resolves({
           number: 123,
@@ -3416,8 +3419,11 @@ describe('Manifest', () => {
           files: [],
         })
         .withArgs(
-          sinon.match.has('headRefName', 'release-please/branches/main2'),
-          'main'
+          sinon.match.has('headBranchName', 'release-please/branches/main2'),
+          'main',
+          sinon.match.string,
+          sinon.match.array,
+          sinon.match({fork: false, draft: false})
         )
         .resolves({
           number: 124,
@@ -3930,7 +3936,7 @@ describe('Manifest', () => {
     it('ignores snoozed, closed pull request if there are no changes', async () => {
       const body = new PullRequestBody([
         {
-          notes: 'Some release notes',
+          notes: '## 1.1.0\n\nSome release notes',
         },
       ]);
       sandbox

--- a/test/util/pull-request-overflow-handler.ts
+++ b/test/util/pull-request-overflow-handler.ts
@@ -1,0 +1,133 @@
+// Copyright 2022 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import {describe, it, beforeEach} from 'mocha';
+import {expect} from 'chai';
+import * as nock from 'nock';
+import * as sinon from 'sinon';
+import * as snapshot from 'snap-shot-it';
+import {readFileSync} from 'fs';
+import {resolve} from 'path';
+import {GitHub} from '../../src';
+import {
+  PullRequestOverflowHandler,
+  FilePullRequestOverflowHandler,
+} from '../../src/util/pull-request-overflow-handler';
+import {PullRequestBody} from '../../src/util/pull-request-body';
+import {PullRequestTitle} from '../../src/util/pull-request-title';
+import {buildGitHubFileRaw} from '../helpers';
+
+nock.disableNetConnect();
+const sandbox = sinon.createSandbox();
+const fixturesPath = './test/fixtures/release-notes';
+
+describe('FilePullRequestOverflowHandler', () => {
+  let github: GitHub;
+  let overflowHandler: PullRequestOverflowHandler;
+  beforeEach(async () => {
+    github = await GitHub.create({
+      owner: 'test-owner',
+      repo: 'test-repo',
+      defaultBranch: 'main',
+    });
+    overflowHandler = new FilePullRequestOverflowHandler(github);
+  });
+  afterEach(() => {
+    sandbox.restore();
+  });
+  describe('handleOverflow', () => {
+    const data = [];
+    for (let i = 0; i < 10; i++) {
+      data.push({
+        notes: `release notes: ${i}`,
+      });
+    }
+    const body = new PullRequestBody(data);
+    it('writes large pull request body contents to a file', async () => {
+      const createFileStub = sandbox
+        .stub(github, 'createFileOnNewBranch')
+        .resolves(
+          'https://github.com/test-owner/test-repo/blob/my-head-branch--release-notes/release-notes.md'
+        );
+      const newContents = await overflowHandler.handleOverflow(
+        {
+          title: PullRequestTitle.ofTargetBranch('main'),
+          body,
+          labels: [],
+          updates: [],
+          draft: false,
+          headRefName: 'my-head-branch',
+        },
+        50
+      );
+      snapshot(newContents);
+      sinon.assert.calledOnce(createFileStub);
+    });
+    it('ignores small pull request body contents', async () => {
+      const newContents = await overflowHandler.handleOverflow({
+        title: PullRequestTitle.ofTargetBranch('main'),
+        body,
+        labels: [],
+        updates: [],
+        draft: false,
+        headRefName: 'my-head-branch',
+      });
+      expect(newContents).to.eql(body.toString());
+    });
+  });
+  describe('parseOverflow', () => {
+    it('parses overflow body and reads file contents', async () => {
+      const body = readFileSync(
+        resolve(fixturesPath, './overflow.txt'),
+        'utf8'
+      );
+      const overflowBody = readFileSync(
+        resolve(fixturesPath, './multiple.txt'),
+        'utf8'
+      );
+      sandbox
+        .stub(github, 'getFileContentsOnBranch')
+        .withArgs('release-notes.md', 'my-head-branch--release-notes')
+        .resolves(buildGitHubFileRaw(overflowBody));
+      const pullRequestBody = await overflowHandler.parseOverflow({
+        title: 'chore: release main',
+        body,
+        headBranchName: 'release-please--branches--main',
+        baseBranchName: 'main',
+        number: 123,
+        labels: [],
+        files: [],
+      });
+      expect(pullRequestBody).to.not.be.undefined;
+      snapshot(pullRequestBody!.toString());
+    });
+    it('ignores small pull request body contents', async () => {
+      const body = readFileSync(
+        resolve(fixturesPath, './multiple.txt'),
+        'utf8'
+      );
+      const pullRequestBody = await overflowHandler.parseOverflow({
+        title: 'chore: release main',
+        body,
+        headBranchName: 'release-please--branches--main',
+        baseBranchName: 'main',
+        number: 123,
+        labels: [],
+        files: [],
+      });
+      expect(pullRequestBody).to.not.be.undefined;
+      snapshot(pullRequestBody!.toString());
+    });
+  });
+});


### PR DESCRIPTION
When release notes are too big to fit into the pull request body, we must store the release notes somewhere. We implement a `PullRequestOverflowHandler` interface that writes the full changes to a new file in a new branch. The release PR includes a link to the file so that the GitHub UI can render it nicely for us.

When release-please parses the merged release pull request, if it detects the overflow case, we download the release notes from that stored file and use it to determine which releases to tag.

Fixes #1675
