### PR TITLE
fix: add initial-version to the properties list

### DIFF
--- a/schemas/config.json
+++ b/schemas/config.json
@@ -393,6 +393,7 @@
     "tag-separator": true,
     "extra-files": true,
     "version-file": true,
-    "snapshot-label": true
+    "snapshot-label": true,
+    "initial-version": true
   }
 }


### PR DESCRIPTION
I think it needs to be here as well.

