### PR TITLE
fix: updating a pull request uses overflow handler if body is too large

### DIFF
--- a/src/manifest.ts
+++ b/src/manifest.ts
@@ -975,6 +975,7 @@ export class Manifest {
       {
         fork: this.fork,
         signoffUser: this.signoffUser,
+        pullRequestOverflowHandler: this.pullRequestOverflowHandler,
       }
     );
     return updatedPullRequest;
@@ -999,6 +1000,7 @@ export class Manifest {
       {
         fork: this.fork,
         signoffUser: this.signoffUser,
+        pullRequestOverflowHandler: this.pullRequestOverflowHandler,
       }
     );
     // TODO: consider leaving the snooze label

--- a/test/helpers.ts
+++ b/test/helpers.ts
@@ -27,7 +27,7 @@ import {expect} from 'chai';
 import {CandidateReleasePullRequest} from '../src/manifest';
 import {Version} from '../src/version';
 import {PullRequestTitle} from '../src/util/pull-request-title';
-import {PullRequestBody} from '../src/util/pull-request-body';
+import {PullRequestBody, ReleaseData} from '../src/util/pull-request-body';
 import {BranchName} from '../src/util/branch-name';
 import {ReleaseType} from '../src/factory';
 import {
@@ -35,6 +35,9 @@ import {
   DEFAULT_FILE_MODE,
 } from '@google-automations/git-file-utils';
 import {CompositeUpdater} from '../src/updaters/composite';
+import {PullRequestOverflowHandler} from '../src/util/pull-request-overflow-handler';
+import {ReleasePullRequest} from '../src/release-pull-request';
+import {PullRequest} from '../src/pull-request';
 
 export function stubSuggesterWithSnapshot(
   sandbox: sinon.SinonSandbox,
@@ -371,4 +374,33 @@ export function mockTags(
     }
   }
   return sandbox.stub(github, 'tagIterator').returns(fakeGenerator());
+}
+
+export function mockReleaseData(count: number): ReleaseData[] {
+  const releaseData: ReleaseData[] = [];
+  const version = Version.parse('1.2.3');
+  for (let i = 0; i < count; i++) {
+    releaseData.push({
+      component: `component${i}`,
+      version,
+      notes: `release notes for component${i}`,
+    });
+  }
+  return releaseData;
+}
+
+export class MockPullRequestOverflowHandler
+  implements PullRequestOverflowHandler
+{
+  async handleOverflow(
+    pullRequest: ReleasePullRequest,
+    _maxSize?: number | undefined
+  ): Promise<string> {
+    return pullRequest.body.toString();
+  }
+  async parseOverflow(
+    pullRequest: PullRequest
+  ): Promise<PullRequestBody | undefined> {
+    return PullRequestBody.parse(pullRequest.body);
+  }
 }

--- a/test/manifest.ts
+++ b/test/manifest.ts
@@ -28,6 +28,7 @@ import {
   mockReleases,
   mockTags,
   assertNoHasUpdate,
+  mockReleaseData,
 } from './helpers';
 import {expect} from 'chai';
 import * as assert from 'assert';
@@ -40,7 +41,7 @@ import {SentenceCase} from '../src/plugins/sentence-case';
 import {NodeWorkspace} from '../src/plugins/node-workspace';
 import {CargoWorkspace} from '../src/plugins/cargo-workspace';
 import {PullRequestTitle} from '../src/util/pull-request-title';
-import {PullRequestBody, ReleaseData} from '../src/util/pull-request-body';
+import {PullRequestBody} from '../src/util/pull-request-body';
 import {RawContent} from '../src/updaters/raw-content';
 import {TagName} from '../src/util/tag-name';
 import snapshot = require('snap-shot-it');
@@ -146,21 +147,6 @@ function pullRequestBody(path: string): string {
     /\r\n/g,
     '\n'
   );
-}
-
-const overflowingReleaseData = mockReleaseData(1000);
-
-function mockReleaseData(count: number): ReleaseData[] {
-  const releaseData: ReleaseData[] = [];
-  const version = Version.parse('1.2.3');
-  for (let i = 0; i < count; i++) {
-    releaseData.push({
-      component: `component${i}`,
-      version,
-      notes: `release notes for component${i}`,
-    });
-  }
-  return releaseData;
 }
 
 describe('Manifest', () => {
@@ -3751,7 +3737,7 @@ describe('Manifest', () => {
     });
 
     describe('with an overflowing body', () => {
-      const body = new PullRequestBody(overflowingReleaseData, {
+      const body = new PullRequestBody(mockReleaseData(1000), {
         useComponents: true,
       });
 

--- a/test/manifest.ts
+++ b/test/manifest.ts
@@ -40,7 +40,7 @@ import {SentenceCase} from '../src/plugins/sentence-case';
 import {NodeWorkspace} from '../src/plugins/node-workspace';
 import {CargoWorkspace} from '../src/plugins/cargo-workspace';
 import {PullRequestTitle} from '../src/util/pull-request-title';
-import {PullRequestBody} from '../src/util/pull-request-body';
+import {PullRequestBody, ReleaseData} from '../src/util/pull-request-body';
 import {RawContent} from '../src/updaters/raw-content';
 import {TagName} from '../src/util/tag-name';
 import snapshot = require('snap-shot-it');
@@ -146,6 +146,21 @@ function pullRequestBody(path: string): string {
     /\r\n/g,
     '\n'
   );
+}
+
+const overflowingReleaseData = mockReleaseData(1000);
+
+function mockReleaseData(count: number): ReleaseData[] {
+  const releaseData: ReleaseData[] = [];
+  const version = Version.parse('1.2.3');
+  for (let i = 0; i < count; i++) {
+    releaseData.push({
+      component: `component${i}`,
+      version,
+      notes: `release notes for component${i}`,
+    });
+  }
+  return releaseData;
 }
 
 describe('Manifest', () => {
@@ -3733,6 +3748,174 @@ describe('Manifest', () => {
       ]);
       const pullRequestNumbers = await manifest.createPullRequests();
       expect(pullRequestNumbers).lengthOf(1);
+    });
+
+    describe('with an overflowing body', () => {
+      const body = new PullRequestBody(overflowingReleaseData, {
+        useComponents: true,
+      });
+
+      it('updates an existing pull request', async function () {
+        sandbox
+          .stub(github, 'getFileContentsOnBranch')
+          .withArgs('README.md', 'main')
+          .resolves(buildGitHubFileRaw('some-content'));
+        stubSuggesterWithSnapshot(sandbox, this.test!.fullTitle());
+        mockPullRequests(
+          github,
+          [
+            {
+              number: 22,
+              title: 'pr title1',
+              body: pullRequestBody('release-notes/single.txt'),
+              headBranchName: 'release-please/branches/main',
+              baseBranchName: 'main',
+              labels: ['autorelease: pending'],
+              files: [],
+            },
+          ],
+          []
+        );
+        sandbox
+          .stub(github, 'updatePullRequest')
+          .withArgs(
+            22,
+            sinon.match.any,
+            sinon.match.any,
+            sinon.match.has('pullRequestOverflowHandler', sinon.match.truthy)
+          )
+          .resolves({
+            number: 22,
+            title: 'pr title1',
+            body: 'pr body1',
+            headBranchName: 'release-please/branches/main',
+            baseBranchName: 'main',
+            labels: [],
+            files: [],
+          });
+        const manifest = new Manifest(
+          github,
+          'main',
+          {
+            'path/a': {
+              releaseType: 'node',
+              component: 'pkg1',
+            },
+            'path/b': {
+              releaseType: 'node',
+              component: 'pkg2',
+            },
+          },
+          {
+            'path/a': Version.parse('1.0.0'),
+            'path/b': Version.parse('0.2.3'),
+          },
+          {
+            separatePullRequests: true,
+            plugins: ['node-workspace'],
+          }
+        );
+        sandbox.stub(manifest, 'buildPullRequests').resolves([
+          {
+            title: PullRequestTitle.ofTargetBranch('main'),
+            body,
+            updates: [
+              {
+                path: 'README.md',
+                createIfMissing: false,
+                updater: new RawContent('some raw content'),
+              },
+            ],
+            labels: [],
+            headRefName: 'release-please/branches/main',
+            draft: false,
+          },
+        ]);
+        const pullRequestNumbers = await manifest.createPullRequests();
+        expect(pullRequestNumbers).lengthOf(1);
+      });
+
+      it('ignores an existing pull request if there are no changes', async function () {
+        sandbox
+          .stub(github, 'getFileContentsOnBranch')
+          .withArgs('README.md', 'main')
+          .resolves(buildGitHubFileRaw('some-content'))
+          .withArgs('release-notes.md', 'my-head-branch--release-notes')
+          .resolves(buildGitHubFileRaw(body.toString()));
+        stubSuggesterWithSnapshot(sandbox, this.test!.fullTitle());
+        mockPullRequests(
+          github,
+          [
+            {
+              number: 22,
+              title: 'pr title1',
+              body: pullRequestBody('release-notes/overflow.txt'),
+              headBranchName: 'release-please/branches/main',
+              baseBranchName: 'main',
+              labels: ['autorelease: pending'],
+              files: [],
+            },
+          ],
+          []
+        );
+        sandbox
+          .stub(github, 'updatePullRequest')
+          .withArgs(
+            22,
+            sinon.match.any,
+            sinon.match.any,
+            sinon.match.has('pullRequestOverflowHandler', sinon.match.truthy)
+          )
+          .resolves({
+            number: 22,
+            title: 'pr title1',
+            body: 'pr body1',
+            headBranchName: 'release-please/branches/main',
+            baseBranchName: 'main',
+            labels: [],
+            files: [],
+          });
+        const manifest = new Manifest(
+          github,
+          'main',
+          {
+            'path/a': {
+              releaseType: 'node',
+              component: 'pkg1',
+            },
+            'path/b': {
+              releaseType: 'node',
+              component: 'pkg2',
+            },
+          },
+          {
+            'path/a': Version.parse('1.0.0'),
+            'path/b': Version.parse('0.2.3'),
+          },
+          {
+            separatePullRequests: true,
+            plugins: ['node-workspace'],
+          }
+        );
+        sandbox.stub(manifest, 'buildPullRequests').resolves([
+          {
+            title: PullRequestTitle.ofTargetBranch('main'),
+            body,
+            updates: [
+              {
+                path: 'README.md',
+                createIfMissing: false,
+                updater: new RawContent('some raw content'),
+              },
+            ],
+            labels: [],
+            headRefName: 'release-please/branches/main',
+            draft: false,
+          },
+        ]);
+        const pullRequestNumbers = await manifest.createPullRequests();
+        expect(pullRequestNumbers).lengthOf(0);
+      });
     });
 
     it('updates an existing snapshot pull request', async function () {


### PR DESCRIPTION
Currently, the pull request body overflow handler is running for new pull requests, but not on updated pull requests
