### PR TITLE
fix(maven-workspace): SNAPSHOT versions should not be included in the manifest

### DIFF
--- a/src/plugins/workspace.ts
+++ b/src/plugins/workspace.ts
@@ -266,13 +266,24 @@ export abstract class WorkspacePlugin<T> extends ManifestPlugin {
         const version = this.bumpVersion(pkg);
         this.logger.debug(`version: ${version} forced bump`);
         updatedVersions.set(packageName, version);
-        updatedPathVersions.set(this.pathFromPackage(pkg), version);
+        if (this.isReleaseVersion(version)) {
+          updatedPathVersions.set(this.pathFromPackage(pkg), version);
+        }
       }
     }
     return {
       updatedVersions,
       updatedPathVersions,
     };
+  }
+
+  /**
+   * Given a release version, determine if we should bump the manifest
+   * version as well.
+   * @param {Version} _version The release version
+   */
+  protected isReleaseVersion(_version: Version): boolean {
+    return true;
   }
 
   /**


### PR DESCRIPTION
Fixes #1718

Example new PR: https://github.com/googleapis/google-cloud-java/pull/8699