### PR TITLE
fix(cargo-workspace): Update target dependencies in Cargo workspace packages

### DIFF
--- a/__snapshots__/cargo-workspace.js
+++ b/__snapshots__/cargo-workspace.js
@@ -27,6 +27,15 @@ Release notes for path: packages/rustA, releaseType: rust
     * pkgB bumped from 2.2.2 to 2.2.3
 </details>
 
+<details><summary>pkgE: 3.3.4</summary>
+
+### Dependencies
+
+* The following workspace dependencies were updated
+  * dependencies
+    * pkgA bumped from 1.1.1 to 1.1.2
+</details>
+
 ---
 This PR was generated with [Release Please](https://github.com/googleapis/release-please). See [documentation](https://github.com/googleapis/release-please#release-please).
 `
@@ -78,6 +87,21 @@ exports['CargoWorkspace plugin run can skip merging rust packages 4'] = `
 
 
 Release notes for path: packages/rustD, releaseType: rust
+
+---
+This PR was generated with [Release Please](https://github.com/googleapis/release-please). See [documentation](https://github.com/googleapis/release-please#release-please).
+`
+
+exports['CargoWorkspace plugin run can skip merging rust packages 5'] = `
+:robot: I have created a release *beep* *boop*
+---
+
+
+### Dependencies
+
+* The following workspace dependencies were updated
+  * dependencies
+    * pkgA bumped from 1.1.1 to 1.1.2
 
 ---
 This PR was generated with [Release Please](https://github.com/googleapis/release-please). See [documentation](https://github.com/googleapis/release-please#release-please).
@@ -170,6 +194,15 @@ Release notes for path: packages/rustA, releaseType: rust
 <details><summary>@here/pkgD: 4.4.5</summary>
 
 Release notes for path: packages/rustD, releaseType: rust
+</details>
+
+<details><summary>pkgE: 3.3.4</summary>
+
+### Dependencies
+
+* The following workspace dependencies were updated
+  * dependencies
+    * pkgA bumped from 1.1.1 to 1.1.2
 </details>
 
 ---

--- a/src/plugins/cargo-workspace.ts
+++ b/src/plugins/cargo-workspace.ts
@@ -387,7 +387,7 @@ function getChangelogDepsNotes(
     return result;
   };
 
-  type DepUpdates = Map<DT, string[]>;
+  type DepUpdates = Map<DT, Set<string>>;
 
   const populateUpdates = (
     originalScope: CargoManifest | TargetDependencies[string],
@@ -412,7 +412,9 @@ function getChangelogDepsNotes(
         }
       }
       if (depUpdates.length > 0) {
-        updates.set(depType, depUpdates);
+        const updatesForType = updates.get(depType) || new Set();
+        depUpdates.forEach(update => updatesForType.add(update));
+        updates.set(depType, updatesForType);
       }
     }
   };

--- a/test/fixtures/plugins/cargo-workspace/Cargo.toml
+++ b/test/fixtures/plugins/cargo-workspace/Cargo.toml
@@ -1,2 +1,2 @@
 [workspace]
-members = ["packages/rustA", "packages/rustB", "packages/rustC", "packages/rustD"]
+members = ["packages/rustA", "packages/rustB", "packages/rustC", "packages/rustD", "packages/rustE"]

--- a/test/fixtures/plugins/cargo-workspace/packages/rustE/Cargo.toml
+++ b/test/fixtures/plugins/cargo-workspace/packages/rustE/Cargo.toml
@@ -1,0 +1,8 @@
+[package]
+name = "pkgE"
+version = "3.3.3"
+
+[dependencies]
+
+[target.'cfg(foobar)'.dependencies]
+pkgA = { version = "1.1.1", path = "../pkgA" }

--- a/test/plugins/cargo-workspace.ts
+++ b/test/plugins/cargo-workspace.ts
@@ -216,6 +216,7 @@ describe('CargoWorkspace plugin', () => {
           'packages/rustB/Cargo.toml',
           'packages/rustC/Cargo.toml',
           'packages/rustD/Cargo.toml',
+          'packages/rustE/Cargo.toml',
         ],
         flatten: false,
         targetBranch: 'main',
@@ -231,6 +232,7 @@ describe('CargoWorkspace plugin', () => {
       assertHasUpdate(updates, 'packages/rustB/Cargo.toml', RawContent);
       assertHasUpdate(updates, 'packages/rustC/Cargo.toml', RawContent);
       assertHasUpdate(updates, 'packages/rustD/Cargo.toml', RawContent);
+      assertHasUpdate(updates, 'packages/rustE/Cargo.toml', RawContent);
       snapshot(dateSafe(rustCandidate!.pullRequest.body.toString()));
     });
     it('can skip merging rust packages', async () => {
@@ -265,6 +267,7 @@ describe('CargoWorkspace plugin', () => {
           'packages/rustB/Cargo.toml',
           'packages/rustC/Cargo.toml',
           'packages/rustD/Cargo.toml',
+          'packages/rustE/Cargo.toml',
         ],
         flatten: false,
         targetBranch: 'main',
@@ -285,7 +288,7 @@ describe('CargoWorkspace plugin', () => {
         }
       );
       const newCandidates = await plugin.run(candidates);
-      expect(newCandidates).lengthOf(4);
+      expect(newCandidates).lengthOf(5);
       for (const newCandidate of newCandidates) {
         safeSnapshot(newCandidate.pullRequest.body.toString());
       }
@@ -324,6 +327,7 @@ describe('CargoWorkspace plugin', () => {
           'packages/rustB/Cargo.toml',
           'packages/rustC/Cargo.toml',
           'packages/rustD/Cargo.toml',
+          'packages/rustE/Cargo.toml',
         ],
         flatten: false,
         targetBranch: 'main',
@@ -338,6 +342,7 @@ describe('CargoWorkspace plugin', () => {
       assertHasUpdate(updates, 'packages/rustA/Cargo.toml', RawContent);
       assertHasUpdate(updates, 'packages/rustB/Cargo.toml', RawContent);
       assertHasUpdate(updates, 'packages/rustC/Cargo.toml', RawContent);
+      assertHasUpdate(updates, 'packages/rustE/Cargo.toml', RawContent);
       snapshot(dateSafe(rustCandidate!.pullRequest.body.toString()));
     });
     it('skips component if not touched', async () => {
@@ -362,6 +367,7 @@ describe('CargoWorkspace plugin', () => {
           'packages/rustB/Cargo.toml',
           'packages/rustC/Cargo.toml',
           'packages/rustD/Cargo.toml',
+          'packages/rustE/Cargo.toml',
         ],
         flatten: false,
         targetBranch: 'main',
@@ -375,6 +381,7 @@ describe('CargoWorkspace plugin', () => {
       const updates = rustCandidate!.pullRequest.updates;
       // pkgA is not touched and does not have a dependency on pkgB
       assertNoHasUpdate(updates, 'packages/rustA/Cargo.toml');
+      assertNoHasUpdate(updates, 'packages/rustE/Cargo.toml');
       assertHasUpdate(updates, 'packages/rustB/Cargo.toml', RawContent);
       snapshot(dateSafe(rustCandidate!.pullRequest.body.toString()));
     });


### PR DESCRIPTION
Hello, I wrote a fix while tracking down #1729 

I'm happy to discuss an alternative approach, but since I already wrote this fix I figured I would put it up for consideration.

TL;DR of the issue is that a Cargo manifest can have compilation target-scoped dependencies, and these must be taken into consideration in addition to the top-level set of dependencies.

Fixes #1729 :crab: 
