### PR TITLE
chore: Adding local testing steps to contributing guide

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -55,4 +55,25 @@ accept your pull requests.
 
         npm run fix
 
+## Testing a new feature using CLI
+
+1. After you've written some new code, in order to test it out, you can use the [CLI][CLI].
+
+   For example, the CLI command:
+
+   ```
+   release-please release-pr \
+   --token=$GITHUB_TOKEN \
+   --repo-url=<owner>/<repo> [extra options]
+   ```
+
+   can be run as from the root of the source code as:
+
+   ```
+   node build/src/bin/release-please.js release-pr \
+   --token=$GITHUB_TOKEN \
+   --repo-url=<owner>/<repo> [extra options]
+   ```
+
 [node]: https://nodejs.org/en/
+[CLI]: https://github.com/googleapis/release-please/blob/main/docs/cli.md/

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -59,18 +59,18 @@ accept your pull requests.
 
 1. After you've written some new code, in order to test it out, you can use the [CLI][CLI].
 
-   For example, the CLI command:
-
-   ```
-   release-please release-pr \
-   --token=$GITHUB_TOKEN \
-   --repo-url=<owner>/<repo> [extra options]
-   ```
-
-   can be run as from the root of the source code as:
+   The below command should be run from the root of the source code:
 
    ```
    node build/src/bin/release-please.js release-pr \
+   --token=$GITHUB_TOKEN \
+   --repo-url=<owner>/<repo> [extra options]
+   ```
+   
+   It is equivalent to running the CLI command:
+
+   ```
+   release-please release-pr \
    --token=$GITHUB_TOKEN \
    --repo-url=<owner>/<repo> [extra options]
    ```


### PR DESCRIPTION
Hi team, just adding some stuff to the guide that maybe useful for contributors.

@suztomo Opened this new PR because I was unable to edit the last one, looks like I messed up with the head of that branch while working on the versioning strategy. Also, there are no steps to generate release-please command afaik. It is included in the node build command. Multi-line command is fixed.

![image](https://user-images.githubusercontent.com/90280028/200589378-3c0c0886-10fd-4b5d-80c0-1a86aa404e09.png)


@chingor13 can you please approve this one?
