### PR TITLE
fix(node-workspace): maintain the dependency version prefix in newCandidate

### DIFF
--- a/__snapshots__/node-workspace.js
+++ b/__snapshots__/node-workspace.js
@@ -24,7 +24,7 @@ Release notes for path: node1, releaseType: node
 
 * The following workspace dependencies were updated
   * dependencies
-    * @here/pkgB bumped from 2.2.2 to ^2.2.3
+    * @here/pkgB bumped from 2.2.2 to 2.2.3
 </details>
 
 ---
@@ -49,7 +49,7 @@ exports['NodeWorkspace plugin run appends dependency notes to an updated module 
 
 * The following workspace dependencies were updated
   * dependencies
-    * @here/pkgB bumped from 2.2.2 to ^2.2.3
+    * @here/pkgB bumped from 2.2.2 to 2.2.3
 `
 
 exports['NodeWorkspace plugin run combines node packages 1'] = `
@@ -138,7 +138,7 @@ Release notes for path: node1, releaseType: node
 
 * The following workspace dependencies were updated
   * dependencies
-    * @here/pkgA bumped from 3.3.3 to ^3.3.4
+    * @here/pkgA bumped from 3.3.3 to 3.3.4
 </details>
 
 <details><summary>@here/pkgC: 1.1.2</summary>
@@ -147,7 +147,7 @@ Release notes for path: node1, releaseType: node
 
 * The following workspace dependencies were updated
   * dependencies
-    * @here/pkgB bumped from 2.2.2 to ^2.2.3
+    * @here/pkgB bumped from 2.2.2 to 2.2.3
 </details>
 
 <details><summary>@here/pkgD: 4.4.5</summary>

--- a/src/plugins/node-workspace.ts
+++ b/src/plugins/node-workspace.ts
@@ -242,13 +242,17 @@ export class NodeWorkspace extends WorkspacePlugin<Package> {
     for (const [depName, resolved] of graphPackage.localDependencies) {
       const depVersion = updatedVersions.get(depName);
       if (depVersion && resolved.type !== 'directory') {
+        const currentVersion = this.combineDeps(pkg)?.[depName];
+        const prefix = currentVersion
+          ? this.detectRangePrefix(currentVersion)
+          : '';
         updatedPackage.updateLocalDependency(
           resolved,
           depVersion.toString(),
-          '^'
+          prefix
         );
         this.logger.info(
-          `${pkg.name}.${depName} updated to ^${depVersion.toString()}`
+          `${pkg.name}.${depName} updated to ${prefix}${depVersion.toString()}`
         );
       }
     }


### PR DESCRIPTION
In https://github.com/googleapis/release-please/pull/1723 I overlooked that prefix is also generated in the newCandidate as I incorrectly assumed that that method is only invoked for new packages. It's actually invoked for new updated of any package.

- [ ] Make sure to open an issue as a [bug/issue](https://github.com/googleapis/release-please/issues/new/choose) before writing your code!  That way we can discuss the change, evaluate designs, and agree on the general idea
- [x] Ensure the tests and linter pass
- [x] Code coverage does not decrease (if any source code was changed)
- [ ] Appropriate docs were updated (if necessary)


Fixes #1723 🦕
