### PR TITLE
fix(dart): throw MissingRequiredFileError if pubspec.yaml is missing

### DIFF
--- a/src/strategies/dart.ts
+++ b/src/strategies/dart.ts
@@ -21,6 +21,7 @@ import {PubspecYaml} from '../updaters/dart/pubspec-yaml';
 import {BaseStrategy, BuildUpdatesOptions} from './base';
 import {GitHubFileContents} from '@google-automations/git-file-utils';
 import {Update} from '../update';
+import {FileNotFoundError, MissingRequiredFileError} from '../errors';
 
 export class Dart extends BaseStrategy {
   private pubspecYmlContents?: GitHubFileContents;
@@ -64,10 +65,21 @@ export class Dart extends BaseStrategy {
 
   private async getPubspecYmlContents(): Promise<GitHubFileContents> {
     if (!this.pubspecYmlContents) {
-      this.pubspecYmlContents = await this.github.getFileContentsOnBranch(
-        this.addPath('pubspec.yaml'),
-        this.targetBranch
-      );
+      try {
+        this.pubspecYmlContents = await this.github.getFileContentsOnBranch(
+          this.addPath('pubspec.yaml'),
+          this.targetBranch
+        );
+      } catch (e) {
+        if (e instanceof FileNotFoundError) {
+          throw new MissingRequiredFileError(
+            this.addPath('pubspec.yaml'),
+            Dart.name,
+            `${this.repository.owner}/${this.repository.repo}`
+          );
+        }
+        throw e;
+      }
     }
     return this.pubspecYmlContents;
   }

--- a/src/strategies/helm.ts
+++ b/src/strategies/helm.ts
@@ -21,6 +21,7 @@ import * as yaml from 'js-yaml';
 import {ChartYaml} from '../updaters/helm/chart-yaml';
 import {BaseStrategy, BuildUpdatesOptions} from './base';
 import {Update} from '../update';
+import {FileNotFoundError, MissingRequiredFileError} from '../errors';
 
 export class Helm extends BaseStrategy {
   private chartYmlContents?: GitHubFileContents;
@@ -63,9 +64,20 @@ export class Helm extends BaseStrategy {
 
   private async getChartYmlContents(): Promise<GitHubFileContents> {
     if (!this.chartYmlContents) {
-      this.chartYmlContents = await this.github.getFileContents(
-        this.addPath('Chart.yaml')
-      );
+      try {
+        this.chartYmlContents = await this.github.getFileContents(
+          this.addPath('Chart.yaml')
+        );
+      } catch (e) {
+        if (e instanceof FileNotFoundError) {
+          throw new MissingRequiredFileError(
+            this.addPath('Chart.yaml'),
+            Helm.name,
+            `${this.repository.owner}/${this.repository.repo}`
+          );
+        }
+        throw e;
+      }
     }
     return this.chartYmlContents;
   }


### PR DESCRIPTION
Towards https://github.com/googleapis/repo-automation-bots/issues/4664

Throwing this error will allow the downstream automation to handle this FileNotFoiundError better (indicating that it's an repository configuration error).

fix(helm): throw MissingRequiredFileError if Chart.yaml is missing