### PR TITLE
fix: handle issue links in BREAKING_CHANGE notes section

### DIFF
--- a/__snapshots__/default-changelog-notes.js
+++ b/__snapshots__/default-changelog-notes.js
@@ -153,6 +153,15 @@ exports['DefaultChangelogNotes buildNotes with commit parsing should handle html
 * render all imagesets as &lt;picture&gt; ([383fb14](https://github.com/googleapis/java-asset/commit/383fb14708ae91f7bb7e64bf0bacab38))
 `
 
+exports['DefaultChangelogNotes buildNotes with commit parsing should handle inline bug links 1'] = `
+## [1.2.3](https://github.com/googleapis/java-asset/compare/v1.2.2...v1.2.3) (1983-10-10)
+
+
+### Bug Fixes
+
+* some bugfix ([#1234](https://github.com/googleapis/java-asset/issues/1234)) ([6f2163b](https://github.com/googleapis/java-asset/commit/6f2163be093d8a8dd90232d06b45c07e))
+`
+
 exports['DefaultChangelogNotes buildNotes with commit parsing should handle meta commits 1'] = `
 ## [1.2.3](https://github.com/googleapis/java-asset/compare/v1.2.2...v1.2.3) (1983-10-10)
 

--- a/__snapshots__/default-changelog-notes.js
+++ b/__snapshots__/default-changelog-notes.js
@@ -109,6 +109,19 @@ exports['DefaultChangelogNotes buildNotes with commit parsing should handle a br
 * some bugfix ([05670cf](https://github.com/googleapis/java-asset/commit/05670cf2e850beffe53bb2691f8701c7))
 `
 
+exports['DefaultChangelogNotes buildNotes with commit parsing should handle a breaking change with reference 1'] = `
+## [1.2.3](https://github.com/googleapis/java-asset/compare/v1.2.2...v1.2.3) (1983-10-10)
+
+
+### ⚠ BREAKING CHANGES
+
+* some bugfix ([#1234](https://github.com/googleapis/java-asset/issues/1234))
+
+### Bug Fixes
+
+* some bugfix ([#1234](https://github.com/googleapis/java-asset/issues/1234)) ([749cd8b](https://github.com/googleapis/java-asset/commit/749cd8b9edc6103a2f40a34ca45c31c5))
+`
+
 exports['DefaultChangelogNotes buildNotes with commit parsing should handle bug links 1'] = `
 ## [1.2.3](https://github.com/googleapis/java-asset/compare/v1.2.2...v1.2.3) (1983-10-10)
 

--- a/src/changelog-notes/default.ts
+++ b/src/changelog-notes/default.ts
@@ -31,6 +31,11 @@ interface DefaultChangelogNotesOptions {
   mainTemplate?: string;
 }
 
+interface Note {
+  title: string;
+  text: string;
+}
+
 export class DefaultChangelogNotes implements ChangelogNotes {
   // allow for customized commit template.
   private commitPartial?: string;
@@ -68,14 +73,23 @@ export class DefaultChangelogNotes implements ChangelogNotes {
       this.headerPartial || preset.writerOpts.headerPartial;
     preset.writerOpts.mainTemplate =
       this.mainTemplate || preset.writerOpts.mainTemplate;
-
     const changelogCommits = commits.map(commit => {
+      const notes = commit.notes
+        .filter(note => note.title === 'BREAKING CHANGE')
+        .map(note =>
+          replaceIssueLink(
+            note,
+            context.host,
+            context.owner,
+            context.repository
+          )
+        );
       return {
         body: '', // commit.body,
         subject: htmlEscape(commit.bareMessage),
         type: commit.type,
         scope: commit.scope,
-        notes: commit.notes.filter(note => note.title === 'BREAKING CHANGE'),
+        notes,
         references: commit.references,
         mentions: [],
         merge: null,
@@ -93,6 +107,19 @@ export class DefaultChangelogNotes implements ChangelogNotes {
       .parseArray(changelogCommits, context, preset.writerOpts)
       .trim();
   }
+}
+
+function replaceIssueLink(
+  note: Note,
+  host: string,
+  owner: string,
+  repo: string
+): Note {
+  note.text = note.text.replace(
+    /\(#(\d+)\)/,
+    `([#$1](${host}/${owner}/${repo}/issues/$1))`
+  );
+  return note;
 }
 
 function htmlEscape(message: string): string {

--- a/test/changelog-notes/default-changelog-notes.ts
+++ b/test/changelog-notes/default-changelog-notes.ts
@@ -135,6 +135,16 @@ describe('DefaultChangelogNotes', () => {
         expect(notes).to.is.string;
         safeSnapshot(notes);
       });
+      it('should handle a breaking change with reference', async () => {
+        const commits = [buildMockCommit('fix!: some bugfix (#1234)')];
+        const changelogNotes = new DefaultChangelogNotes();
+        const notes = await changelogNotes.buildNotes(
+          parseConventionalCommits(commits),
+          notesOptions
+        );
+        expect(notes).to.is.string;
+        safeSnapshot(notes);
+      });
       it('should parse multiple commit messages from a single commit', async () => {
         const commits = [buildCommitFromFixture('multiple-messages')];
         const changelogNotes = new DefaultChangelogNotes();

--- a/test/changelog-notes/default-changelog-notes.ts
+++ b/test/changelog-notes/default-changelog-notes.ts
@@ -175,6 +175,16 @@ describe('DefaultChangelogNotes', () => {
         expect(notes).to.is.string;
         safeSnapshot(notes);
       });
+      it('should handle inline bug links', async () => {
+        const commits = [buildMockCommit('fix: some bugfix (#1234)')];
+        const changelogNotes = new DefaultChangelogNotes();
+        const notes = await changelogNotes.buildNotes(
+          parseConventionalCommits(commits),
+          notesOptions
+        );
+        expect(notes).to.is.string;
+        safeSnapshot(notes);
+      });
       it('should handle git trailers', async () => {
         const commits = [buildCommitFromFixture('git-trailers-with-breaking')];
         const changelogNotes = new DefaultChangelogNotes();


### PR DESCRIPTION
This is somewhat hacky as we are delegating the changelog generation to the conventional-changelog-writer package which is not doing the explicit issue linking for `notes`. That library has not been updated in months so it's unlikely that we can fix it there.

In the future, we should consider bringing the changelog generation in-house into the `DefaultChangelogNotes` class.

Fixes #1754