### PR TITLE
fix: handle incrementing ruby patch versions larger than 1 digit

### DIFF
--- a/__snapshots__/version-rb.js
+++ b/__snapshots__/version-rb.js
@@ -24,6 +24,31 @@ end
 
 `
 
+exports['version.rb updateContent updates long patch versions in version.rb 1'] = `
+# Copyright 2019 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+module Google
+  module Cloud
+    module Bigtable
+      VERSION = "0.6.11".freeze
+    end
+  end
+end
+
+`
+
 exports['version.rb updateContent updates version in version.rb 1'] = `
 # Copyright 2019 Google LLC
 #

--- a/src/updaters/ruby/version-rb.ts
+++ b/src/updaters/ruby/version-rb.ts
@@ -25,7 +25,7 @@ export class VersionRB extends DefaultUpdater {
    */
   updateContent(content: string): string {
     return content.replace(
-      /(["'])[0-9]+\.[0-9]+\.[0-9](-\w+)?["']/,
+      /(["'])[0-9]+\.[0-9]+\.[0-9]+(-\w+)?["']/,
       `$1${this.version}$1`
     );
   }

--- a/test/updaters/fixtures/version-with-long-patch.rb
+++ b/test/updaters/fixtures/version-with-long-patch.rb
@@ -1,0 +1,21 @@
+# Copyright 2019 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+module Google
+  module Cloud
+    module Bigtable
+      VERSION = "0.6.10".freeze
+    end
+  end
+end

--- a/test/updaters/version-rb.ts
+++ b/test/updaters/version-rb.ts
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+import {expect} from 'chai';
 import {readFileSync} from 'fs';
 import {resolve} from 'path';
 import * as snapshot from 'snap-shot-it';
@@ -44,6 +45,18 @@ describe('version.rb', () => {
         .replace(/"/g, "'");
       const version = new VersionRB({
         version: Version.parse('0.6.0'),
+      });
+      const newContent = version.updateContent(oldContent);
+      snapshot(newContent);
+    });
+
+    it('updates long patch versions in version.rb', async () => {
+      const oldContent = readFileSync(
+        resolve(fixturesPath, './version-with-long-patch.rb'),
+        'utf8'
+      ).replace(/\r\n/g, '\n');
+      const version = new VersionRB({
+        version: Version.parse('0.6.11'),
       });
       const newContent = version.updateContent(oldContent);
       snapshot(newContent);

--- a/test/updaters/version-rb.ts
+++ b/test/updaters/version-rb.ts
@@ -12,7 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import {expect} from 'chai';
 import {readFileSync} from 'fs';
 import {resolve} from 'path';
 import * as snapshot from 'snap-shot-it';


### PR DESCRIPTION
This fixes the linked issue by applying a small fix to updaters/version-rb.ts.

- [x] Make sure to open an issue as a [bug/issue](https://github.com/googleapis/release-please/issues/new/choose) before writing your code!  That way we can discuss the change, evaluate designs, and agree on the general idea
- [x] Ensure the tests and linter pass

Fixes #1761 🦕
