### PR TITLE
refactor!: parse conventional commits in manifest

### DIFF
--- a/__snapshots__/base.js
+++ b/__snapshots__/base.js
@@ -8,7 +8,7 @@ exports['Strategy buildReleasePullRequest allows overriding initial version 1'] 
 
 ### Miscellaneous Chores
 
-* initial commit ([abc123](https://github.com/googleapis/base-test-repo/commit/abc123))
+* initial commit ([16d3754](https://github.com/googleapis/base-test-repo/commit/16d3754a2134a6d19ee19d2e5ba4dfbc))
 
 ---
 This PR was generated with [Release Please](https://github.com/googleapis/release-please). See [documentation](https://github.com/googleapis/release-please#release-please).
@@ -24,7 +24,7 @@ exports['Strategy buildReleasePullRequest allows overriding initial version in b
 
 ### Features
 
-* initial commit ([abc123](https://github.com/googleapis/base-test-repo/commit/abc123))
+* initial commit ([a90fc00](https://github.com/googleapis/base-test-repo/commit/a90fc00ca62382346da72dd8f51078a7))
 
 ---
 This PR was generated with [Release Please](https://github.com/googleapis/release-please). See [documentation](https://github.com/googleapis/release-please#release-please).
@@ -40,7 +40,7 @@ exports['Strategy buildReleasePullRequest should pass changelogHost to default b
 
 ### Bug Fixes
 
-* a bugfix ([abc5566](https://example.com/googleapis/base-test-repo/commit/abc5566))
+* a bugfix ([6c1715c](https://example.com/googleapis/base-test-repo/commit/6c1715c07438036db68bb939cf36fe6f))
 
 ---
 This PR was generated with [Release Please](https://github.com/googleapis/release-please). See [documentation](https://github.com/googleapis/release-please#release-please).

--- a/src/manifest.ts
+++ b/src/manifest.ts
@@ -15,7 +15,7 @@
 import {ChangelogSection} from './changelog-notes';
 import {GitHub, GitHubRelease, GitHubTag} from './github';
 import {Version, VersionsMap} from './version';
-import {Commit} from './commit';
+import {Commit, parseConventionalCommits} from './commit';
 import {PullRequest} from './pull-request';
 import {logger as defaultLogger, Logger} from './util/logger';
 import {CommitSplit} from './util/commit-split';
@@ -677,7 +677,10 @@ export class Manifest {
       );
       this.logger.debug(`type: ${config.releaseType}`);
       this.logger.debug(`targetBranch: ${this.targetBranch}`);
-      let pathCommits = commitsPerPath[path];
+      let pathCommits = parseConventionalCommits(
+        commitsPerPath[path],
+        this.logger
+      );
       // The processCommits hook can be implemented by plugins to
       // post-process commits. This can be used to perform cleanup, e.g,, sentence
       // casing all commit messages:

--- a/src/plugin.ts
+++ b/src/plugin.ts
@@ -15,7 +15,7 @@
 import {GitHub} from './github';
 import {CandidateReleasePullRequest, RepositoryConfig} from './manifest';
 import {Strategy} from './strategy';
-import {Commit} from './commit';
+import {Commit, ConventionalCommit} from './commit';
 import {Release} from './release';
 import {logger as defaultLogger, Logger} from './util/logger';
 
@@ -47,9 +47,7 @@ export abstract class ManifestPlugin {
    * @param {Commit[]} commits The set of commits that will feed into release pull request.
    * @returns {Commit[]} The modified commit objects.
    */
-  // TODO: for next major version, let's run the default conventional commit parser earlier
-  // (outside of the strategy classes) and pass in the ConventionalCommit[] objects in.
-  processCommits(commits: Commit[]): Commit[] {
+  processCommits(commits: ConventionalCommit[]): ConventionalCommit[] {
     return commits;
   }
 

--- a/src/plugins/linked-versions.ts
+++ b/src/plugins/linked-versions.ts
@@ -17,7 +17,7 @@ import {RepositoryConfig, CandidateReleasePullRequest} from '../manifest';
 import {GitHub} from '../github';
 import {Logger} from '../util/logger';
 import {Strategy} from '../strategy';
-import {Commit} from '../commit';
+import {Commit, parseConventionalCommits} from '../commit';
 import {Release} from '../release';
 import {Version} from '../version';
 import {buildStrategy} from '../factory';
@@ -87,7 +87,7 @@ export class LinkedVersions extends ManifestPlugin {
       const strategy = groupStrategies[path];
       const latestRelease = releasesByPath[path];
       const releasePullRequest = await strategy.buildReleasePullRequest(
-        commitsByPath[path],
+        parseConventionalCommits(commitsByPath[path], this.logger),
         latestRelease
       );
       if (releasePullRequest?.version) {

--- a/src/plugins/sentence-case.ts
+++ b/src/plugins/sentence-case.ts
@@ -15,7 +15,7 @@
 import {ManifestPlugin} from '../plugin';
 import {GitHub} from '../github';
 import {RepositoryConfig} from '../manifest';
-import {Commit} from '../commit';
+import {ConventionalCommit} from '../commit';
 
 // A list of words that should not be converted to uppercase:
 const SPECIAL_WORDS = ['gRPC', 'npm'];
@@ -43,9 +43,13 @@ export class SentenceCase extends ManifestPlugin {
    * @param {Commit[]} commits The set of commits that will feed into release pull request.
    * @returns {Commit[]} The modified commit objects.
    */
-  processCommits(commits: Commit[]): Commit[] {
+  processCommits(commits: ConventionalCommit[]): ConventionalCommit[] {
     this.logger.info(`SentenceCase processing ${commits.length} commits`);
     for (const commit of commits) {
+      // The parsed conventional commit message, without the type:
+      console.info(commit.bareMessage);
+      commit.bareMessage = this.toUpperCase(commit.bareMessage);
+
       // Check whether commit is in conventional commit format, if it is
       // we'll split the string by type and description:
       if (commit.message.includes(':')) {

--- a/src/strategies/base.ts
+++ b/src/strategies/base.ts
@@ -25,7 +25,7 @@ import {
 import {DefaultVersioningStrategy} from '../versioning-strategies/default';
 import {DefaultChangelogNotes} from '../changelog-notes/default';
 import {Update} from '../update';
-import {ConventionalCommit, Commit, parseConventionalCommits} from '../commit';
+import {ConventionalCommit, Commit} from '../commit';
 import {Version, VersionsMap} from '../version';
 import {TagName} from '../util/tag-name';
 import {Release} from '../release';
@@ -249,14 +249,12 @@ export abstract class BaseStrategy implements Strategy {
    *   open a pull request.
    */
   async buildReleasePullRequest(
-    commits: Commit[],
+    commits: ConventionalCommit[],
     latestRelease?: Release,
     draft?: boolean,
     labels: string[] = []
   ): Promise<ReleasePullRequest | undefined> {
-    const conventionalCommits = await this.postProcessCommits(
-      parseConventionalCommits(commits, this.logger)
-    );
+    const conventionalCommits = await this.postProcessCommits(commits);
     this.logger.info(`Considering: ${conventionalCommits.length} commits`);
     if (conventionalCommits.length === 0) {
       this.logger.info(`No commits for path: ${this.path}, skipping`);

--- a/src/strategies/java.ts
+++ b/src/strategies/java.ts
@@ -17,7 +17,7 @@ import {Version} from '../version';
 import {BaseStrategy, BaseStrategyOptions, BuildUpdatesOptions} from './base';
 import {Changelog} from '../updaters/changelog';
 import {JavaSnapshot} from '../versioning-strategies/java-snapshot';
-import {Commit} from '../commit';
+import {ConventionalCommit} from '../commit';
 import {Release} from '../release';
 import {ReleasePullRequest} from '../release-pull-request';
 import {PullRequestTitle} from '../util/pull-request-title';
@@ -74,7 +74,7 @@ export class Java extends BaseStrategy {
   }
 
   async buildReleasePullRequest(
-    commits: Commit[],
+    commits: ConventionalCommit[],
     latestRelease?: Release,
     draft?: boolean,
     labels: string[] = []
@@ -156,7 +156,7 @@ export class Java extends BaseStrategy {
   }
 
   protected async needsSnapshot(
-    commits: Commit[],
+    commits: ConventionalCommit[],
     latestRelease?: Release
   ): Promise<boolean> {
     if (this.skipSnapshot) {

--- a/test/helpers.ts
+++ b/test/helpers.ts
@@ -20,7 +20,11 @@ import * as snapshot from 'snap-shot-it';
 import * as suggester from 'code-suggester';
 import {CreatePullRequestUserOptions} from 'code-suggester/build/src/types';
 import {Octokit} from '@octokit/rest';
-import {Commit} from '../src/commit';
+import {
+  Commit,
+  ConventionalCommit,
+  parseConventionalCommits,
+} from '../src/commit';
 import {GitHub, GitHubTag, GitHubRelease} from '../src/github';
 import {Update} from '../src/update';
 import {expect} from 'chai';
@@ -110,6 +114,23 @@ export function readPOJO(name: string): object {
   return JSON.parse(content);
 }
 
+export function buildMockConventionalCommit(
+  message: string,
+  files: string[] = []
+): ConventionalCommit[] {
+  return parseConventionalCommits([
+    {
+      // Ensure SHA is same on Windows with replace:
+      sha: crypto
+        .createHash('md5')
+        .update(message.replace(/\r\n/g, '\n'))
+        .digest('hex'),
+      message,
+      files: files,
+    },
+  ]);
+}
+
 export function buildMockCommit(message: string, files: string[] = []): Commit {
   return {
     // Ensure SHA is same on Windows with replace:
@@ -121,6 +142,7 @@ export function buildMockCommit(message: string, files: string[] = []): Commit {
     files: files,
   };
 }
+
 export function buildGitHubFileContent(
   fixturesPath: string,
   fixture: string

--- a/test/manifest.ts
+++ b/test/manifest.ts
@@ -2880,6 +2880,8 @@ describe('Manifest', () => {
         );
         const pullRequests = await manifest.buildPullRequests();
         expect(pullRequests).not.empty;
+        // This assertion verifies that conventional commit parsing
+        // was applied before calling the processCommits plugin hook:
         sinon.assert.calledWith(spyPlugin.processCommits, [
           {
             sha: 'aaaaaa',

--- a/test/plugins/sentence-case.ts
+++ b/test/plugins/sentence-case.ts
@@ -16,6 +16,7 @@ import {SentenceCase} from '../../src/plugins/sentence-case';
 import {expect} from 'chai';
 
 import {GitHub} from '../../src/github';
+import {buildMockConventionalCommit} from '../helpers';
 
 describe('SentenceCase Plugin', () => {
   let github: GitHub;
@@ -30,14 +31,8 @@ describe('SentenceCase Plugin', () => {
     it('converts description to sentence case', async () => {
       const plugin = new SentenceCase(github, 'main', {});
       const commits = await plugin.processCommits([
-        {
-          sha: 'abc123',
-          message: 'fix: hello world',
-        },
-        {
-          sha: 'abc123',
-          message: 'fix: Goodnight moon',
-        },
+        ...buildMockConventionalCommit('fix: hello world'),
+        ...buildMockConventionalCommit('fix: Goodnight moon'),
       ]);
       expect(commits[0].message).to.equal('fix: Hello world');
       expect(commits[1].message).to.equal('fix: Goodnight moon');
@@ -45,14 +40,8 @@ describe('SentenceCase Plugin', () => {
     it('leaves reserved words lowercase', async () => {
       const plugin = new SentenceCase(github, 'main', {});
       const commits = await plugin.processCommits([
-        {
-          sha: 'abc123',
-          message: 'feat: gRPC can now handle proxies',
-        },
-        {
-          sha: 'abc123',
-          message: 'fix: npm now rocks',
-        },
+        ...buildMockConventionalCommit('feat: gRPC can now handle proxies'),
+        ...buildMockConventionalCommit('fix: npm now rocks'),
       ]);
       expect(commits[0].message).to.equal('feat: gRPC can now handle proxies');
       expect(commits[1].message).to.equal('fix: npm now rocks');
@@ -60,14 +49,8 @@ describe('SentenceCase Plugin', () => {
     it('handles sentences with now breaks', async () => {
       const plugin = new SentenceCase(github, 'main', {});
       const commits = await plugin.processCommits([
-        {
-          sha: 'abc123',
-          message: 'feat: beep-boop-hello',
-        },
-        {
-          sha: 'abc123',
-          message: 'fix:log4j.foo.bar',
-        },
+        ...buildMockConventionalCommit('feat: beep-boop-hello'),
+        ...buildMockConventionalCommit('fix:log4j.foo.bar'),
       ]);
       expect(commits[0].message).to.equal('feat: Beep-boop-hello');
       expect(commits[1].message).to.equal('fix: Log4j.foo.bar');
@@ -76,14 +59,8 @@ describe('SentenceCase Plugin', () => {
   it('allows a custom list of specialWords to be provided', async () => {
     const plugin = new SentenceCase(github, 'main', {}, ['hello']);
     const commits = await plugin.processCommits([
-      {
-        sha: 'abc123',
-        message: 'fix: hello world',
-      },
-      {
-        sha: 'abc123',
-        message: 'fix: Goodnight moon',
-      },
+      ...buildMockConventionalCommit('fix: hello world'),
+      ...buildMockConventionalCommit('fix: Goodnight moon'),
     ]);
     expect(commits[0].message).to.equal('fix: hello world');
     expect(commits[1].message).to.equal('fix: Goodnight moon');
@@ -91,24 +68,20 @@ describe('SentenceCase Plugin', () => {
   it('handles subject with multiple : characters', async () => {
     const plugin = new SentenceCase(github, 'main', {}, []);
     const commits = await plugin.processCommits([
-      {
-        sha: 'abc123',
-        message: 'fix: hello world:goodnight moon',
-      },
+      ...buildMockConventionalCommit('abc123'),
+      ...buildMockConventionalCommit('fix: hello world:goodnight moon'),
     ]);
     expect(commits[0].message).to.equal('fix: Hello world:goodnight moon');
   });
   it('handles commit with no :', async () => {
     const plugin = new SentenceCase(github, 'main', {}, []);
     const commits = await plugin.processCommits([
-      {
-        sha: 'abc123',
-        message: 'hello world goodnight moon',
-      },
+      ...buildMockConventionalCommit('hello world goodnight moon'),
     ]);
     // Ensure there's no exception, a commit without a <type> is not
     // a conventional commit, and will not show up in CHANGELOG. We
     // Do not bother sentence-casing:
-    expect(commits[0].message).to.equal('hello world goodnight moon');
+    console.info(commits);
+    expect(commits.length).to.equal(0);
   });
 });

--- a/test/strategies/base.ts
+++ b/test/strategies/base.ts
@@ -20,7 +20,11 @@ import {Update} from '../../src/update';
 import {GitHub} from '../../src/github';
 import {PullRequestBody} from '../../src/util/pull-request-body';
 import snapshot = require('snap-shot-it');
-import {dateSafe, assertHasUpdate} from '../helpers';
+import {
+  dateSafe,
+  assertHasUpdate,
+  buildMockConventionalCommit,
+} from '../helpers';
 import {GenericJson} from '../../src/updaters/generic-json';
 import {Generic} from '../../src/updaters/generic';
 import {GenericXml} from '../../src/updaters/generic-xml';
@@ -63,12 +67,9 @@ describe('Strategy', () => {
         github,
         component: 'google-cloud-automl',
       });
-      const commits = [
-        {
-          sha: 'abc123',
-          message: 'chore: initial commit\n\nRelease-As: 2.3.4',
-        },
-      ];
+      const commits = buildMockConventionalCommit(
+        'chore: initial commit\n\nRelease-As: 2.3.4'
+      );
       const pullRequest = await strategy.buildReleasePullRequest(commits);
       expect(pullRequest).to.not.be.undefined;
       expect(pullRequest?.version?.toString()).to.eql('2.3.4');
@@ -81,12 +82,7 @@ describe('Strategy', () => {
         component: 'google-cloud-automl',
         initialVersion: '0.1.0',
       });
-      const commits = [
-        {
-          sha: 'abc123',
-          message: 'feat: initial commit',
-        },
-      ];
+      const commits = buildMockConventionalCommit('feat: initial commit');
       const pullRequest = await strategy.buildReleasePullRequest(commits);
       expect(pullRequest).to.not.be.undefined;
       expect(pullRequest?.version?.toString()).to.eql('0.1.0');
@@ -100,7 +96,7 @@ describe('Strategy', () => {
         extraFiles: ['0', 'foo/1.~csv', 'foo/2.bak', 'foo/baz/bar/', '/3.java'],
       });
       const pullRequest = await strategy.buildReleasePullRequest(
-        [{sha: 'aaa', message: 'fix: a bugfix'}],
+        buildMockConventionalCommit('fix: a bugfix'),
         undefined
       );
       expect(pullRequest).to.exist;
@@ -123,7 +119,7 @@ describe('Strategy', () => {
         extraFiles: ['0', {type: 'json', path: '/3.json', jsonpath: '$.foo'}],
       });
       const pullRequest = await strategy.buildReleasePullRequest(
-        [{sha: 'aaa', message: 'fix: a bugfix'}],
+        buildMockConventionalCommit('fix: a bugfix'),
         undefined
       );
       expect(pullRequest).to.exist;
@@ -140,7 +136,7 @@ describe('Strategy', () => {
         extraFiles: ['0', {type: 'yaml', path: '/3.yaml', jsonpath: '$.foo'}],
       });
       const pullRequest = await strategy.buildReleasePullRequest(
-        [{sha: 'aaa', message: 'fix: a bugfix'}],
+        buildMockConventionalCommit('fix: a bugfix'),
         undefined
       );
       expect(pullRequest).to.exist;
@@ -157,7 +153,7 @@ describe('Strategy', () => {
         extraFiles: ['0', {type: 'xml', path: '/3.xml', xpath: '$.foo'}],
       });
       const pullRequest = await strategy.buildReleasePullRequest(
-        [{sha: 'aaa', message: 'fix: a bugfix'}],
+        buildMockConventionalCommit('fix: a bugfix'),
         undefined
       );
       expect(pullRequest).to.exist;
@@ -174,7 +170,7 @@ describe('Strategy', () => {
         extraFiles: ['0', {type: 'pom', path: '/3.xml'}],
       });
       const pullRequest = await strategy.buildReleasePullRequest(
-        [{sha: 'aaa', message: 'fix: a bugfix'}],
+        buildMockConventionalCommit('fix: a bugfix'),
         undefined
       );
       expect(pullRequest).to.exist;
@@ -202,7 +198,7 @@ describe('Strategy', () => {
         ],
       });
       const pullRequest = await strategy.buildReleasePullRequest(
-        [{sha: 'aaa', message: 'fix: a bugfix'}],
+        buildMockConventionalCommit('fix: a bugfix'),
         undefined
       );
       expect(pullRequest).to.exist;
@@ -219,12 +215,7 @@ describe('Strategy', () => {
         component: 'google-cloud-automl',
         changelogHost: 'https://example.com',
       });
-      const commits = [
-        {
-          sha: 'abc5566',
-          message: 'fix: a bugfix',
-        },
-      ];
+      const commits = buildMockConventionalCommit('fix: a bugfix');
       const pullRequest = await strategy.buildReleasePullRequest(commits);
       expect(pullRequest).to.exist;
       expect(pullRequest?.body.toString()).to.have.string(
@@ -253,7 +244,7 @@ describe('Strategy', () => {
             extraFiles: [file],
           });
           await strategy.buildReleasePullRequest(
-            [{sha: 'aaa', message: 'fix: a bugfix'}],
+            buildMockConventionalCommit('fix: a bugfix'),
             undefined
           );
           expect.fail(`expected [addPath] to reject path: ${file}`);
@@ -273,7 +264,7 @@ describe('Strategy', () => {
         extraLabels: ['foo', 'bar'],
       });
       const pullRequest = await strategy.buildReleasePullRequest(
-        [{sha: 'aaa', message: 'fix: a bugfix'}],
+        buildMockConventionalCommit('fix: a bugfix'),
         undefined
       );
       expect(pullRequest).to.exist;

--- a/test/strategies/dart.ts
+++ b/test/strategies/dart.ts
@@ -15,7 +15,7 @@
 import {describe, it, afterEach, beforeEach} from 'mocha';
 import {Dart} from '../../src/strategies/dart';
 import {
-  buildMockCommit,
+  buildMockConventionalCommit,
   buildGitHubFileContent,
   assertHasUpdate,
 } from '../helpers';
@@ -46,7 +46,7 @@ describe('Dart', () => {
   });
   describe('buildReleasePullRequest', () => {
     const commits = [
-      buildMockCommit(
+      ...buildMockConventionalCommit(
         'fix(deps): update dependency com.google.cloud:google-cloud-storage to v1.120.0'
       ),
     ];
@@ -92,7 +92,7 @@ describe('Dart', () => {
         github,
       });
       const commits = [
-        buildMockCommit(
+        ...buildMockConventionalCommit(
           'fix(deps): update dependency com.google.cloud:google-cloud-storage to v1.120.0'
         ),
       ];
@@ -124,7 +124,7 @@ describe('Dart', () => {
         packageName: 'some-dart-package',
       });
       const commits = [
-        buildMockCommit(
+        ...buildMockConventionalCommit(
           'fix(deps): update dependency com.google.cloud:google-cloud-storage to v1.120.0'
         ),
       ];

--- a/test/strategies/dotnet-yoshi.ts
+++ b/test/strategies/dotnet-yoshi.ts
@@ -23,7 +23,7 @@ import {
   buildGitHubFileContent,
   assertNoHasUpdate,
 } from '../helpers';
-import {buildMockCommit} from '../helpers';
+import {buildMockConventionalCommit} from '../helpers';
 import {TagName} from '../../src/util/tag-name';
 import {Changelog} from '../../src/updaters/changelog';
 import {PullRequestBody} from '../../src/util/pull-request-body';
@@ -33,13 +33,13 @@ const sandbox = sinon.createSandbox();
 const fixturesPath = './test/fixtures/strategies/dotnet-yoshi';
 
 const COMMITS = [
-  buildMockCommit(
+  ...buildMockConventionalCommit(
     'fix(deps): update dependency com.google.cloud:google-cloud-storage to v1.120.0'
   ),
-  buildMockCommit(
+  ...buildMockConventionalCommit(
     'fix(deps): update dependency com.google.cloud:google-cloud-spanner to v1.50.0'
   ),
-  buildMockCommit('chore: update common templates'),
+  ...buildMockConventionalCommit('chore: update common templates'),
 ];
 
 describe('DotnetYoshi', () => {

--- a/test/strategies/elixir.ts
+++ b/test/strategies/elixir.ts
@@ -14,7 +14,7 @@
 
 import {describe, it, afterEach, beforeEach} from 'mocha';
 import {Elixir} from '../../src/strategies/elixir';
-import {buildMockCommit, assertHasUpdate} from '../helpers';
+import {buildMockConventionalCommit, assertHasUpdate} from '../helpers';
 import * as nock from 'nock';
 import * as sinon from 'sinon';
 import {GitHub} from '../../src/github';
@@ -30,7 +30,7 @@ const sandbox = sinon.createSandbox();
 describe('Elixir', () => {
   let github: GitHub;
   const commits = [
-    buildMockCommit(
+    ...buildMockConventionalCommit(
       'fix(deps): update dependency com.google.cloud:google-cloud-storage to v1.120.0'
     ),
   ];

--- a/test/strategies/expo.ts
+++ b/test/strategies/expo.ts
@@ -15,7 +15,7 @@
 import {describe, it, afterEach, beforeEach} from 'mocha';
 import {Expo} from '../../src/strategies/expo';
 import {
-  buildMockCommit,
+  buildMockConventionalCommit,
   buildGitHubFileContent,
   assertHasUpdate,
 } from '../helpers';
@@ -38,7 +38,7 @@ const expoFixturesPath = './test/fixtures/strategies/expo';
 describe('Expo', () => {
   let github: GitHub;
   const commits = [
-    buildMockCommit(
+    ...buildMockConventionalCommit(
       'fix(deps): update dependency com.google.cloud:google-cloud-storage to v1.120.0'
     ),
   ];
@@ -126,7 +126,7 @@ describe('Expo', () => {
         github,
       });
       const commits = [
-        buildMockCommit(
+        ...buildMockConventionalCommit(
           'fix(deps): update dependency com.google.cloud:google-cloud-storage to v1.120.0'
         ),
       ];
@@ -159,7 +159,7 @@ describe('Expo', () => {
         component: 'abc-123',
       });
       const commits = [
-        buildMockCommit(
+        ...buildMockConventionalCommit(
           'fix(deps): update dependency com.google.cloud:google-cloud-storage to v1.120.0'
         ),
       ];

--- a/test/strategies/go-yoshi.ts
+++ b/test/strategies/go-yoshi.ts
@@ -18,7 +18,7 @@ import {GitHub} from '../../src/github';
 import {GoYoshi} from '../../src/strategies/go-yoshi';
 import * as sinon from 'sinon';
 import {assertHasUpdate, dateSafe} from '../helpers';
-import {buildMockCommit} from '../helpers';
+import {buildMockConventionalCommit} from '../helpers';
 import {TagName} from '../../src/util/tag-name';
 import {Version} from '../../src/version';
 import {Changelog} from '../../src/updaters/changelog';
@@ -28,11 +28,11 @@ import {VersionGo} from '../../src/updaters/go/version-go';
 const sandbox = sinon.createSandbox();
 
 const COMMITS = [
-  buildMockCommit(
+  ...buildMockConventionalCommit(
     'fix(iam): update dependency com.google.cloud:google-cloud-storage to v1.120.0',
     ['iam/foo.go']
   ),
-  buildMockCommit('chore: update common templates'),
+  ...buildMockConventionalCommit('chore: update common templates'),
 ];
 
 describe('GoYoshi', () => {
@@ -110,10 +110,10 @@ describe('GoYoshi', () => {
         includeComponentInTag: false,
       });
       const commits = [
-        buildMockCommit('fix: some generic fix'),
-        buildMockCommit('fix(translate): some translate fix'),
-        buildMockCommit('fix(logging): some logging fix'),
-        buildMockCommit('feat: some generic feature'),
+        ...buildMockConventionalCommit('fix: some generic fix'),
+        ...buildMockConventionalCommit('fix(translate): some translate fix'),
+        ...buildMockConventionalCommit('fix(logging): some logging fix'),
+        ...buildMockConventionalCommit('feat: some generic feature'),
       ];
       const pullRequest = await strategy.buildReleasePullRequest(commits);
       const pullRequestBody = pullRequest!.body.toString();
@@ -131,12 +131,12 @@ describe('GoYoshi', () => {
         includeComponentInTag: false,
       });
       const commits = [
-        buildMockCommit('fix: some generic fix'),
-        buildMockCommit('fix(iam/apiv1): some firestore fix', [
+        ...buildMockConventionalCommit('fix: some generic fix'),
+        ...buildMockConventionalCommit('fix(iam/apiv1): some firestore fix', [
           'accessapproval/apiv1/access_approval_client.go',
           'iam/apiv1/admin/firestore_admin_client.go',
         ]),
-        buildMockCommit('feat: some generic feature'),
+        ...buildMockConventionalCommit('feat: some generic feature'),
       ];
       const pullRequest = await strategy.buildReleasePullRequest(commits);
       const pullRequestBody = pullRequest!.body.toString();
@@ -156,10 +156,18 @@ describe('GoYoshi', () => {
         github,
       });
       const commits = [
-        buildMockCommit('feat(all): auto-regenerate discovery clients (#1281)'),
-        buildMockCommit('feat(all): auto-regenerate discovery clients (#1280)'),
-        buildMockCommit('feat(all): auto-regenerate discovery clients (#1279)'),
-        buildMockCommit('feat(all): auto-regenerate discovery clients (#1278)'),
+        ...buildMockConventionalCommit(
+          'feat(all): auto-regenerate discovery clients (#1281)'
+        ),
+        ...buildMockConventionalCommit(
+          'feat(all): auto-regenerate discovery clients (#1280)'
+        ),
+        ...buildMockConventionalCommit(
+          'feat(all): auto-regenerate discovery clients (#1279)'
+        ),
+        ...buildMockConventionalCommit(
+          'feat(all): auto-regenerate discovery clients (#1278)'
+        ),
       ];
       const pullRequest = await strategy.buildReleasePullRequest(commits);
       const pullRequestBody = pullRequest!.body.toString();

--- a/test/strategies/go.ts
+++ b/test/strategies/go.ts
@@ -18,7 +18,7 @@ import {GitHub} from '../../src/github';
 import {Go} from '../../src/strategies/go';
 import * as sinon from 'sinon';
 import {assertHasUpdate} from '../helpers';
-import {buildMockCommit} from '../helpers';
+import {buildMockConventionalCommit} from '../helpers';
 import {TagName} from '../../src/util/tag-name';
 import {Version} from '../../src/version';
 import {Changelog} from '../../src/updaters/changelog';
@@ -26,13 +26,13 @@ import {Changelog} from '../../src/updaters/changelog';
 const sandbox = sinon.createSandbox();
 
 const COMMITS = [
-  buildMockCommit(
+  ...buildMockConventionalCommit(
     'fix(deps): update dependency com.google.cloud:google-cloud-storage to v1.120.0'
   ),
-  buildMockCommit(
+  ...buildMockConventionalCommit(
     'fix(deps): update dependency com.google.cloud:google-cloud-spanner to v1.50.0'
   ),
-  buildMockCommit('chore: update common templates'),
+  ...buildMockConventionalCommit('chore: update common templates'),
 ];
 
 describe('Go', () => {

--- a/test/strategies/helm.ts
+++ b/test/strategies/helm.ts
@@ -15,7 +15,7 @@
 import {describe, it, afterEach, beforeEach} from 'mocha';
 import {Helm} from '../../src/strategies/helm';
 import {
-  buildMockCommit,
+  buildMockConventionalCommit,
   buildGitHubFileContent,
   assertHasUpdate,
 } from '../helpers';
@@ -35,7 +35,7 @@ const fixturesPath = './test/fixtures/strategies/helm';
 describe('Helm', () => {
   let github: GitHub;
   const commits = [
-    buildMockCommit(
+    ...buildMockConventionalCommit(
       'fix(deps): update dependency com.google.cloud:google-cloud-storage to v1.120.0'
     ),
   ];

--- a/test/strategies/java-yoshi.ts
+++ b/test/strategies/java-yoshi.ts
@@ -22,7 +22,7 @@ import {
   assertHasUpdate,
   assertNoHasUpdate,
 } from '../helpers';
-import {buildMockCommit} from '../helpers';
+import {buildMockConventionalCommit} from '../helpers';
 import {TagName} from '../../src/util/tag-name';
 import {Version} from '../../src/version';
 import {Changelog} from '../../src/updaters/changelog';
@@ -34,13 +34,13 @@ const sandbox = sinon.createSandbox();
 const fixturesPath = './test/fixtures/strategies/java-yoshi';
 
 const COMMITS = [
-  buildMockCommit(
+  ...buildMockConventionalCommit(
     'fix(deps): update dependency com.google.cloud:google-cloud-storage to v1.120.0'
   ),
-  buildMockCommit(
+  ...buildMockConventionalCommit(
     'fix(deps): update dependency com.google.cloud:google-cloud-spanner to v1.50.0'
   ),
-  buildMockCommit('chore: update common templates'),
+  ...buildMockConventionalCommit('chore: update common templates'),
 ];
 
 describe('JavaYoshi', () => {
@@ -134,7 +134,9 @@ describe('JavaYoshi', () => {
     });
     it('handles promotion to 1.0.0', async () => {
       const commits = [
-        buildMockCommit('feat: promote to 1.0.0\n\nRelease-As: 1.0.0'),
+        ...buildMockConventionalCommit(
+          'feat: promote to 1.0.0\n\nRelease-As: 1.0.0'
+        ),
       ];
       const expectedVersion = '1.0.0';
       const strategy = new JavaYoshi({

--- a/test/strategies/java.ts
+++ b/test/strategies/java.ts
@@ -20,7 +20,7 @@ import {
   assertHasUpdate,
   assertHasUpdates,
   assertNoHasUpdate,
-  buildMockCommit,
+  buildMockConventionalCommit,
 } from '../helpers';
 import {expect} from 'chai';
 import {Version} from '../../src/version';
@@ -47,13 +47,13 @@ describe('Java', () => {
   describe('buildReleasePullRequest', () => {
     describe('for default component', () => {
       const COMMITS_NO_SNAPSHOT = [
-        buildMockCommit('fix(deps): update dependency'),
-        buildMockCommit('fix(deps): update dependency'),
-        buildMockCommit('chore: update common templates'),
+        ...buildMockConventionalCommit('fix(deps): update dependency'),
+        ...buildMockConventionalCommit('fix(deps): update dependency'),
+        ...buildMockConventionalCommit('chore: update common templates'),
       ];
       const COMMITS_WITH_SNAPSHOT = [
         ...COMMITS_NO_SNAPSHOT,
-        buildMockCommit('chore(main): release 2.3.4-SNAPSHOT'),
+        ...buildMockConventionalCommit('chore(main): release 2.3.4-SNAPSHOT'),
       ];
 
       it('returns release PR changes with defaultInitialVersion', async () => {
@@ -192,7 +192,9 @@ describe('Java', () => {
         };
         const release = await strategy.buildReleasePullRequest(
           [
-            buildMockCommit('chore(main): release other 2.3.4-SNAPSHOT'),
+            ...buildMockConventionalCommit(
+              'chore(main): release other 2.3.4-SNAPSHOT'
+            ),
             ...COMMITS_NO_SNAPSHOT,
           ],
           latestRelease
@@ -290,14 +292,20 @@ describe('Java', () => {
 
     describe('with includeComponentInTag', () => {
       const COMMITS_NO_SNAPSHOT = [
-        buildMockCommit('fix(deps): update dependency'),
-        buildMockCommit('fix(deps): update dependency'),
-        buildMockCommit('chore: update common templates'),
-        buildMockCommit('chore(main): release other-sample 13.3.5'),
+        ...buildMockConventionalCommit('fix(deps): update dependency'),
+        ...buildMockConventionalCommit('fix(deps): update dependency'),
+        ...buildMockConventionalCommit('chore: update common templates'),
+        ...buildMockConventionalCommit(
+          'chore(main): release other-sample 13.3.5'
+        ),
       ];
       const COMMITS_WITH_SNAPSHOT = COMMITS_NO_SNAPSHOT.concat(
-        buildMockCommit('chore(main): release other-sample 13.3.6-SNAPSHOT'),
-        buildMockCommit('chore(main): release test-sample 2.3.4-SNAPSHOT')
+        ...buildMockConventionalCommit(
+          'chore(main): release other-sample 13.3.6-SNAPSHOT'
+        ),
+        ...buildMockConventionalCommit(
+          'chore(main): release test-sample 2.3.4-SNAPSHOT'
+        )
       );
 
       it('returns release PR changes with defaultInitialVersion', async () => {

--- a/test/strategies/krm-blueprint.ts
+++ b/test/strategies/krm-blueprint.ts
@@ -15,7 +15,7 @@
 import {describe, it, afterEach, beforeEach} from 'mocha';
 import {KRMBlueprint} from '../../src/strategies/krm-blueprint';
 import {
-  buildMockCommit,
+  buildMockConventionalCommit,
   stubFilesFromFixtures,
   assertHasUpdate,
   assertNoHasUpdate,
@@ -36,7 +36,7 @@ const fixturesPath = './test/fixtures/strategies/krm-blueprint';
 describe('KRMBlueprint', () => {
   let github: GitHub;
   const commits = [
-    buildMockCommit(
+    ...buildMockConventionalCommit(
       'fix(deps): update dependency com.google.cloud:google-cloud-storage to v1.120.0'
     ),
   ];

--- a/test/strategies/maven.ts
+++ b/test/strategies/maven.ts
@@ -15,7 +15,11 @@
 import {afterEach, beforeEach, describe, it} from 'mocha';
 import {GitHub} from '../../src';
 import * as sinon from 'sinon';
-import {assertHasUpdate, assertHasUpdates, buildMockCommit} from '../helpers';
+import {
+  assertHasUpdate,
+  assertHasUpdates,
+  buildMockConventionalCommit,
+} from '../helpers';
 import {Changelog} from '../../src/updaters/changelog';
 import {Generic} from '../../src/updaters/generic';
 import {JavaReleased} from '../../src/updaters/java/java-released';
@@ -28,8 +32,8 @@ import {expect} from 'chai';
 const sandbox = sinon.createSandbox();
 
 const COMMITS = [
-  buildMockCommit('fix(deps): update dependency'),
-  buildMockCommit('chore: update common templates'),
+  ...buildMockConventionalCommit('fix(deps): update dependency'),
+  ...buildMockConventionalCommit('chore: update common templates'),
 ];
 
 describe('Maven', () => {

--- a/test/strategies/node.ts
+++ b/test/strategies/node.ts
@@ -15,7 +15,7 @@
 import {describe, it, afterEach, beforeEach} from 'mocha';
 import {Node} from '../../src/strategies/node';
 import {
-  buildMockCommit,
+  buildMockConventionalCommit,
   buildGitHubFileContent,
   assertHasUpdate,
 } from '../helpers';
@@ -39,7 +39,7 @@ const fixturesPath = './test/fixtures/strategies/node';
 describe('Node', () => {
   let github: GitHub;
   const commits = [
-    buildMockCommit(
+    ...buildMockConventionalCommit(
       'fix(deps): update dependency com.google.cloud:google-cloud-storage to v1.120.0'
     ),
   ];
@@ -95,7 +95,7 @@ describe('Node', () => {
         github,
       });
       const commits = [
-        buildMockCommit(
+        ...buildMockConventionalCommit(
           'fix(deps): update dependency com.google.cloud:google-cloud-storage to v1.120.0'
         ),
       ];
@@ -125,7 +125,7 @@ describe('Node', () => {
         component: 'abc-123',
       });
       const commits = [
-        buildMockCommit(
+        ...buildMockConventionalCommit(
           'fix(deps): update dependency com.google.cloud:google-cloud-storage to v1.120.0'
         ),
       ];

--- a/test/strategies/ocaml.ts
+++ b/test/strategies/ocaml.ts
@@ -22,7 +22,7 @@ import {
   assertNoHasUpdate,
   stubFilesFromFixtures,
 } from '../helpers';
-import {buildMockCommit} from '../helpers';
+import {buildMockConventionalCommit} from '../helpers';
 import {TagName} from '../../src/util/tag-name';
 import {Version} from '../../src/version';
 import {Changelog} from '../../src/updaters/changelog';
@@ -34,13 +34,13 @@ const sandbox = sinon.createSandbox();
 const fixturesPath = './test/fixtures/strategies/ocaml';
 
 const COMMITS = [
-  buildMockCommit(
+  ...buildMockConventionalCommit(
     'fix(deps): update dependency com.google.cloud:google-cloud-storage to v1.120.0'
   ),
-  buildMockCommit(
+  ...buildMockConventionalCommit(
     'fix(deps): update dependency com.google.cloud:google-cloud-spanner to v1.50.0'
   ),
-  buildMockCommit('chore: update common templates'),
+  ...buildMockConventionalCommit('chore: update common templates'),
 ];
 
 describe('OCaml', () => {

--- a/test/strategies/php-yoshi.ts
+++ b/test/strategies/php-yoshi.ts
@@ -18,7 +18,7 @@ import {GitHub} from '../../src/github';
 import {PHPYoshi} from '../../src/strategies/php-yoshi';
 import * as sinon from 'sinon';
 import {assertHasUpdate, buildGitHubFileRaw, dateSafe} from '../helpers';
-import {buildMockCommit} from '../helpers';
+import {buildMockConventionalCommit} from '../helpers';
 import {TagName} from '../../src/util/tag-name';
 import {Version} from '../../src/version';
 import {Changelog} from '../../src/updaters/changelog';
@@ -37,15 +37,15 @@ describe('PHPYoshi', () => {
   let github: GitHub;
   let getFileStub: sinon.SinonStub;
   const commits = [
-    buildMockCommit(
+    ...buildMockConventionalCommit(
       'fix(deps): update dependency com.google.cloud:google-cloud-storage to v1.120.0',
       ['Client1/foo.php']
     ),
-    buildMockCommit(
+    ...buildMockConventionalCommit(
       'fix(deps): update dependency com.google.cloud:google-cloud-spanner to v1.50.0',
       ['Client2/foo.php', 'Client3/bar.php']
     ),
-    buildMockCommit('misc: update common templates'),
+    ...buildMockConventionalCommit('misc: update common templates'),
   ];
   beforeEach(async () => {
     github = await GitHub.create({
@@ -179,15 +179,15 @@ describe('PHPYoshi', () => {
       });
       const latestRelease = undefined;
       const commits = [
-        buildMockCommit(
+        ...buildMockConventionalCommit(
           'fix(deps): update dependency com.google.cloud:google-cloud-storage to v1.120.0',
           ['Client1/foo.php', '.git/release-please.yml']
         ),
-        buildMockCommit(
+        ...buildMockConventionalCommit(
           'fix(deps): update dependency com.google.cloud:google-cloud-spanner to v1.50.0',
           ['Client2/foo.php', 'Client3/bar.php']
         ),
-        buildMockCommit('misc: update common templates'),
+        ...buildMockConventionalCommit('misc: update common templates'),
       ];
       getFileStub
         .withArgs('.git/VERSION', 'main')

--- a/test/strategies/php.ts
+++ b/test/strategies/php.ts
@@ -18,7 +18,7 @@ import {GitHub} from '../../src/github';
 import {PHP} from '../../src/strategies/php';
 import * as sinon from 'sinon';
 import {assertHasUpdate} from '../helpers';
-import {buildMockCommit} from '../helpers';
+import {buildMockConventionalCommit} from '../helpers';
 import {TagName} from '../../src/util/tag-name';
 import {Version} from '../../src/version';
 import {Changelog} from '../../src/updaters/changelog';
@@ -27,13 +27,13 @@ import {RootComposerUpdatePackages} from '../../src/updaters/php/root-composer-u
 const sandbox = sinon.createSandbox();
 
 const COMMITS = [
-  buildMockCommit(
+  ...buildMockConventionalCommit(
     'fix(deps): update dependency com.google.cloud:google-cloud-storage to v1.120.0'
   ),
-  buildMockCommit(
+  ...buildMockConventionalCommit(
     'fix(deps): update dependency com.google.cloud:google-cloud-spanner to v1.50.0'
   ),
-  buildMockCommit('chore: update common templates'),
+  ...buildMockConventionalCommit('chore: update common templates'),
 ];
 
 describe('PHP', () => {

--- a/test/strategies/python.ts
+++ b/test/strategies/python.ts
@@ -18,7 +18,7 @@ import {GitHub} from '../../src/github';
 import {Python} from '../../src/strategies/python';
 import * as sinon from 'sinon';
 import {buildGitHubFileContent, assertHasUpdate} from '../helpers';
-import {buildMockCommit} from '../helpers';
+import {buildMockConventionalCommit} from '../helpers';
 import {PythonFileWithVersion} from '../../src/updaters/python/python-file-with-version';
 import {TagName} from '../../src/util/tag-name';
 import {Version} from '../../src/version';
@@ -30,13 +30,13 @@ import {Changelog} from '../../src/updaters/changelog';
 const sandbox = sinon.createSandbox();
 
 const COMMITS = [
-  buildMockCommit(
+  ...buildMockConventionalCommit(
     'fix(deps): update dependency com.google.cloud:google-cloud-storage to v1.120.0'
   ),
-  buildMockCommit(
+  ...buildMockConventionalCommit(
     'fix(deps): update dependency com.google.cloud:google-cloud-spanner to v1.50.0'
   ),
-  buildMockCommit('chore: update common templates'),
+  ...buildMockConventionalCommit('chore: update common templates'),
 ];
 
 describe('Python', () => {

--- a/test/strategies/ruby-yoshi.ts
+++ b/test/strategies/ruby-yoshi.ts
@@ -18,7 +18,7 @@ import {GitHub} from '../../src/github';
 import {RubyYoshi} from '../../src/strategies/ruby-yoshi';
 import * as sinon from 'sinon';
 import {assertHasUpdate, safeSnapshot} from '../helpers';
-import {buildMockCommit} from '../helpers';
+import {buildMockConventionalCommit} from '../helpers';
 import {TagName} from '../../src/util/tag-name';
 import {Version} from '../../src/version';
 import {Changelog} from '../../src/updaters/changelog';
@@ -27,15 +27,15 @@ import {VersionRB} from '../../src/updaters/ruby/version-rb';
 const sandbox = sinon.createSandbox();
 
 const COMMITS = [
-  buildMockCommit(
+  ...buildMockConventionalCommit(
     'fix(deps): update dependency com.google.cloud:google-cloud-storage to v1.120.0 (#1234)',
     ['path1/foo.rb']
   ),
-  buildMockCommit(
+  ...buildMockConventionalCommit(
     'fix(deps): update dependency com.google.cloud:google-cloud-spanner to v1.50.0',
     ['path1/foo.rb', 'path2/bar.rb']
   ),
-  buildMockCommit('chore: update common templates'),
+  ...buildMockConventionalCommit('chore: update common templates'),
 ];
 
 describe('RubyYoshi', () => {

--- a/test/strategies/ruby.ts
+++ b/test/strategies/ruby.ts
@@ -18,7 +18,7 @@ import {GitHub} from '../../src/github';
 import {Ruby} from '../../src/strategies/ruby';
 import * as sinon from 'sinon';
 import {assertHasUpdate} from '../helpers';
-import {buildMockCommit} from '../helpers';
+import {buildMockConventionalCommit} from '../helpers';
 import {TagName} from '../../src/util/tag-name';
 import {Version} from '../../src/version';
 import {Changelog} from '../../src/updaters/changelog';
@@ -28,13 +28,13 @@ import {PullRequestBody} from '../../src/util/pull-request-body';
 const sandbox = sinon.createSandbox();
 
 const COMMITS = [
-  buildMockCommit(
+  ...buildMockConventionalCommit(
     'fix(deps): update dependency com.google.cloud:google-cloud-storage to v1.120.0'
   ),
-  buildMockCommit(
+  ...buildMockConventionalCommit(
     'fix(deps): update dependency com.google.cloud:google-cloud-spanner to v1.50.0'
   ),
-  buildMockCommit('chore: update common templates'),
+  ...buildMockConventionalCommit('chore: update common templates'),
 ];
 
 describe('Ruby', () => {

--- a/test/strategies/rust.ts
+++ b/test/strategies/rust.ts
@@ -18,7 +18,7 @@ import {GitHub} from '../../src/github';
 import {Rust} from '../../src/strategies/rust';
 import * as sinon from 'sinon';
 import {buildGitHubFileContent, assertHasUpdate, dateSafe} from '../helpers';
-import {buildMockCommit} from '../helpers';
+import {buildMockConventionalCommit} from '../helpers';
 import {TagName} from '../../src/util/tag-name';
 import {Version} from '../../src/version';
 import {Changelog} from '../../src/updaters/changelog';
@@ -29,13 +29,13 @@ import snapshot = require('snap-shot-it');
 const sandbox = sinon.createSandbox();
 
 const COMMITS = [
-  buildMockCommit(
+  ...buildMockConventionalCommit(
     'fix(deps): update dependency com.google.cloud:google-cloud-storage to v1.120.0'
   ),
-  buildMockCommit(
+  ...buildMockConventionalCommit(
     'fix(deps): update dependency com.google.cloud:google-cloud-spanner to v1.50.0'
   ),
-  buildMockCommit('chore: update common templates'),
+  ...buildMockConventionalCommit('chore: update common templates'),
 ];
 
 describe('Rust', () => {

--- a/test/strategies/simple.ts
+++ b/test/strategies/simple.ts
@@ -18,7 +18,7 @@ import {GitHub} from '../../src/github';
 import {Simple} from '../../src/strategies/simple';
 import * as sinon from 'sinon';
 import {assertHasUpdate} from '../helpers';
-import {buildMockCommit} from '../helpers';
+import {buildMockConventionalCommit} from '../helpers';
 import {TagName} from '../../src/util/tag-name';
 import {Version} from '../../src/version';
 import {Changelog} from '../../src/updaters/changelog';
@@ -27,13 +27,13 @@ import {DefaultUpdater} from '../../src/updaters/default';
 const sandbox = sinon.createSandbox();
 
 const COMMITS = [
-  buildMockCommit(
+  ...buildMockConventionalCommit(
     'fix(deps): update dependency com.google.cloud:google-cloud-storage to v1.120.0'
   ),
-  buildMockCommit(
+  ...buildMockConventionalCommit(
     'fix(deps): update dependency com.google.cloud:google-cloud-spanner to v1.50.0'
   ),
-  buildMockCommit('chore: update common templates'),
+  ...buildMockConventionalCommit('chore: update common templates'),
 ];
 
 describe('Simple', () => {

--- a/test/strategies/terraform-module.ts
+++ b/test/strategies/terraform-module.ts
@@ -17,7 +17,7 @@ import {expect} from 'chai';
 import {GitHub} from '../../src/github';
 import {TerraformModule} from '../../src/strategies/terraform-module';
 import * as sinon from 'sinon';
-import {assertHasUpdate, buildMockCommit} from '../helpers';
+import {assertHasUpdate, buildMockConventionalCommit} from '../helpers';
 import {TagName} from '../../src/util/tag-name';
 import {Version} from '../../src/version';
 import {Changelog} from '../../src/updaters/changelog';
@@ -27,13 +27,13 @@ import {ModuleVersion} from '../../src/updaters/terraform/module-version';
 const sandbox = sinon.createSandbox();
 
 const COMMITS = [
-  buildMockCommit(
+  ...buildMockConventionalCommit(
     'fix(deps): update dependency com.google.cloud:google-cloud-storage to v1.120.0'
   ),
-  buildMockCommit(
+  ...buildMockConventionalCommit(
     'fix(deps): update dependency com.google.cloud:google-cloud-spanner to v1.50.0'
   ),
-  buildMockCommit('chore: update common templates'),
+  ...buildMockConventionalCommit('chore: update common templates'),
 ];
 
 describe('TerraformModule', () => {


### PR DESCRIPTION
Parse conventional commits in manifest, applying plugins earlier before passing to strategy.

Fixes #1672 