### PR TITLE
feat!: strategies can parse multiple releases from single release PR

### DIFF
--- a/src/manifest.ts
+++ b/src/manifest.ts
@@ -1054,7 +1054,7 @@ export class Manifest {
 
     // Find merged release pull requests
     const generator = await this.findMergedReleasePullRequests();
-    const releases: CandidateRelease[] = [];
+    const candidateReleases: CandidateRelease[] = [];
     for await (const pullRequest of generator) {
       for (const path in this.repositoryConfig) {
         const config = this.repositoryConfig[path];
@@ -1062,11 +1062,11 @@ export class Manifest {
         this.logger.debug(`type: ${config.releaseType}`);
         this.logger.debug(`targetBranch: ${this.targetBranch}`);
         const strategy = strategiesByPath[path];
-        const release = await strategy.buildRelease(pullRequest, {
+        const releases = await strategy.buildReleases(pullRequest, {
           groupPullRequestTitlePattern: this.groupPullRequestTitlePattern,
         });
-        if (release) {
-          releases.push({
+        for (const release of releases) {
+          candidateReleases.push({
             ...release,
             path,
             pullRequest,
@@ -1076,13 +1076,11 @@ export class Manifest {
               (!!release.tag.version.preRelease ||
                 release.tag.version.major === 0),
           });
-        } else {
-          this.logger.info(`No release necessary for path: ${path}`);
         }
       }
     }
 
-    return releases;
+    return candidateReleases;
   }
 
   /**

--- a/src/strategies/base.ts
+++ b/src/strategies/base.ts
@@ -625,7 +625,7 @@ export abstract class BaseStrategy implements Strategy {
   ): Promise<Release[]> {
     const release = await this.buildRelease(mergedPullRequest, options);
     if (release) {
-      return [release]
+      return [release];
     }
     return [];
   }

--- a/src/strategies/base.ts
+++ b/src/strategies/base.ts
@@ -496,6 +496,7 @@ export abstract class BaseStrategy implements Strategy {
    * Given a merged pull request, build the candidate release.
    * @param {PullRequest} mergedPullRequest The merged release pull request.
    * @returns {Release} The candidate release.
+   * @deprecated Use buildReleases() instead.
    */
   async buildRelease(
     mergedPullRequest: PullRequest,

--- a/src/strategies/base.ts
+++ b/src/strategies/base.ts
@@ -613,6 +613,22 @@ export abstract class BaseStrategy implements Strategy {
     };
   }
 
+  /**
+   * Given a merged pull request, build the candidate releases.
+   * @param {PullRequest} mergedPullRequest The merged release pull request.
+   * @returns {Release} The candidate release.
+   */
+  async buildReleases(
+    mergedPullRequest: PullRequest,
+    options?: BuildReleaseOptions
+  ): Promise<Release[]> {
+    const release = await this.buildRelease(mergedPullRequest, options);
+    if (release) {
+      return [release]
+    }
+    return [];
+  }
+
   isPublishedVersion(_version: Version): boolean {
     return true;
   }

--- a/src/strategy.ts
+++ b/src/strategy.ts
@@ -61,6 +61,16 @@ export interface Strategy {
   ): Promise<Release | undefined>;
 
   /**
+   * Given a merged pull request, build the candidate releases.
+   * @param {PullRequest} mergedPullRequest The merged release pull request.
+   * @returns {Release} The candidate release.
+   */
+  buildReleases(
+    mergedPullRequest: PullRequest,
+    options?: BuildReleaseOptions
+  ): Promise<Release[]>;
+
+  /**
    * Return the component for this strategy. This may be a computed field.
    * @returns {string}
    */

--- a/src/strategy.ts
+++ b/src/strategy.ts
@@ -54,6 +54,7 @@ export interface Strategy {
    * Given a merged pull request, build the candidate release.
    * @param {PullRequest} mergedPullRequest The merged release pull request.
    * @returns {Release} The candidate release.
+   * @deprecated Use buildReleases() instead.
    */
   buildRelease(
     mergedPullRequest: PullRequest,


### PR DESCRIPTION
This will give strategies an option to create multiple tags from a single PR. For example, `java-yoshi` for a monorepo could configure itself to be a single component (create a single release PR), but then create several releases/tags.
