### PR TITLE
fix(java-yoshi): throw MissingRequiredFile error if no versions.txt found

### DIFF
--- a/src/strategies/java-yoshi.ts
+++ b/src/strategies/java-yoshi.ts
@@ -17,7 +17,7 @@ import {VersionsManifest} from '../updaters/java/versions-manifest';
 import {Version, VersionsMap} from '../version';
 import {Changelog} from '../updaters/changelog';
 import {GitHubFileContents} from '@google-automations/git-file-utils';
-import {GitHubAPIError, MissingRequiredFileError} from '../errors';
+import {MissingRequiredFileError, FileNotFoundError} from '../errors';
 import {ConventionalCommit} from '../commit';
 import {Java, JavaBuildUpdatesOption} from './java';
 import {JavaUpdate} from '../updaters/java/java-update';
@@ -70,7 +70,7 @@ export class JavaYoshi extends Java {
           this.targetBranch
         );
       } catch (err) {
-        if (err instanceof GitHubAPIError) {
+        if (err instanceof FileNotFoundError) {
           throw new MissingRequiredFileError(
             this.addPath('versions.txt'),
             JavaYoshi.name,


### PR DESCRIPTION
Fixes `Failed to find file: versions.txt` from the logs

This is a remnant from the refactor of the git file cache which throws a different error when a file is not found.