### PR TITLE
fix(ruby): gemfile.lock should not update when gem name is empty

### DIFF
--- a/__snapshots__/gemfile-lock.js
+++ b/__snapshots__/gemfile-lock.js
@@ -1,3 +1,67 @@
+exports['Gemfile.lock updateContent does not update anything if gem name is not provided 1'] = `
+PATH
+  remote: .
+  specs:
+    foo (0.1.0)
+
+GEM
+  remote: https://rubygems.org/
+  specs:
+    ast (2.4.2)
+    foobar (1.0.1)
+    diff-lcs (1.5.0)
+    json (2.6.3)
+    parallel (1.22.1)
+    parser (3.1.3.0)
+      ast (~> 2.4.1)
+    rainbow (3.1.1)
+    rake (13.0.6)
+    regexp_parser (2.6.1)
+    rexml (3.2.5)
+    rspec (3.12.0)
+      rspec-core (~> 3.12.0)
+      rspec-expectations (~> 3.12.0)
+      rspec-mocks (~> 3.12.0)
+    rspec-core (3.12.0)
+      rspec-support (~> 3.12.0)
+    rspec-expectations (3.12.0)
+      diff-lcs (>= 1.2.0, < 2.0)
+      rspec-support (~> 3.12.0)
+    rspec-mocks (3.12.0)
+      diff-lcs (>= 1.2.0, < 2.0)
+      rspec-support (~> 3.12.0)
+    rspec-support (3.12.0)
+    rubocop (1.39.0)
+      json (~> 2.3)
+      parallel (~> 1.10)
+      parser (>= 3.1.2.1)
+      rainbow (>= 2.2.2, < 4.0)
+      regexp_parser (>= 1.8, < 3.0)
+      rexml (>= 3.2.5, < 4.0)
+      rubocop-ast (>= 1.23.0, < 2.0)
+      ruby-progressbar (~> 1.7)
+      unicode-display_width (>= 1.4.0, < 3.0)
+    rubocop-ast (1.24.0)
+      parser (>= 3.1.1.0)
+    ruby-progressbar (1.11.0)
+    unicode-display_width (2.3.0)
+
+PLATFORMS
+  ruby
+
+DEPENDENCIES
+  bundler
+  foo!
+  foobar
+  rake
+  rspec
+  rubocop
+
+BUNDLED WITH
+   2.3.26
+
+`
+
 exports['Gemfile.lock updateContent updates prerelease in Gemfile.lock 1'] = `
 PATH
   remote: .

--- a/src/updaters/ruby/gemfile-lock.ts
+++ b/src/updaters/ruby/gemfile-lock.ts
@@ -46,6 +46,10 @@ export class GemfileLock extends DefaultUpdater {
    * @returns {string} The updated content
    */
   updateContent(content: string): string {
+    if (!this.gemName) {
+      return content;
+    }
+
     // Bundler will convert 1.0.0-alpha1 to 1.0.0.pre.alpha1, so we need to
     // do the same here.
     const versionString = resolveRubyGemfileLockVersion(

--- a/test/updaters/gemfile-lock.ts
+++ b/test/updaters/gemfile-lock.ts
@@ -40,6 +40,7 @@ describe('Gemfile.lock', () => {
       ['foo', '1.0.0', 'foo 1.0.0', 'foo 1.0.0', false, 'no parantheses around version'],
       ['foo', '1.0.0', 'barfoo (1.0.0)', 'barfoo (1.0.0)', false, 'prefixed gem name'],
       ['foo', '1.0.0', 'foobar (0.1.0)', 'foobar (0.1.0)', false, 'suffixed gem name'],
+      ['', '1.0.0', 'foobar (0.1.0)', 'foobar (0.1.0)', false, 'empty gem name'],
     ];
 
     testTable.forEach(
@@ -63,6 +64,19 @@ describe('Gemfile.lock', () => {
         });
       }
     );
+
+    it('does not update anything if gem name is not provided', async () => {
+      const oldContent = readFileSync(
+        resolve(fixturesPath, './Gemfile.lock'),
+        'utf8'
+      ).replace(/\r\n/g, '\n');
+      const version = new GemfileLock({
+        version: Version.parse('0.2.0'),
+        gemName: '',
+      });
+      const newContent = version.updateContent(oldContent);
+      snapshot(newContent);
+    });
 
     it('updates version in Gemfile.lock', async () => {
       const oldContent = readFileSync(


### PR DESCRIPTION
PR #1790 introduced support to update Gemfile.lock files. However this introduced an issue that updates random gem versions when the `package-name` (gemName) is not provided (which is optional). This fix ensures the gemName is valid before attempting to update the Gemfile.lock file.

Thank you for opening a Pull Request! Before submitting your PR, there are a few things you can do to make sure it goes smoothly:
- [x] Make sure to open an issue as a [bug/issue](https://github.com/googleapis/release-please/issues/new/choose) before writing your code!  That way we can discuss the change, evaluate designs, and agree on the general idea
- [x] Ensure the tests and linter pass
- [x] Code coverage does not decrease (if any source code was changed)
- [x] Appropriate docs were updated (if necessary)

Fixes  issue introduced in PR #1790
