### PR TITLE
feat(cli): add ability to dynamically load release-please plugin

### DIFF
--- a/__snapshots__/cli.js
+++ b/__snapshots__/cli.js
@@ -10,6 +10,8 @@ Options:
                                 debugging).           [boolean] [default: false]
   --trace                       print extra verbose errors (use only for local
                                 debugging).           [boolean] [default: false]
+  --plugin                      load plugin named release-please-<plugin-name>
+                                                           [array] [default: []]
   --token                       GitHub token with repo write permissions
   --api-url                     URL to use when making API requests
                                     [string] [default: "https://api.github.com"]
@@ -75,6 +77,8 @@ Options:
                                                       [boolean] [default: false]
   --trace               print extra verbose errors (use only for local
                         debugging).                   [boolean] [default: false]
+  --plugin              load plugin named release-please-<plugin-name>
+                                                           [array] [default: []]
   --token               GitHub token with repo write permissions
   --api-url             URL to use when making API requests
                                     [string] [default: "https://api.github.com"]
@@ -114,6 +118,8 @@ Options:
                                                       [boolean] [default: false]
   --trace           print extra verbose errors (use only for local debugging).
                                                       [boolean] [default: false]
+  --plugin          load plugin named release-please-<plugin-name>
+                                                           [array] [default: []]
   --token           GitHub token with repo write permissions
   --api-url         URL to use when making API requests
                                     [string] [default: "https://api.github.com"]
@@ -156,6 +162,9 @@ Options:
                                     debugging).       [boolean] [default: false]
   --trace                           print extra verbose errors (use only for
                                     local debugging). [boolean] [default: false]
+  --plugin                          load plugin named
+                                    release-please-<plugin-name>
+                                                           [array] [default: []]
   --token                           GitHub token with repo write permissions
   --api-url                         URL to use when making API requests
                                     [string] [default: "https://api.github.com"]

--- a/src/bin/release-please.ts
+++ b/src/bin/release-please.ts
@@ -833,7 +833,9 @@ export const parser = yargs
         if (plugin?.init) {
           console.log(`loading plugin: ${pluginName}`);
         } else {
-          console.warn(`plugin: ${pluginName} did not have an init() function.`);
+          console.warn(
+            `plugin: ${pluginName} did not have an init() function.`
+          );
         }
       } catch (e) {
         console.warn(`failed to require plugin: ${pluginName}:`, e);

--- a/src/bin/release-please.ts
+++ b/src/bin/release-please.ts
@@ -828,11 +828,15 @@ export const parser = yargs
   .middleware(argv => {
     for (const pluginName of argv.plugin) {
       console.log(`requiring plugin: ${pluginName}`);
-      const plugin = require(pluginName.toString());
-      if (plugin?.init) {
-        console.log(`loading plugin: ${pluginName}`);
-      } else {
-        console.warn(`plugin: ${pluginName} did not have an init() function.`);
+      try {
+        const plugin = require(pluginName.toString());
+        if (plugin?.init) {
+          console.log(`loading plugin: ${pluginName}`);
+        } else {
+          console.warn(`plugin: ${pluginName} did not have an init() function.`);
+        }
+      } catch (e) {
+        console.warn(`failed to require plugin: ${pluginName}:`, e);
       }
     }
   })

--- a/src/bin/release-please.ts
+++ b/src/bin/release-please.ts
@@ -820,6 +820,22 @@ export const parser = yargs
       setLogger(new CheckpointLogger(true));
     }
   })
+  .option('plugin', {
+    describe: 'load plugin named release-please-<plugin-name>',
+    type: 'array',
+    default: [],
+  })
+  .middleware(argv => {
+    for (const pluginName of argv.plugin) {
+      console.log(`requiring plugin: ${pluginName}`);
+      const plugin = require(pluginName.toString());
+      if (plugin?.init) {
+        console.log(`loading plugin: ${pluginName}`);
+      } else {
+        console.warn(`plugin: ${pluginName} did not have an init() function.`);
+      }
+    }
+  })
   .demandCommand(1)
   .strict(true)
   .scriptName('release-please');

--- a/src/index.ts
+++ b/src/index.ts
@@ -20,6 +20,7 @@ export {
   PluginType,
 } from './manifest';
 export {Commit, ConventionalCommit} from './commit';
+export {Strategy} from './strategy';
 export {BaseStrategyOptions, BuildUpdatesOptions} from './strategies/base';
 export {
   ReleaseBuilder,


### PR DESCRIPTION
feat: export Strategy interface so external packages can implement

This should allow you to publish private configs in your own npm package and load via the CLI (you can already load configs programatically via `registerReleaseType` etc).

To make an external package dynamically loadable via the release-please CLI, export an `init()` method from your main file that registers your release-please extensions.
