### PR TITLE
feat(java-monorepo): switch to using .repo-metadata.json

### DIFF
--- a/__snapshots__/java-yoshi-mono-repo.js
+++ b/__snapshots__/java-yoshi-mono-repo.js
@@ -1,4 +1,4 @@
-exports['JavaYoshiMonoRepo buildUpdates does not update changelog.json if no artifacts matched in artifact-map.json 1'] = `
+exports['JavaYoshiMonoRepo buildUpdates does not update changelog.json if no .repo-metadata.json is found 1'] = `
 {"entries":[]}
 `
 

--- a/src/strategies/java-yoshi-mono-repo.ts
+++ b/src/strategies/java-yoshi-mono-repo.ts
@@ -187,10 +187,10 @@ export class JavaYoshiMonoRepo extends Java {
         }),
       });
 
-      // The artifact map maps from directory paths in repo to artifact names on
-      // Maven, e.g, java-secretmanager to com.google.cloud/google-cloud-secretmanager.
-      const artifactMap = await this.getArtifactMap('artifact-map.json');
-      if (artifactMap && options.commits) {
+      // Bail early if the repository has no root changelog.json.
+      // This file is used to opt into machine readable commits.
+      const hasChangelogJson = !!(await this.hasChangelogJson());
+      if (hasChangelogJson && options.commits) {
         const changelogUpdates: Array<Updater> = [];
         const cs = new CommitSplit({
           includeEmpty: false,
@@ -204,11 +204,15 @@ export class JavaYoshiMonoRepo extends Java {
           })
         );
         for (const path of Object.keys(splitCommits)) {
-          if (artifactMap[path]) {
-            this.logger.info(`Found artifact ${artifactMap[path]} for ${path}`);
+          const repoMetadata = await this.getRepoMetadata(path);
+          const artifactName = repoMetadata
+            ? repoMetadata['distribution_name']
+            : null;
+          if (repoMetadata && artifactName) {
+            this.logger.info(`Found artifact ${artifactName} for ${path}`);
             changelogUpdates.push(
               new ChangelogJson({
-                artifactName: artifactMap[path],
+                artifactName,
                 version,
                 // We filter out "chore:" commits, to reduce noise in the upstream
                 // release notes. We will only show a product release note entry
@@ -230,12 +234,24 @@ export class JavaYoshiMonoRepo extends Java {
     return updates;
   }
 
-  private async getArtifactMap(
+  private async hasChangelogJson(): Promise<Boolean> {
+    try {
+      await this.github.getFileContentsOnBranch(
+        'changelog.json',
+        this.targetBranch
+      );
+      return true;
+    } catch (e) {
+      return false;
+    }
+  }
+
+  private async getRepoMetadata(
     path: string
   ): Promise<Record<string, string> | null> {
     try {
       const content = await this.github.getFileContentsOnBranch(
-        path,
+        this.addPath(`${path}/.repo-metadata.json`),
         this.targetBranch
       );
       return JSON.parse(content.parsedContent);

--- a/test/fixtures/strategies/java-yoshi/.repo-metadata.json
+++ b/test/fixtures/strategies/java-yoshi/.repo-metadata.json
@@ -1,0 +1,17 @@
+{
+  "api_shortname": "appengine",
+  "name_pretty": "App Engine Admin API",
+  "product_documentation": "https://cloud.google.com/appengine/docs/admin-api/",
+  "api_description": "you to manage your App Engine applications.",
+  "client_documentation": "https://cloud.google.com/java/docs/reference/google-cloud-appengine-admin/latest/overview",
+  "release_level": "stable",
+  "transport": "grpc",
+  "language": "java",
+  "repo": "googleapis/google-cloud-java",
+  "repo_short": "java-appengine-admin",
+  "distribution_name": "cloud.google.com:foo",
+  "api_id": "appengine.googleapis.com",
+  "library_type": "GAPIC_AUTO",
+  "requires_billing": true,
+  "codeowner_team": "@googleapis/aap-dpes"
+}

--- a/test/fixtures/strategies/java-yoshi/artifact-map.json
+++ b/test/fixtures/strategies/java-yoshi/artifact-map.json
@@ -1,3 +1,0 @@
-{
-  "foo": "cloud.google.com:foo"
-}

--- a/test/strategies/java-yoshi-mono-repo.ts
+++ b/test/strategies/java-yoshi-mono-repo.ts
@@ -344,8 +344,8 @@ describe('JavaYoshiMonoRepo', () => {
         .withArgs('versions.txt', 'main')
         .resolves(buildGitHubFileContent(fixturesPath, 'versions.txt'));
       getFileContentsStub
-        .withArgs('artifact-map.json', 'main')
-        .resolves(buildGitHubFileContent(fixturesPath, 'artifact-map.json'));
+        .withArgs('foo/.repo-metadata.json', 'main')
+        .resolves(buildGitHubFileContent(fixturesPath, '.repo-metadata.json'));
       getFileContentsStub
         .withArgs('changelog.json', 'main')
         .resolves(buildGitHubFileContent(fixturesPath, 'changelog.json'));
@@ -404,8 +404,8 @@ describe('JavaYoshiMonoRepo', () => {
         .withArgs('versions.txt', 'main')
         .resolves(buildGitHubFileContent(fixturesPath, 'versions.txt'));
       getFileContentsStub
-        .withArgs('artifact-map.json', 'main')
-        .resolves(buildGitHubFileContent(fixturesPath, 'artifact-map.json'));
+        .withArgs('foo/.repo-metadata.json', 'main')
+        .resolves(buildGitHubFileContent(fixturesPath, '.repo-metadata.json'));
       getFileContentsStub
         .withArgs('changelog.json', 'main')
         .resolves(buildGitHubFileContent(fixturesPath, 'changelog.json'));
@@ -433,7 +433,7 @@ describe('JavaYoshiMonoRepo', () => {
       );
     });
 
-    it('does not update changelog.json if no artifacts matched in artifact-map.json', async () => {
+    it('does not update changelog.json if no .repo-metadata.json is found', async () => {
       const COMMITS = [
         ...buildMockConventionalCommit(
           'fix(deps): update dependency com.google.cloud:google-cloud-storage to v1.120.0',
@@ -457,9 +457,6 @@ describe('JavaYoshiMonoRepo', () => {
       getFileContentsStub
         .withArgs('versions.txt', 'main')
         .resolves(buildGitHubFileContent(fixturesPath, 'versions.txt'));
-      getFileContentsStub
-        .withArgs('artifact-map.json', 'main')
-        .resolves(buildGitHubFileContent(fixturesPath, 'artifact-map.json'));
       getFileContentsStub
         .withArgs('changelog.json', 'main')
         .resolves(buildGitHubFileContent(fixturesPath, 'changelog.json'));


### PR DESCRIPTION
Switches to using .repo-metadata.json to get artifact name, rather than artifact-map.json

Here it is in action: https://github.com/bcoe/google-cloud-java/pull/14