### PR TITLE
fix: filter changelog.json commits based on changelog sections

### DIFF
--- a/src/strategies/java-yoshi-mono-repo.ts
+++ b/src/strategies/java-yoshi-mono-repo.ts
@@ -30,8 +30,7 @@ import {
 import {ConventionalCommit} from '../commit';
 import {Java, JavaBuildUpdatesOption} from './java';
 import {JavaUpdate} from '../updaters/java/java-update';
-
-const BREAKING_CHANGE_NOTE = 'BREAKING CHANGE';
+import {filterCommits} from '../util/filter-commits';
 
 export class JavaYoshiMonoRepo extends Java {
   private versionsContent?: GitHubFileContents;
@@ -200,12 +199,7 @@ export class JavaYoshiMonoRepo extends Java {
           includeEmpty: false,
         });
         const splitCommits = cs.split(
-          options.commits.filter(commit => {
-            const isBreaking = commit.notes.find(note => {
-              return note.title === BREAKING_CHANGE_NOTE;
-            });
-            return commit.type !== 'chore' || isBreaking;
-          })
+          filterCommits(options.commits, this.changelogSections)
         );
         for (const path of Object.keys(splitCommits)) {
           const repoMetadata = await this.getRepoMetadata(path);

--- a/src/strategies/node.ts
+++ b/src/strategies/node.ts
@@ -21,8 +21,7 @@ import {Changelog} from '../updaters/changelog';
 import {PackageJson} from '../updaters/node/package-json';
 import {GitHubFileContents} from '@google-automations/git-file-utils';
 import {FileNotFoundError, MissingRequiredFileError} from '../errors';
-
-const BREAKING_CHANGE_NOTE = 'BREAKING CHANGE';
+import {filterCommits} from '../util/filter-commits';
 
 export class Node extends BaseStrategy {
   private pkgJsonContents?: GitHubFileContents;
@@ -73,12 +72,7 @@ export class Node extends BaseStrategy {
 
     // If a machine readable changelog.json exists update it:
     if (options.commits && packageName) {
-      const commits = options.commits.filter(commit => {
-        const isBreaking = commit.notes.find(note => {
-          return note.title === BREAKING_CHANGE_NOTE;
-        });
-        return commit.type !== 'chore' || isBreaking;
-      });
+      const commits = filterCommits(options.commits, this.changelogSections);
       updates.push({
         path: 'changelog.json',
         createIfMissing: false,

--- a/src/util/filter-commits.ts
+++ b/src/util/filter-commits.ts
@@ -1,0 +1,63 @@
+// Copyright 2023 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import {ChangelogSection} from '../changelog-notes';
+import {ConventionalCommit} from '../commit';
+
+const BREAKING_CHANGE_NOTE = 'BREAKING CHANGE';
+
+const DEFAULT_CHANGELOG_SECTIONS = [
+  {type: 'feat', section: 'Features'},
+  {type: 'fix', section: 'Bug Fixes'},
+  {type: 'perf', section: 'Performance Improvements'},
+  {type: 'revert', section: 'Reverts'},
+  {type: 'chore', section: 'Miscellaneous Chores', hidden: true},
+  {type: 'docs', section: 'Documentation', hidden: true},
+  {type: 'style', section: 'Styles', hidden: true},
+  {type: 'refactor', section: 'Code Refactoring', hidden: true},
+  {type: 'test', section: 'Tests', hidden: true},
+  {type: 'build', section: 'Build System', hidden: true},
+  {type: 'ci', section: 'Continuous Integration', hidden: true},
+];
+
+/**
+ * Given a set of conventional commits and the configured
+ * changelog sections provided by the user, return the set
+ * of commits that should be displayed:
+ *
+ * @param commits
+ * @param changelogSections
+ * @returns ConventionalCommit[]
+ */
+export function filterCommits(
+  commits: ConventionalCommit[],
+  changelogSections?: ChangelogSection[]
+): ConventionalCommit[] {
+  changelogSections = changelogSections ?? DEFAULT_CHANGELOG_SECTIONS;
+  const hiddenSections: Array<string> = [];
+  const visibleSections: Array<string> = [];
+  for (const section of changelogSections) {
+    if (!section.hidden) visibleSections.push(section.type);
+    else hiddenSections.push(section.type);
+  }
+  return commits.filter(commit => {
+    const isBreaking = commit.notes.find(note => {
+      return note.title === BREAKING_CHANGE_NOTE;
+    });
+    return (
+      visibleSections.includes(commit.type) ||
+      (isBreaking && hiddenSections.includes(commit.type))
+    );
+  });
+}

--- a/test/util/filter-commits.ts
+++ b/test/util/filter-commits.ts
@@ -1,0 +1,92 @@
+// Copyright 2023 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import {filterCommits} from '../../src/util/filter-commits';
+import {describe, it} from 'mocha';
+import {expect} from 'chai';
+
+const BREAKING_CHANGE_NOTE = 'BREAKING CHANGE';
+
+describe('filterCommits', () => {
+  it('removes unknown commit types', () => {
+    const commits = filterCommits([
+      {
+        type: 'User-Name',
+        notes: [],
+        references: [],
+        bareMessage: '',
+        message: '',
+        scope: null,
+        breaking: false,
+        sha: 'deadbeef',
+      },
+    ]);
+    expect(commits.length).to.equal(0);
+  });
+  it('removes unknown commit type for breaking change', () => {
+    const commits = filterCommits([
+      {
+        type: 'User-Name',
+        notes: [
+          {
+            title: BREAKING_CHANGE_NOTE,
+            text: 'foo breaking change',
+          },
+        ],
+        references: [],
+        bareMessage: '',
+        message: '',
+        scope: null,
+        breaking: false,
+        sha: 'deadbeef',
+      },
+    ]);
+    expect(commits.length).to.equal(0);
+  });
+  it('removes hidden commit types for non-breaking changes', () => {
+    const commits = filterCommits([
+      {
+        type: 'chore',
+        notes: [],
+        references: [],
+        bareMessage: '',
+        message: '',
+        scope: null,
+        breaking: false,
+        sha: 'deadbeef',
+      },
+    ]);
+    expect(commits.length).to.equal(0);
+  });
+  it('includes hidden commit types for non-breaking changes', () => {
+    const commits = filterCommits([
+      {
+        type: 'chore',
+        notes: [
+          {
+            title: BREAKING_CHANGE_NOTE,
+            text: 'foo breaking change',
+          },
+        ],
+        references: [],
+        bareMessage: '',
+        message: '',
+        scope: null,
+        breaking: false,
+        sha: 'deadbeef',
+      },
+    ]);
+    expect(commits.length).to.equal(1);
+  });
+});


### PR DESCRIPTION
Unknown changelog types were showing up in changelog.json leading to a lot of noise in the file.