### PR TITLE
fix: Support TOML up to v1.0.0-rc.1 spec.

### DIFF
--- a/__snapshots__/generic-toml.js
+++ b/__snapshots__/generic-toml.js
@@ -67,3 +67,25 @@ x86-64-dep = { version = "1.2.3", registry = "private", path = ".." }
 foobar-dep = "1.2.3"
 
 `
+
+exports['GenericToml updateContent updates matching entry with TOML v1.0.0 spec 1'] = `
+[package]
+version = "2.3.4"
+
+[v1spec]
+# taken from toml.io#Arrays examples
+integers = [ 1, 2, 3 ]
+colors = [ "red", "yellow", "green" ]
+nested_arrays_of_ints = [ [ 1, 2 ], [3, 4, 5] ]
+nested_mixed_array = [ [ 1, 2 ], ["a", "b", "c"] ]
+string_array = [ "all", 'strings', """are the same""", '''type''' ]
+
+[heterogenous]
+# Mixed-type arrays are allowed
+numbers = [ 0.1, 0.2, 0.5, 1, 2, 5 ]
+contributors = [
+  "Foo Bar <foo@example.com>",
+  { name = "Baz Qux", email = "bazqux@example.com", url = "https://example.com/bazqux" }
+]
+
+`

--- a/package.json
+++ b/package.json
@@ -69,7 +69,7 @@
   "dependencies": {
     "@conventional-commits/parser": "^0.4.1",
     "@google-automations/git-file-utils": "^1.2.5",
-    "@iarna/toml": "^2.2.5",
+    "@iarna/toml": "^3.0.0",
     "@lerna/collect-updates": "^6.4.1",
     "@lerna/package": "^6.4.1",
     "@lerna/package-graph": "^6.4.1",

--- a/test/updaters/fixtures/toml/v1.0.0.toml
+++ b/test/updaters/fixtures/toml/v1.0.0.toml
@@ -1,0 +1,18 @@
+[package]
+version = '1.0.0'
+
+[v1spec]
+# taken from toml.io#Arrays examples
+integers = [ 1, 2, 3 ]
+colors = [ "red", "yellow", "green" ]
+nested_arrays_of_ints = [ [ 1, 2 ], [3, 4, 5] ]
+nested_mixed_array = [ [ 1, 2 ], ["a", "b", "c"] ]
+string_array = [ "all", 'strings', """are the same""", '''type''' ]
+
+[heterogenous]
+# Mixed-type arrays are allowed
+numbers = [ 0.1, 0.2, 0.5, 1, 2, 5 ]
+contributors = [
+  "Foo Bar <foo@example.com>",
+  { name = "Baz Qux", email = "bazqux@example.com", url = "https://example.com/bazqux" }
+]

--- a/test/updaters/generic-toml.ts
+++ b/test/updaters/generic-toml.ts
@@ -76,5 +76,18 @@ describe('GenericToml', () => {
       const newContent = updater.updateContent(oldContent);
       expect(newContent).to.eql(oldContent);
     });
+    it('updates matching entry with TOML v1.0.0 spec', async () => {
+      const oldContent = readFileSync(
+        resolve(fixturesPath, './toml/v1.0.0.toml'),
+        'utf8'
+      ).replace(/\r\n/g, '\n');
+      const updater = new GenericToml(
+        '$.package.version',
+        Version.parse('v2.3.4')
+      );
+      const newContent = updater.updateContent(oldContent);
+      expect(newContent).not.to.eql(oldContent);
+      snapshot(newContent);
+    });
   });
 });


### PR DESCRIPTION
Thank you for opening a Pull Request! Before submitting your PR, there are a few things you can do to make sure it goes smoothly:

- [x] Make sure to open an issue as a [bug/issue](https://github.com/googleapis/release-please/issues/new/choose) before writing your code! That way we can discuss the change, evaluate designs, and agree on the general idea
- [x] Ensure the tests and linter pass
- [x] Code coverage does not decrease (if any source code was changed)
- [x] Appropriate docs were updated (if necessary)

Fixes #1836 🦕

This PR updates  `@iarna/toml` the latest release of  `v3.0.0`, which supports up to TOML v1.0.0-rc.1.

While it does not explicitly state support for v1.0.0, it is worth noting that all structrural changes were introduced in the rc.1 (namely, heterogeneous arrays). 

For reference, you can see the test added in [cf0a809](https://github.com/googleapis/release-please/pull/1837/commits/cf0a809924973618ceec5364543b0f5ba72a2675)  failing (w/o updating the lib) here:
https://github.com/BradenM/release-please/actions/runs/4040572970/jobs/6946340169#step:8:5167

