### PR TITLE
feat(changelog.json): add pr suffix to issues array

### DIFF
--- a/__snapshots__/changelog-json.js
+++ b/__snapshots__/changelog-json.js
@@ -1,3 +1,43 @@
+exports['changelog.json adds PR # suffix to issues array 1'] = `
+{
+  "repository": "foo/bar",
+  "entries": [
+    {
+      "changes": [
+        {
+          "type": "feat",
+          "sha": "81228f3507ad6f742242474628ff58b2",
+          "message": "some feature",
+          "issues": []
+        },
+        {
+          "type": "fix",
+          "sha": "4e34bedd7131c9e6b0060038b0eba8cf",
+          "message": "Support TOML up to v1.0.0-rc.1 spec.",
+          "issues": [
+            "1837"
+          ]
+        },
+        {
+          "type": "docs",
+          "sha": "abbf5480ac552b33404be825a817df2a",
+          "message": "some documentation",
+          "issues": []
+        }
+      ],
+      "version": "14.0.0",
+      "language": "JAVA",
+      "artifactName": "foo-artifact",
+      "id": "abc-123-efd-qwerty",
+      "createTime": "2023-01-05T16:42:33.446Z"
+    },
+    {},
+    {}
+  ],
+  "updateTime": "2023-01-05T16:42:33.446Z"
+}
+`
+
 exports['changelog.json prepends latest release to existing changelog 1'] = `
 {
   "repository": "foo/bar",

--- a/src/updaters/changelog-json.ts
+++ b/src/updaters/changelog-json.ts
@@ -67,9 +67,6 @@ export class ChangelogJson extends DefaultUpdater {
     const changes = [];
     for (const commit of this.commits) {
       const issues = new Set<string>();
-      for (const ref of commit.references) {
-        issues.add(ref.issue);
-      }
       // The commit.message field contains the type/scope prefix.
       let message = commit.message.replace(COMMIT_PREFIX, '');
       // When squashing commits, GitHub adds a suffix refrencing
@@ -80,6 +77,11 @@ export class ChangelogJson extends DefaultUpdater {
       if (match && match.groups?.pr) {
         message = message.replace(match[0], '');
         issues.add(match.groups.pr);
+      }
+      // Array.from(someSet) will maintain elements in insertion
+      // order, given this we add references after the pr suffix.
+      for (const ref of commit.references) {
+        issues.add(ref.issue);
       }
       const change: Change = {
         type: commit.type,

--- a/src/updaters/changelog-json.ts
+++ b/src/updaters/changelog-json.ts
@@ -66,7 +66,10 @@ export class ChangelogJson extends DefaultUpdater {
     logger.info(`adding release ${this.version} for ${this.artifactName}`);
     const changes = [];
     for (const commit of this.commits) {
-      const issues = commit.references.map(ref => ref.issue);
+      const issues = new Set<string>();
+      for (const ref of commit.references) {
+        issues.add(ref.issue);
+      }
       // The commit.message field contains the type/scope prefix.
       let message = commit.message.replace(COMMIT_PREFIX, '');
       // When squashing commits, GitHub adds a suffix refrencing
@@ -76,13 +79,13 @@ export class ChangelogJson extends DefaultUpdater {
       const match = message.match(PR_SUFFIX_REGEX);
       if (match && match.groups?.pr) {
         message = message.replace(match[0], '');
-        issues.unshift(match.groups.pr);
+        issues.add(match.groups.pr);
       }
       const change: Change = {
         type: commit.type,
         sha: commit.sha,
         message: message,
-        issues,
+        issues: Array.from(issues),
       };
       if (commit.scope) change.scope = commit.scope;
       for (const note of commit.notes) {

--- a/src/updaters/changelog-json.ts
+++ b/src/updaters/changelog-json.ts
@@ -19,6 +19,7 @@ import {randomUUID} from 'crypto';
 
 const BREAKING_CHANGE_TITLE = 'BREAKING CHANGE';
 const COMMIT_PREFIX = /^[^:]+: ?/;
+const PR_SUFFIX_REGEX = / ?\(#(?<pr>[0-9]+)\)$/;
 
 interface ChangelogJsonOptions extends UpdateOptions {
   artifactName: string;
@@ -65,13 +66,23 @@ export class ChangelogJson extends DefaultUpdater {
     logger.info(`adding release ${this.version} for ${this.artifactName}`);
     const changes = [];
     for (const commit of this.commits) {
+      const issues = commit.references.map(ref => ref.issue);
       // The commit.message field contains the type/scope prefix.
-      const message = commit.message.replace(COMMIT_PREFIX, '');
+      let message = commit.message.replace(COMMIT_PREFIX, '');
+      // When squashing commits, GitHub adds a suffix refrencing
+      // the # of the PR, e.g., chore(main): release 15.5.1 (#1838)
+      // this logic removes this suffix and prepends it to the
+      // issues array.
+      const match = message.match(PR_SUFFIX_REGEX);
+      if (match && match.groups?.pr) {
+        message = message.replace(match[0], '');
+        issues.unshift(match.groups.pr);
+      }
       const change: Change = {
         type: commit.type,
         sha: commit.sha,
         message: message,
-        issues: commit.references.map(ref => ref.issue),
+        issues,
       };
       if (commit.scope) change.scope = commit.scope;
       for (const note of commit.notes) {

--- a/test/updaters/changelog-json.ts
+++ b/test/updaters/changelog-json.ts
@@ -69,4 +69,29 @@ describe('changelog.json', () => {
         .replace(ISO_DATE_REGEX, '2023-01-05T16:42:33.446Z')
     );
   });
+  // In discussion with downstream implementers, we decideed that it would
+  // make it easier to customize the CHANGELOG generated if we pre-parsed
+  // the PR # suffix that GitHub adds to squashed commits.
+  it('adds PR # suffix to issues array', async () => {
+    const oldContent = '{"repository": "foo/bar", "entries": [{}, {}]}';
+    const commits = [
+      buildMockCommit('feat: some feature'),
+      buildMockCommit('fix: Support TOML up to v1.0.0-rc.1 spec. (#1837)'),
+      buildMockCommit('docs: some documentation'),
+    ];
+    const conventionalCommits = parseConventionalCommits(commits);
+    const changelogJson = new ChangelogJson({
+      version: Version.parse('14.0.0'),
+      artifactName: 'foo-artifact',
+      language: 'JAVA',
+      commits: conventionalCommits,
+    });
+    const newContent = changelogJson.updateContent(oldContent);
+    snapshot(
+      newContent
+        .replace(/\r\n/g, '\n') // make newline consistent regardless of OS.
+        .replace(UUID_REGEX, 'abc-123-efd-qwerty')
+        .replace(ISO_DATE_REGEX, '2023-01-05T16:42:33.446Z')
+    );
+  });
 });


### PR DESCRIPTION
In discussion with downstream implementers, we decideed that it would make it easier to customize the CHANGELOG generated if we pre-parsed the PR # suffix that GitHub adds to squashed commits.