### PR TITLE
fix: github issues link

### DIFF
--- a/src/github.ts
+++ b/src/github.ts
@@ -1401,7 +1401,7 @@ export class GitHub {
   commentOnIssue = wrapAsync(
     async (comment: string, number: number): Promise<string> => {
       this.logger.debug(
-        `adding comment to https://github.com/${this.repository.owner}/${this.repository.repo}/issue/${number}`
+        `adding comment to https://github.com/${this.repository.owner}/${this.repository.repo}/issues/${number}`
       );
       const resp = await this.octokit.issues.createComment({
         owner: this.repository.owner,


### PR DESCRIPTION
Found a small bug while going through debug logs: Github issues can be addressed with the /issues/ (plural) link, but the /issue one leads to a 404. The debug logs (visible in GH action logs) use the 404ing one.

Example:
- https://github.com/googleapis/release-please/issues/1848 works
- https://github.com/googleapis/release-please/issue/1848 is a 404
