### PR TITLE
feat: allow excluding file paths to filter out commits

### DIFF
--- a/docs/manifest-releaser.md
+++ b/docs/manifest-releaser.md
@@ -262,6 +262,8 @@ defaults (those are documented in comments)
     ".": {
       // overrides release-type for node
       "release-type": "node",
+      // exclude commits from that path from processing
+      "exclude-paths": ["path/to/myPyPkgA"]
     },
 
     // path segment should be relative to repository root

--- a/schemas/config.json
+++ b/schemas/config.json
@@ -184,6 +184,13 @@
             ]
           }
         },
+        "exclude-paths": {
+          "description": "Path of commits to be excluded from parsing. If all files from commit belong to one of the paths it will be skipped",
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
         "version-file": {
           "description": "Path to the specialize version file. Used by `ruby` and `simple` strategies.",
           "type": "string"
@@ -394,6 +401,7 @@
     "extra-files": true,
     "version-file": true,
     "snapshot-label": true,
-    "initial-version": true
+    "initial-version": true,
+    "exclude-paths": true
   }
 }

--- a/src/manifest.ts
+++ b/src/manifest.ts
@@ -170,7 +170,7 @@ interface ReleaserConfigJson {
   'snapshot-label'?: string; // Java-only
   'skip-snapshot'?: boolean; // Java-only
   'initial-version'?: string;
-  'exclude-paths'?:string[] // manifest-only
+  'exclude-paths'?: string[]; // manifest-only
 }
 
 export interface ManifestOptions {
@@ -1288,6 +1288,7 @@ function extractReleaserConfig(
     extraLabels: config['extra-label']?.split(','),
     skipSnapshot: config['skip-snapshot'],
     initialVersion: config['initial-version'],
+    excludePaths: config['exclude-paths'],
   };
 }
 
@@ -1622,6 +1623,7 @@ function mergeReleaserConfig(
     skipSnapshot: pathConfig.skipSnapshot ?? defaultConfig.skipSnapshot,
     initialVersion: pathConfig.initialVersion ?? defaultConfig.initialVersion,
     extraLabels: pathConfig.extraLabels ?? defaultConfig.extraLabels,
+    excludePaths: pathConfig.excludePaths ?? defaultConfig.excludePaths,
   };
 }
 

--- a/src/manifest.ts
+++ b/src/manifest.ts
@@ -170,6 +170,7 @@ interface ReleaserConfigJson {
   'snapshot-label'?: string; // Java-only
   'skip-snapshot'?: boolean; // Java-only
   'initial-version'?: string;
+  'exclude-paths'?:string[] // manifest-only
 }
 
 export interface ManifestOptions {

--- a/src/util/commit-exclude.ts
+++ b/src/util/commit-exclude.ts
@@ -1,3 +1,17 @@
+// Copyright 2023 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 import {Commit} from '../commit';
 import {ReleaserConfig} from '../manifest';
 import {normalizePaths} from './commit-utils';

--- a/src/util/commit-exclude.ts
+++ b/src/util/commit-exclude.ts
@@ -1,0 +1,41 @@
+import {Commit} from '../commit';
+import {ReleaserConfig} from '../manifest';
+import {normalizePaths} from './commit-utils';
+
+export type CommitExcludeConfig = Pick<ReleaserConfig, 'excludePaths'>;
+
+export class CommitExclude {
+  private excludePaths: Record<string, string[]> = {};
+
+  constructor(config: Record<string, CommitExcludeConfig>) {
+    Object.entries(config).forEach(([path, releaseConfig]) => {
+      if (releaseConfig.excludePaths) {
+        this.excludePaths[path] = normalizePaths(releaseConfig.excludePaths);
+      }
+    });
+  }
+
+  excludeCommits<T extends Commit>(
+    commitsPerPath: Record<string, T[]>
+  ): Record<string, T[]> {
+    const filteredCommitsPerPath: Record<string, T[]> = {};
+    Object.entries(commitsPerPath).forEach(([path, commits]) => {
+      if (this.excludePaths[path]) {
+        commits = commits.filter(commit =>
+          this.shouldInclude(commit, this.excludePaths[path])
+        );
+      }
+      filteredCommitsPerPath[path] = commits;
+    });
+    return filteredCommitsPerPath;
+  }
+
+  private shouldInclude(commit: Commit, excludePaths: string[]): boolean {
+    return (
+      !commit.files ||
+      !commit.files.every(file =>
+        excludePaths.some(path => file.indexOf(`${path}/`) === 0)
+      )
+    );
+  }
+}

--- a/src/util/commit-split.ts
+++ b/src/util/commit-split.ts
@@ -14,6 +14,7 @@
 
 import {Commit} from '../commit';
 import {ROOT_PROJECT_PATH} from '../manifest';
+import {normalizePaths} from './commit-utils';
 
 export interface CommitSplitOptions {
   // Include empty git commits: each empty commit is included
@@ -54,29 +55,14 @@ export class CommitSplit {
     opts = opts || {};
     this.includeEmpty = !!opts.includeEmpty;
     if (opts.packagePaths) {
-      const paths: string[] = [];
-      for (let newPath of opts.packagePaths) {
-        // The special "." path, representing the root of the module, should be
-        // ignored by commit-split as it is assigned all commits in manifest.ts
-        if (newPath === ROOT_PROJECT_PATH) {
-          continue;
-        }
-        // normalize so that all paths have leading and trailing slashes for
-        // non-overlap validation.
-        // NOTE: GitHub API always returns paths using the `/` separator,
-        // regardless of what platform the client code is running on
-        newPath = newPath.replace(/\/$/, '');
-        newPath = newPath.replace(/^\//, '');
-        newPath = newPath.replace(/$/, '/');
-        newPath = newPath.replace(/^/, '/');
-        // store them with leading and trailing slashes removed.
-        newPath = newPath.replace(/\/$/, '');
-        newPath = newPath.replace(/^\//, '');
-        paths.push(newPath);
-      }
-
-      // sort by longest paths first
-      this.packagePaths = paths.sort((a, b) => b.length - a.length);
+      const paths: string[] = normalizePaths(opts.packagePaths);
+      this.packagePaths = paths
+        .filter(path => {
+          // The special "." path, representing the root of the module, should be
+          // ignored by commit-split as it is assigned all commits in manifest.ts
+          return path !== ROOT_PROJECT_PATH;
+        })
+        .sort((a, b) => b.length - a.length); // sort by longest paths first
     }
   }
 

--- a/src/util/commit-utils.ts
+++ b/src/util/commit-utils.ts
@@ -1,0 +1,16 @@
+export const normalizePaths = (paths: string[]) => {
+  return paths.map(path => {
+    // normalize so that all paths have leading and trailing slashes for
+    // non-overlap validation.
+    // NOTE: GitHub API always returns paths using the `/` separator,
+    // regardless of what platform the client code is running on
+    let newPath = path.replace(/\/$/, '');
+    newPath = newPath.replace(/^\//, '');
+    newPath = newPath.replace(/$/, '/');
+    newPath = newPath.replace(/^/, '/');
+    // store them with leading and trailing slashes removed.
+    newPath = newPath.replace(/\/$/, '');
+    newPath = newPath.replace(/^\//, '');
+    return newPath;
+  });
+};

--- a/src/util/commit-utils.ts
+++ b/src/util/commit-utils.ts
@@ -1,3 +1,17 @@
+// Copyright 2023 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 export const normalizePaths = (paths: string[]) => {
   return paths.map(path => {
     // normalize so that all paths have leading and trailing slashes for

--- a/test/fixtures/manifest/config/exclude-paths.json
+++ b/test/fixtures/manifest/config/exclude-paths.json
@@ -1,0 +1,15 @@
+{
+  "release-type": "simple",
+  "label": "custom: pending",
+  "release-label": "custom: tagged",
+  "exclude-paths": ["path-ignore"],
+  "packages": {
+    ".": {
+      "component": "root",
+      "exclude-paths": ["path-root-ignore"]
+    },
+    "node-lib": {
+      "component": "node-lib"
+    }
+  }
+}

--- a/test/manifest.ts
+++ b/test/manifest.ts
@@ -504,6 +504,37 @@ describe('Manifest', () => {
         'lang: nodejs',
       ]);
     });
+    it('should read exclude paths from manifest', async () => {
+      const getFileContentsStub = sandbox.stub(
+        github,
+        'getFileContentsOnBranch'
+      );
+      getFileContentsStub
+        .withArgs('release-please-config.json', 'main')
+        .resolves(
+          buildGitHubFileContent(
+            fixturesPath,
+            'manifest/config/exclude-paths.json'
+          )
+        )
+        .withArgs('.release-please-manifest.json', 'main')
+        .resolves(
+          buildGitHubFileContent(
+            fixturesPath,
+            'manifest/versions/versions.json'
+          )
+        );
+      const manifest = await Manifest.fromManifest(
+        github,
+        github.repository.defaultBranch
+      );
+      expect(manifest.repositoryConfig['.'].excludePaths).to.deep.equal([
+        'path-root-ignore',
+      ]);
+      expect(manifest.repositoryConfig['node-lib'].excludePaths).to.deep.equal([
+        'path-ignore',
+      ]);
+    });
     it('should build simple plugins from manifest', async () => {
       const getFileContentsStub = sandbox.stub(
         github,

--- a/test/util/commit-exclude.ts
+++ b/test/util/commit-exclude.ts
@@ -1,3 +1,17 @@
+// Copyright 2023 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 import {Commit} from '../../src';
 import {
   CommitExclude,

--- a/test/util/commit-exclude.ts
+++ b/test/util/commit-exclude.ts
@@ -1,0 +1,89 @@
+import {Commit} from '../../src';
+import {
+  CommitExclude,
+  CommitExcludeConfig,
+} from '../../src/util/commit-exclude';
+import {expect} from 'chai';
+
+describe('commit-exclude', () => {
+  const commitsPerPath: Record<string, Commit[]> = {
+    '.': [
+      {
+        sha: 'pack1Pack2',
+        message: 'commit pack1Pack2',
+        files: ['pkg1/foo.txt', 'pkg2/bar.txt'],
+      },
+      {
+        sha: 'rootCommit',
+        message: 'commit root',
+        files: ['foo.txt'],
+      },
+      {
+        sha: 'pack3',
+        message: 'commit pack3',
+        files: ['pkg3/bar/foo.txt'],
+      },
+    ],
+    pkg1: [
+      {
+        sha: 'pack1Pack2',
+        message: 'commit pack1Pack2',
+        files: ['pkg1/foo.txt', 'pkg2/bar.txt'],
+      },
+    ],
+    pkg2: [
+      {
+        sha: 'pack1Pack2',
+        message: 'commit pack1Pack2',
+        files: ['pkg1/foo.txt', 'pkg2/bar.txt'],
+      },
+    ],
+    pkg3: [
+      {
+        sha: 'pack3',
+        message: 'commit pack3',
+        files: ['pkg3/foo.txt'],
+      },
+      {
+        sha: 'pack3sub',
+        message: 'commit pack3sub',
+        files: ['pkg3/bar/foo.txt'],
+      },
+    ],
+  };
+
+  it('should not exclude anything if paths are empty', () => {
+    const config: Record<string, CommitExcludeConfig> = {};
+    const commitExclude = new CommitExclude(config);
+    const newCommitsPerPath = commitExclude.excludeCommits(commitsPerPath);
+    expect(newCommitsPerPath['.'].length).to.equal(3);
+    expect(newCommitsPerPath['pkg1'].length).to.equal(1);
+    expect(newCommitsPerPath['pkg2'].length).to.equal(1);
+    expect(newCommitsPerPath['pkg3'].length).to.equal(2);
+  });
+
+  it('should not exclude only if all files are from excluded path', () => {
+    const config: Record<string, CommitExcludeConfig> = {
+      '.': {excludePaths: ['pkg3', 'pkg1']},
+      pkg3: {excludePaths: ['pkg3/bar']},
+    };
+    const commitExclude = new CommitExclude(config);
+    const newCommitsPerPath = commitExclude.excludeCommits(commitsPerPath);
+    expect(newCommitsPerPath['.'].length).to.equal(2);
+    expect(newCommitsPerPath['pkg1'].length).to.equal(1);
+    expect(newCommitsPerPath['pkg2'].length).to.equal(1);
+    expect(newCommitsPerPath['pkg3'].length).to.equal(1);
+  });
+
+  it('should exclude if all files are from excluded path', () => {
+    const config: Record<string, CommitExcludeConfig> = {
+      '.': {excludePaths: ['pkg3', 'pkg1', 'pkg2']},
+    };
+    const commitExclude = new CommitExclude(config);
+    const newCommitsPerPath = commitExclude.excludeCommits(commitsPerPath);
+    expect(newCommitsPerPath['.'].length).to.equal(1);
+    expect(newCommitsPerPath['pkg1'].length).to.equal(1);
+    expect(newCommitsPerPath['pkg2'].length).to.equal(1);
+    expect(newCommitsPerPath['pkg3'].length).to.equal(2);
+  });
+});

--- a/test/util/commit-exclude.ts
+++ b/test/util/commit-exclude.ts
@@ -64,6 +64,18 @@ describe('commit-exclude', () => {
         files: ['pkg3/bar/foo.txt'],
       },
     ],
+    pkg4: [
+      {
+        sha: 'pack3',
+        message: 'commit pack3',
+        files: ['pkg3/foo.txt'],
+      },
+      {
+        sha: 'pack3sub',
+        message: 'commit pack3sub',
+        files: ['pkg3/bar/foo.txt'],
+      },
+    ],
   };
 
   it('should not exclude anything if paths are empty', () => {
@@ -99,5 +111,27 @@ describe('commit-exclude', () => {
     expect(newCommitsPerPath['pkg1'].length).to.equal(1);
     expect(newCommitsPerPath['pkg2'].length).to.equal(1);
     expect(newCommitsPerPath['pkg3'].length).to.equal(2);
+  });
+
+  it('should make decision only on relevant files', () => {
+    const createCommit = (files: string[]) => {
+      const first = files.at(0)!;
+      return {
+        sha: first.split('/').at(0)!,
+        message: `commit ${first}`,
+        files,
+      };
+    };
+    const commits: Record<string, Commit[]> = {
+      a: [createCommit(['a/b/c', 'd/e/f', 'd/e/g'])],
+      d: [createCommit(['a/b/c', 'd/e/f', 'd/e/g'])],
+    };
+    const config: Record<string, CommitExcludeConfig> = {
+      d: {excludePaths: ['d/e']},
+    };
+    const commitExclude = new CommitExclude(config);
+    const newCommitsPerPath = commitExclude.excludeCommits(commits);
+    expect(newCommitsPerPath['a'].length).to.equal(1);
+    expect(newCommitsPerPath['d'].length).to.equal(0);
   });
 });

--- a/test/util/commit-exclude.ts
+++ b/test/util/commit-exclude.ts
@@ -115,9 +115,9 @@ describe('commit-exclude', () => {
 
   it('should make decision only on relevant files', () => {
     const createCommit = (files: string[]) => {
-      const first = files.at(0)!;
+      const first = files[0];
       return {
-        sha: first.split('/').at(0)!,
+        sha: first.split('/')[0],
         message: `commit ${first}`,
         files,
       };


### PR DESCRIPTION
Idea is to exclude commits if all files in those commits are from specific paths.

In my case I have multiple packages in `packages` and `.` umbrella package. Some of packages are different and handled by different workflow and I need to exclude those from umbrella.

Tested only with `config-file`

Note: I think it is possible to break it with `"package/foo":{"exclude-paths":["package/foo"]}` but I did not test it yet.

Thank you for opening a Pull Request! Before submitting your PR, there are a few things you can do to make sure it goes smoothly:
- [x] Make sure to open an issue as a [bug/issue](https://github.com/googleapis/release-please/issues/new/choose) before writing your code!  That way we can discuss the change, evaluate designs, and agree on the general idea
- [x] Ensure the tests and linter pass
- [x] Code coverage does not decrease (if any source code was changed)
- [x] Appropriate docs were updated (if necessary)

Fixes #908🦕
