### PR TITLE
docs: show `extra-files` syntax for generic files

### DIFF
--- a/docs/customizing.md
+++ b/docs/customizing.md
@@ -142,6 +142,14 @@ using the [Generic](/src/updaters/generic.ts) updater. You can specify
 a comma separated list of file paths with the `--extra-files` CLI option
 or the `extra-files` option in the manifest configuration.
 
+```json
+{
+  "extra-files": [
+    "path/to/file.md"
+  ]
+}
+```
+
 To mark versions needing an update in those files, you will add annotations
 (usually in comments).
 


### PR DESCRIPTION
Presently, finding the correct syntax is not easy, as it is not provided in any of the following:
* https://github.com/googleapis/release-please/blob/122820d/docs/customizing.md
* https://github.com/googleapis/release-please/blob/122820d/docs/manifest-releaser.md
* https://github.com/googleapis/release-please/blob/122820d/README.md

It can be found in the following places:
* https://github.com/googleapis/release-please/blob/122820d/schemas/config.json#L110-L118
* https://github.com/googleapis/release-please/blob/122820d/test/fixtures/manifest/config/extra-files.json

Related:
* https://github.com/google-github-actions/release-please-action/blob/ee9822e/README.md#adding-additional-files

---

Edit: to make it easier to skim over this, could be shortened to just:

```json
{
  "extra-files": ["path/to/file.md"]
}
```