### PR TITLE
build: update to latest cloud-rad doc generator

### DIFF
--- a/.kokoro/release/docs-devsite.sh
+++ b/.kokoro/release/docs-devsite.sh
@@ -25,5 +25,5 @@ if [[ -z "$CREDENTIALS" ]]; then
 fi
 
 npm install
-npm install --no-save @google-cloud/cloud-rad@^0.2.5
+npm install --no-save @google-cloud/cloud-rad@^0.3.5
 npx @google-cloud/cloud-rad

--- a/owlbot.py
+++ b/owlbot.py
@@ -27,6 +27,7 @@ node.owlbot_main(templates_excludes=[
   '.kokoro/presubmit/node10/system-test.cfg',
   '.kokoro/continuous/node10/system-test.cfg',
   '.kokoro/system-test.sh',
+  '.kokoro/release/docs-devsite.sh',
   '.mocharc.js',
   '.github/generated-files-bot.yml',
   '.github/release-please.yml',


### PR DESCRIPTION
This library is node >= 14. The 0.2.5 version of the doc generator does not appear to support node 14 yet.

Fixes #1897