### PR TITLE
fix: needsBootstrap computation considers also tags

### DIFF
--- a/src/manifest.ts
+++ b/src/manifest.ts
@@ -543,7 +543,6 @@ export class Manifest {
       }
     }
 
-    const needsBootstrap = releasesFound < expectedReleases;
     if (releasesFound < expectedReleases) {
       this.logger.warn(
         `Expected ${expectedReleases} releases, only found ${releasesFound}`
@@ -563,6 +562,9 @@ export class Manifest {
         releasesFound++;
       }
     }
+
+    const needsBootstrap = releasesFound < expectedReleases;
+
     if (releasesFound < expectedReleases) {
       this.logger.warn(
         `Expected ${expectedReleases} releases, only found ${releasesFound}`


### PR DESCRIPTION
Current implementation when setting up boolean `needsBootstrap` considers only github releases.
In setup of one umbrella release and multiple packages without github release (only tags) that leads to commit search up to maximum depth.

Fixes #1903 🦕
