### PR TITLE
fix(helm): maintain any existing comments in Chart.yaml

### DIFF
--- a/__snapshots__/chart-yaml.js
+++ b/__snapshots__/chart-yaml.js
@@ -1,12 +1,27 @@
 exports['ChartYaml updateContent updates version in Chart.yaml 1'] = `
+# Copyright 2021 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 name: helm-test-repo
 version: 1.1.0
 apiVersion: v2
+# renovate: image=imageName
 appVersion: 2.0.0
 dependencies:
   - name: another-repo
     version: 0.15.3
-    repository: linkToHelmChartRepo
+    repository: "linkToHelmChartRepo"
 maintainers:
   - Abhinav Khanna
 

--- a/package.json
+++ b/package.json
@@ -100,6 +100,7 @@
     "unist-util-visit": "^2.0.3",
     "unist-util-visit-parents": "^3.1.1",
     "xpath": "^0.0.32",
+    "yaml": "^2.2.2",
     "yargs": "^17.0.0"
   },
   "engines": {

--- a/src/updaters/helm/chart-yaml.ts
+++ b/src/updaters/helm/chart-yaml.ts
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import * as yaml from 'js-yaml';
+import * as yaml from 'yaml';
 import {logger as defaultLogger, Logger} from '../../util/logger';
 import {DefaultUpdater} from '../default';
 
@@ -26,13 +26,13 @@ export class ChartYaml extends DefaultUpdater {
    * @returns {string} The updated content
    */
   updateContent(content: string, logger: Logger = defaultLogger): string {
-    const data = yaml.load(content, {json: true});
-    if (data === null || data === undefined) {
+    const chart = yaml.parseDocument(content);
+    if (chart === null || chart === undefined) {
       return '';
     }
-    const parsed = JSON.parse(JSON.stringify(data));
-    logger.info(`updating from ${parsed.version} to ${this.version}`);
-    parsed.version = this.version.toString();
-    return yaml.dump(parsed);
+    const oldVersion = chart.get('version');
+    logger.info(`updating from ${oldVersion} to ${this.version}`);
+    chart.set('version', this.version.toString());
+    return chart.toString();
   }
 }

--- a/test/updaters/fixtures/helm/Chart.yaml
+++ b/test/updaters/fixtures/helm/Chart.yaml
@@ -15,6 +15,7 @@
 name: helm-test-repo
 version: 1.0.0
 apiVersion: v2
+# renovate: image=imageName
 appVersion: 2.0.0
 dependencies:
   - name: another-repo


### PR DESCRIPTION
As raised in #1944, the current approach for Helm charts (using `js-yaml` library) strips all comments from the file. This PR switches to using the popular `yaml` library ([eemeli/yaml](https://github.com/eemeli/yaml)), and then patching the version value directly. This helps maintain any comments which have been added to the Chart.yaml - Renovate comments are the driving cause in our case.

Fixes #1944 🦕
