### PR TITLE
docs(schema): update include-v-in-tag default value in config option description

### DIFF
--- a/schemas/config.json
+++ b/schemas/config.json
@@ -75,7 +75,7 @@
           "type": "boolean"
         },
         "include-v-in-tag": {
-          "description": "When tagging a release, include `v` in the tag. Defaults to `false`.",
+          "description": "When tagging a release, include `v` in the tag. Defaults to `true`.",
           "type": "boolean"
         },
         "changelog-type": {


### PR DESCRIPTION
Updates the config schema documentation because it appears `include-v-in-tag` defaults to `true`:

https://github.com/googleapis/release-please/blob/bdd9b0158ce79d958da01ebf54cb6b07925bc125/src/strategies/base.ts#L139

Let me know if I should create an issue, but this is a small doc change so I didn't think it was necessary.