### PR TITLE
feat: add support for crystal lang projects

### DIFF
--- a/src/strategies/crystal.ts
+++ b/src/strategies/crystal.ts
@@ -1,0 +1,81 @@
+// Copyright 2023 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import {GitHubFileContents} from '@google-automations/git-file-utils';
+import {Changelog} from '../updaters/changelog';
+import * as yaml from 'js-yaml';
+import {ShardYml} from '../updaters/crystal/shard-yml';
+import {BaseStrategy, BuildUpdatesOptions} from './base';
+import {Update} from '../update';
+import {FileNotFoundError, MissingRequiredFileError} from '../errors';
+
+export class Crystal extends BaseStrategy {
+  private shardYmlContents?: GitHubFileContents;
+  protected async buildUpdates(
+    options: BuildUpdatesOptions
+  ): Promise<Update[]> {
+    const updates: Update[] = [];
+    const version = options.newVersion;
+
+    updates.push({
+      path: this.addPath(this.changelogPath),
+      createIfMissing: true,
+      updater: new Changelog({
+        version,
+        changelogEntry: options.changelogEntry,
+      }),
+    });
+
+    updates.push({
+      path: this.addPath('shard.yml'),
+      createIfMissing: false,
+      cachedFileContents: this.shardYmlContents,
+      updater: new ShardYml({
+        version,
+      }),
+    });
+
+    return updates;
+  }
+
+  async getDefaultPackageName(): Promise<string | undefined> {
+    const shardYmlContents = await this.getShardYmlContents();
+    const chart = yaml.load(shardYmlContents.parsedContent, {json: true});
+    if (typeof chart === 'object') {
+      return (chart as {name: string}).name;
+    } else {
+      return undefined;
+    }
+  }
+
+  private async getShardYmlContents(): Promise<GitHubFileContents> {
+    if (!this.shardYmlContents) {
+      try {
+        this.shardYmlContents = await this.github.getFileContents(
+          this.addPath('shard.yml')
+        );
+      } catch (e) {
+        if (e instanceof FileNotFoundError) {
+          throw new MissingRequiredFileError(
+            this.addPath('shard.yml'),
+            Crystal.name,
+            `${this.repository.owner}/${this.repository.repo}`
+          );
+        }
+        throw e;
+      }
+    }
+    return this.shardYmlContents;
+  }
+}

--- a/src/updaters/crystal/shard-yml.ts
+++ b/src/updaters/crystal/shard-yml.ts
@@ -1,0 +1,38 @@
+// Copyright 2023 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import * as yaml from 'yaml';
+import {logger as defaultLogger, Logger} from '../../util/logger';
+import {DefaultUpdater} from '../default';
+
+/**
+ * Updates a Crystal shard.yml file.
+ */
+export class ShardYml extends DefaultUpdater {
+  /**
+   * Given initial file contents, return updated contents.
+   * @param {string} content The initial content
+   * @returns {string} The updated content
+   */
+  updateContent(content: string, logger: Logger = defaultLogger): string {
+    const shard = yaml.parseDocument(content);
+    if (shard === null || shard === undefined) {
+      return '';
+    }
+    const oldVersion = shard.get('version');
+    logger.info(`updating from ${oldVersion} to ${this.version}`);
+    shard.set('version', this.version.toString());
+    return shard.toString();
+  }
+}


### PR DESCRIPTION
This change adds support for projects written in [Crystal](https://crystal-lang.org/). In a Crystal project, version information is stored in the `version` field of a file called `shard.yml` in the root of your project.
Functionally, this new crystal strategy is the same as the pre-existing Helm strategy, so I've used that as the basis for my implementation.