### PR TITLE
feat: prerelease type

### DIFF
--- a/__snapshots__/cli.js
+++ b/__snapshots__/cli.js
@@ -188,6 +188,7 @@ Options:
                                     the minor for non-breaking changes prior to
                                     the first major release
                                                       [boolean] [default: false]
+  --prerelease-type                 type of the prerelease, e.g., alpha [string]
   --extra-files                     extra files for the strategy to consider
                                                                         [string]
   --version-file                    path to version file to update, e.g.,

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -51,6 +51,7 @@ Extra options:
 | `--versioning-strategy` | [`VersioningStrategyType`](/docs/customizing.md#versioning-strategies) | Override method of determining SemVer version bumps based on commits. Defaults to `default` |
 | `--bump-minor-pre-major` | `boolean` | Configuration option for the versioning strategy. If set, will bump the minor version for breaking changes for versions < 1.0.0 |
 | `--bump-patch-for-minor-pre-major` | `boolean` | Configuration option for the versioning strategy. If set, will bump the patch version for features for versions < 1.0.0 |
+| `--prerelease-type` | `string` | Configuration option for the prerelese versioning strategy. If prerelease strategy used and type set, will set the prerelese part of the version to the provided value in case prerelease part is not present. |
 | `--draft` | `boolean` | If set, create releases as drafts |
 | `--prerelease` | `boolean` | If set, create releases that are pre-major or pre-release version marked as pre-release on Github|
 | `--draft-pull-request` | `boolean` | If set, create pull requests as drafts |
@@ -101,6 +102,7 @@ need to specify your release options:
 | `--versioning-strategy` | VersioningStrategy | Override method of determining SemVer version bumps based on commits. Defaults to `default` |
 | `--bump-minor-pre-major` | boolean | Configuration option for the versioning strategy. If set, will bump the minor version for breaking changes for versions < 1.0.0 |
 | `--bump-patch-for-minor-pre-major` | boolean | Configuration option for the versioning strategy. If set, will bump the patch version for features for versions < 1.0.0 |
+| `--prerelease-type` | `string` | Configuration option for the prerelese versioning strategy. If prerelease strategy used and type set, will set the prerelese part of the version to the provided value in case prerelease part is not present. |
 | `--draft-pull-request` | boolean | If set, create pull requests as drafts |
 | `--label` | string | Comma-separated list of labels to apply to the release pull requests. Defaults to `autorelease: pending` |`autorelease: tagged` |
 | `--changelog-path` | `string` | Override the path to the managed CHANGELOG. Defaults to `CHANGELOG.md` |

--- a/docs/customizing.md
+++ b/docs/customizing.md
@@ -45,6 +45,8 @@ version given a list of parsed commits.
 | `always-bump-major` | Always bump major version |                                                                                  
 | `service-pack`      | Designed for Java backport fixes. Uses Maven's specification for service pack versions (e.g. 1.2.3-sp.1)    |
 
+| `prerelease`      | Bumping prerelease number (eg. 1.2.0-beta01 to 1.2.0-beta02) or if prerelease type is set, using that in the prerelease part (eg. 1.2.1 to 1.3.0-beta)  |
+
 ### Adding additional versioning strategy types
 
 To add a new versioning strategy, create a new class that implements the

--- a/docs/manifest-releaser.md
+++ b/docs/manifest-releaser.md
@@ -172,6 +172,9 @@ defaults (those are documented in comments)
   // absence defaults to false
   "bump-patch-for-minor-pre-major": true,
 
+  // setting the type of prerelease in case of prerelease strategy
+  "prerelease-type": true,
+
   // set default conventional commit => changelog sections mapping/appearance.
   // absence defaults to https://git.io/JqCZL
   "changelog-sections": [...],

--- a/docs/manifest-releaser.md
+++ b/docs/manifest-releaser.md
@@ -173,7 +173,7 @@ defaults (those are documented in comments)
   "bump-patch-for-minor-pre-major": true,
 
   // setting the type of prerelease in case of prerelease strategy
-  "prerelease-type": true,
+  "prerelease-type": "beta",
 
   // set default conventional commit => changelog sections mapping/appearance.
   // absence defaults to https://git.io/JqCZL

--- a/schemas/config.json
+++ b/schemas/config.json
@@ -22,7 +22,7 @@
         },
         "prerelease-type": {
           "description": "Configuration option for the prerelese versioning strategy. If prerelease strategy used and type set, will set the prerelese part of the version to the provided value in case prerelease part is not present.",
-          "type": "boolean"
+          "type": "string"
         },
         "versioning": {
           "description": "Versioning strategy. Defaults to `default`",

--- a/schemas/config.json
+++ b/schemas/config.json
@@ -20,6 +20,10 @@
           "description": "Feature changes only bump semver patch if version < 1.0.0",
           "type": "boolean"
         },
+        "prerelease-type": {
+          "description": "Configuration option for the prerelese versioning strategy. If prerelease strategy used and type set, will set the prerelese part of the version to the provided value in case prerelease part is not present.",
+          "type": "boolean"
+        },
         "versioning": {
           "description": "Versioning strategy. Defaults to `default`",
           "type": "string"
@@ -290,7 +294,11 @@
                   "type": {
                     "description": "The name of the plugin.",
                     "type": "string",
-                    "enum": ["cargo-workspace", "maven-workspace", "node-workspace"]
+                    "enum": [
+                      "cargo-workspace",
+                      "maven-workspace",
+                      "node-workspace"
+                    ]
                   },
                   "updateAllPackages": {
                     "description": "Whether to force updating all packages regardless of the dependency tree. Defaults to `false`.",

--- a/src/bin/release-please.ts
+++ b/src/bin/release-please.ts
@@ -63,6 +63,7 @@ interface ManifestArgs {
 interface VersioningArgs {
   bumpMinorPreMajor?: boolean;
   bumpPatchForMinorPreMajor?: boolean;
+  prereleaseType?: string;
   releaseAs?: string;
 
   // only for Ruby: TODO replace with generic bootstrap option
@@ -275,6 +276,10 @@ function pullRequestStrategyOptions(yargs: yargs.Argv): yargs.Argv {
       default: false,
       type: 'boolean',
     })
+    .option('prerelease-type', {
+      describe: 'type of the prerelease, e.g., alpha',
+      type: 'string',
+    })
     .option('extra-files', {
       describe: 'extra files for the strategy to consider',
       type: 'string',
@@ -447,6 +452,7 @@ const createReleasePullRequestCommand: yargs.CommandModule<
           draftPullRequest: argv.draftPullRequest,
           bumpMinorPreMajor: argv.bumpMinorPreMajor,
           bumpPatchForMinorPreMajor: argv.bumpPatchForMinorPreMajor,
+          prereleaseType: argv.prereleaseType,
           changelogPath: argv.changelogPath,
           changelogType: argv.changelogType,
           changelogHost: argv.changelogHost,
@@ -711,6 +717,7 @@ const bootstrapCommand: yargs.CommandModule<{}, BootstrapArgs> = {
       draftPullRequest: argv.draftPullRequest,
       bumpMinorPreMajor: argv.bumpMinorPreMajor,
       bumpPatchForMinorPreMajor: argv.bumpPatchForMinorPreMajor,
+      prereleaseType: argv.prereleaseType,
       changelogPath: argv.changelogPath,
       changelogHost: argv.changelogHost,
       changelogSections: argv.changelogSections,

--- a/src/factories/versioning-strategy-factory.ts
+++ b/src/factories/versioning-strategy-factory.ts
@@ -28,6 +28,7 @@ export interface VersioningStrategyFactoryOptions {
   type?: VersioningStrategyType;
   bumpMinorPreMajor?: boolean;
   bumpPatchForMinorPreMajor?: boolean;
+  prereleaseType?: string;
   github: GitHub;
 }
 

--- a/src/factory.ts
+++ b/src/factory.ts
@@ -119,6 +119,7 @@ export async function buildStrategy(
     type: options.versioning,
     bumpMinorPreMajor: options.bumpMinorPreMajor,
     bumpPatchForMinorPreMajor: options.bumpPatchForMinorPreMajor,
+    prereleaseType: options.prereleaseType,
   });
   const changelogNotes = buildChangelogNotes({
     type: options.changelogType || 'default',

--- a/src/manifest.ts
+++ b/src/manifest.ts
@@ -94,6 +94,7 @@ export interface ReleaserConfig {
   versioning?: VersioningStrategyType;
   bumpMinorPreMajor?: boolean;
   bumpPatchForMinorPreMajor?: boolean;
+  prereleaseType?: string;
 
   // Strategy options
   releaseAs?: string;
@@ -148,6 +149,7 @@ interface ReleaserConfigJson {
   versioning?: VersioningStrategyType;
   'bump-minor-pre-major'?: boolean;
   'bump-patch-for-minor-pre-major'?: boolean;
+  'prerelease-type'?: string;
   'changelog-sections'?: ChangelogSection[];
   'release-as'?: string;
   'skip-github-release'?: boolean;
@@ -1290,6 +1292,7 @@ function extractReleaserConfig(
     releaseType: config['release-type'],
     bumpMinorPreMajor: config['bump-minor-pre-major'],
     bumpPatchForMinorPreMajor: config['bump-patch-for-minor-pre-major'],
+    prereleaseType: config['prerelease-type'],
     versioning: config['versioning'],
     changelogSections: config['changelog-sections'],
     changelogPath: config['changelog-path'],
@@ -1635,6 +1638,7 @@ function mergeReleaserConfig(
     bumpPatchForMinorPreMajor:
       pathConfig.bumpPatchForMinorPreMajor ??
       defaultConfig.bumpPatchForMinorPreMajor,
+    prereleaseType: pathConfig.prereleaseType ?? defaultConfig.prereleaseType,
     versioning: pathConfig.versioning ?? defaultConfig.versioning,
     changelogSections:
       pathConfig.changelogSections ?? defaultConfig.changelogSections,

--- a/src/version.ts
+++ b/src/version.ts
@@ -82,6 +82,10 @@ export class Version {
     const buildPart = this.build ? `+${this.build}` : '';
     return `${this.major}.${this.minor}.${this.patch}${preReleasePart}${buildPart}`;
   }
+
+  get isPreMajor(): boolean {
+    return this.major < 1;
+  }
 }
 
 export type VersionsMap = Map<string, Version>;

--- a/src/versioning-strategies/default.ts
+++ b/src/versioning-strategies/default.ts
@@ -24,7 +24,7 @@ import {ConventionalCommit} from '../commit';
 import {Version} from '../version';
 import {logger as defaultLogger, Logger} from '../util/logger';
 
-interface DefaultVersioningStrategyOptions {
+export interface DefaultVersioningStrategyOptions {
   bumpMinorPreMajor?: boolean;
   bumpPatchForMinorPreMajor?: boolean;
   logger?: Logger;
@@ -89,13 +89,13 @@ export class DefaultVersioningStrategy implements VersioningStrategy {
     }
 
     if (breaking > 0) {
-      if (version.major < 1 && this.bumpMinorPreMajor) {
+      if (version.isPreMajor && this.bumpMinorPreMajor) {
         return new MinorVersionUpdate();
       } else {
         return new MajorVersionUpdate();
       }
     } else if (features > 0) {
-      if (version.major < 1 && this.bumpPatchForMinorPreMajor) {
+      if (version.isPreMajor && this.bumpPatchForMinorPreMajor) {
         return new PatchVersionUpdate();
       } else {
         return new MinorVersionUpdate();

--- a/src/versioning-strategies/dependency-manifest.ts
+++ b/src/versioning-strategies/dependency-manifest.ts
@@ -57,13 +57,13 @@ export class DependencyManifest extends DefaultVersioningStrategy {
 
     let dependencyBump: VersionUpdater;
     if (breaking > 0) {
-      if (version.major < 1 && this.bumpMinorPreMajor) {
+      if (version.isPreMajor && this.bumpMinorPreMajor) {
         dependencyBump = new MinorVersionUpdate();
       } else {
         dependencyBump = new MajorVersionUpdate();
       }
     } else if (features > 0) {
-      if (version.major < 1 && this.bumpPatchForMinorPreMajor) {
+      if (version.isPreMajor && this.bumpPatchForMinorPreMajor) {
         dependencyBump = new PatchVersionUpdate();
       } else {
         dependencyBump = new MinorVersionUpdate();

--- a/test/cli.ts
+++ b/test/cli.ts
@@ -839,6 +839,32 @@ describe('CLI', () => {
         sinon.assert.calledOnce(createPullRequestsStub);
       });
 
+      it('handles --prerelease-type', async () => {
+        await parser.parseAsync(
+          'release-pr --repo-url=googleapis/release-please-cli --release-type=java-yoshi --prerelease-type=alpha'
+        );
+
+        sinon.assert.calledOnceWithExactly(gitHubCreateStub, {
+          owner: 'googleapis',
+          repo: 'release-please-cli',
+          token: undefined,
+          apiUrl: 'https://api.github.com',
+          graphqlUrl: 'https://api.github.com',
+        });
+        sinon.assert.calledOnceWithExactly(
+          fromConfigStub,
+          fakeGitHub,
+          'main',
+          sinon.match({
+            releaseType: 'java-yoshi',
+            prereleaseType: 'alpha',
+          }),
+          sinon.match.any,
+          undefined
+        );
+        sinon.assert.calledOnce(createPullRequestsStub);
+      });
+
       it('handles java --extra-files', async () => {
         await parser.parseAsync(
           'release-pr --repo-url=googleapis/release-please-cli --release-type=java-yoshi --extra-files=foo/bar.java,asdf/qwer.java'

--- a/test/factory.ts
+++ b/test/factory.ts
@@ -61,6 +61,20 @@ describe('factory', () => {
       expect(await strategy.getComponent()).not.ok;
       expect(strategy.changelogNotes).instanceof(DefaultChangelogNotes);
     });
+    it('should build a with configuration', async () => {
+      const strategy = await buildStrategy({
+        github,
+        releaseType: 'simple',
+        bumpMinorPreMajor: true,
+        bumpPatchForMinorPreMajor: true,
+      });
+      expect(strategy).instanceof(Simple);
+      expect(strategy.versioningStrategy).instanceof(DefaultVersioningStrategy);
+      const versioningStrategy =
+          strategy.versioningStrategy as DefaultVersioningStrategy;
+      expect(versioningStrategy.bumpMinorPreMajor).to.be.true;
+      expect(versioningStrategy.bumpPatchForMinorPreMajor).to.be.true;
+    });
     it('should build with prerelease type', async () => {
       const strategy = await buildStrategy({
         github,

--- a/test/factory.ts
+++ b/test/factory.ts
@@ -71,7 +71,7 @@ describe('factory', () => {
       expect(strategy).instanceof(Simple);
       expect(strategy.versioningStrategy).instanceof(DefaultVersioningStrategy);
       const versioningStrategy =
-          strategy.versioningStrategy as DefaultVersioningStrategy;
+        strategy.versioningStrategy as DefaultVersioningStrategy;
       expect(versioningStrategy.bumpMinorPreMajor).to.be.true;
       expect(versioningStrategy.bumpPatchForMinorPreMajor).to.be.true;
     });

--- a/test/factory.ts
+++ b/test/factory.ts
@@ -32,6 +32,7 @@ import {DependencyManifest} from '../src/versioning-strategies/dependency-manife
 import {GitHubChangelogNotes} from '../src/changelog-notes/github';
 import {DefaultChangelogNotes} from '../src/changelog-notes/default';
 import {Java} from '../src/strategies/java';
+import {PrereleaseVersioningStrategy} from '../src/versioning-strategies/prerelease';
 
 describe('factory', () => {
   let github: GitHub;
@@ -60,19 +61,24 @@ describe('factory', () => {
       expect(await strategy.getComponent()).not.ok;
       expect(strategy.changelogNotes).instanceof(DefaultChangelogNotes);
     });
-    it('should build a with configuration', async () => {
+    it('should build with prerelease type', async () => {
       const strategy = await buildStrategy({
         github,
         releaseType: 'simple',
         bumpMinorPreMajor: true,
         bumpPatchForMinorPreMajor: true,
+        versioning: 'prerelease',
+        prereleaseType: 'alpha',
       });
       expect(strategy).instanceof(Simple);
-      expect(strategy.versioningStrategy).instanceof(DefaultVersioningStrategy);
+      expect(strategy.versioningStrategy).instanceof(
+        PrereleaseVersioningStrategy
+      );
       const versioningStrategy =
-        strategy.versioningStrategy as DefaultVersioningStrategy;
+        strategy.versioningStrategy as PrereleaseVersioningStrategy;
       expect(versioningStrategy.bumpMinorPreMajor).to.be.true;
       expect(versioningStrategy.bumpPatchForMinorPreMajor).to.be.true;
+      expect(versioningStrategy.prereleaseType).to.eql('alpha');
     });
     it('should throw for unknown type', async () => {
       try {

--- a/test/manifest.ts
+++ b/test/manifest.ts
@@ -5116,6 +5116,7 @@ describe('Manifest', () => {
               '[HOTFIX] - chore${scope}: release${component} ${version}',
             packageName: 'my-package-name',
             includeComponentInTag: false,
+            prerelease: undefined,
           },
         },
         {

--- a/test/version.ts
+++ b/test/version.ts
@@ -150,4 +150,12 @@ describe('Version', () => {
       ]);
     });
   });
+  describe('isPreMajor', () => {
+    it('should return true for versions < 1.0.0', () => {
+      expect(Version.parse('0.1.0').isPreMajor).to.be.true;
+    });
+    it('should return false for versions >= 1.0.0', () => {
+      expect(Version.parse('1.0.0').isPreMajor).to.be.false;
+    });
+  });
 });

--- a/test/versioning-strategies/prerelease.ts
+++ b/test/versioning-strategies/prerelease.ts
@@ -55,31 +55,76 @@ describe('PrereleaseVersioningStrategy', () => {
         breaking: false,
       },
     ];
-    const expectedBumps: Record<string, string> = {
-      '1.2.3': '2.0.0',
-      '0.1.2': '1.0.0',
-      '1.0.0-beta01': '1.0.0-beta02',
-      '2.0.0-beta01': '2.0.0-beta02',
-      '1.0.1-beta01': '2.0.0-beta01',
-      '1.1.0-beta01': '2.0.0-beta01',
-      '1.1.1-beta01': '2.0.0-beta01',
-    };
-    for (const old in expectedBumps) {
-      const expected = expectedBumps[old];
-      it(`can bump ${old} to ${expected}`, async () => {
-        const strategy = new PrereleaseVersioningStrategy();
-        const oldVersion = Version.parse(old);
+    describe('without prerelease type', () => {
+      const expectedBumps: Record<string, string> = {
+        '1.2.3': '2.0.0',
+        '0.1.2': '1.0.0',
+        '1.0.0-beta01': '1.0.0-beta02',
+        '2.0.0-beta01': '2.0.0-beta02',
+        '1.0.1-beta01': '2.0.0-beta01',
+        '1.1.0-beta01': '2.0.0-beta01',
+        '1.1.1-beta01': '2.0.0-beta01',
+      };
+      for (const old in expectedBumps) {
+        const expected = expectedBumps[old];
+        it(`can bump ${old} to ${expected}`, async () => {
+          const strategy = new PrereleaseVersioningStrategy();
+          const oldVersion = Version.parse(old);
+          const newVersion = await strategy.bump(oldVersion, commits);
+          expect(newVersion.toString()).to.equal(expected);
+        });
+      }
+      it('can bump a minor pre major for breaking change', async () => {
+        const strategy = new PrereleaseVersioningStrategy({
+          bumpMinorPreMajor: true,
+        });
+        const oldVersion = Version.parse('0.1.2');
         const newVersion = await strategy.bump(oldVersion, commits);
-        expect(newVersion.toString()).to.equal(expected);
+        expect(newVersion.toString()).to.equal('0.2.0');
       });
-    }
-    it('can bump a minor pre major for breaking change', async () => {
-      const strategy = new PrereleaseVersioningStrategy({
-        bumpMinorPreMajor: true,
+    });
+
+    describe('with prerelease type', () => {
+      const expectedBumps: Record<string, string> = {
+        '1.2.3': '2.0.0-beta',
+        '0.1.2': '1.0.0-beta',
+        '1.0.0-alpha': '1.0.0-alpha.1',
+        '1.0.0-beta': '1.0.0-beta.1',
+        '2.0.0-beta': '2.0.0-beta.1',
+        '1.0.1-beta': '2.0.0-beta',
+        '1.1.0-beta': '2.0.0-beta',
+        '1.1.1-beta': '2.0.0-beta',
+        '1.0.0-beta01': '1.0.0-beta02',
+        '2.0.0-beta01': '2.0.0-beta02',
+        '1.0.1-beta01': '2.0.0-beta01',
+        '1.1.0-beta01': '2.0.0-beta01',
+        '1.1.1-beta01': '2.0.0-beta01',
+        '1.0.0-beta2023.1': '1.0.0-beta2023.2',
+        '2.0.0-beta2023.1': '2.0.0-beta2023.2',
+        '1.0.1-beta2023.1': '2.0.0-beta2023.1',
+        '1.1.0-beta2023.1': '2.0.0-beta2023.1',
+        '1.1.1-beta2023.1': '2.0.0-beta2023.1',
+      };
+      for (const old in expectedBumps) {
+        const expected = expectedBumps[old];
+        it(`can bump ${old} to ${expected}`, async () => {
+          const strategy = new PrereleaseVersioningStrategy({
+            prereleaseType: 'beta',
+          });
+          const oldVersion = Version.parse(old);
+          const newVersion = await strategy.bump(oldVersion, commits);
+          expect(newVersion.toString()).to.equal(expected);
+        });
+      }
+      it('can bump a minor pre major for breaking change', async () => {
+        const strategy = new PrereleaseVersioningStrategy({
+          bumpMinorPreMajor: true,
+          prereleaseType: 'beta',
+        });
+        const oldVersion = Version.parse('0.1.2');
+        const newVersion = await strategy.bump(oldVersion, commits);
+        expect(newVersion.toString()).to.equal('0.2.0-beta');
       });
-      const oldVersion = Version.parse('0.1.2');
-      const newVersion = await strategy.bump(oldVersion, commits);
-      expect(newVersion.toString()).to.equal('0.2.0');
     });
   });
 
@@ -119,31 +164,76 @@ describe('PrereleaseVersioningStrategy', () => {
         breaking: false,
       },
     ];
-    const expectedBumps: Record<string, string> = {
-      '1.2.3': '1.3.0',
-      '0.1.2': '0.2.0',
-      '1.0.0-beta01': '1.0.0-beta02',
-      '2.0.0-beta01': '2.0.0-beta02',
-      '1.0.1-beta01': '1.1.0-beta01',
-      '1.1.0-beta01': '1.1.0-beta02',
-      '1.1.1-beta01': '1.2.0-beta01',
-    };
-    for (const old in expectedBumps) {
-      const expected = expectedBumps[old];
-      it(`can bump ${old} to ${expected}`, async () => {
-        const strategy = new PrereleaseVersioningStrategy();
-        const oldVersion = Version.parse(old);
+    describe('without prerelease type', () => {
+      const expectedBumps: Record<string, string> = {
+        '1.2.3': '1.3.0',
+        '0.1.2': '0.2.0',
+        '1.0.0-beta01': '1.0.0-beta02',
+        '2.0.0-beta01': '2.0.0-beta02',
+        '1.0.1-beta01': '1.1.0-beta01',
+        '1.1.0-beta01': '1.1.0-beta02',
+        '1.1.1-beta01': '1.2.0-beta01',
+      };
+      for (const old in expectedBumps) {
+        const expected = expectedBumps[old];
+        it(`can bump ${old} to ${expected}`, async () => {
+          const strategy = new PrereleaseVersioningStrategy();
+          const oldVersion = Version.parse(old);
+          const newVersion = await strategy.bump(oldVersion, commits);
+          expect(newVersion.toString()).to.equal(expected);
+        });
+      }
+      it('can bump a patch pre-major', async () => {
+        const strategy = new PrereleaseVersioningStrategy({
+          bumpPatchForMinorPreMajor: true,
+        });
+        const oldVersion = Version.parse('0.1.2');
         const newVersion = await strategy.bump(oldVersion, commits);
-        expect(newVersion.toString()).to.equal(expected);
+        expect(newVersion.toString()).to.equal('0.1.3');
       });
-    }
-    it('can bump a patch pre-major', async () => {
-      const strategy = new PrereleaseVersioningStrategy({
-        bumpPatchForMinorPreMajor: true,
+    });
+    describe('with prerelease type', () => {
+      const expectedBumps: Record<string, string> = {
+        '1.2.3': '1.3.0-beta',
+        '0.1.2': '0.2.0-beta',
+        '1.0.0-alpha': '1.0.0-alpha.1',
+        '1.0.0-beta': '1.0.0-beta.1',
+        '2.0.0-beta': '2.0.0-beta.1',
+        '1.0.1-beta': '1.1.0-beta',
+        '1.1.0-alpha': '1.1.0-alpha.1',
+        '1.1.0-beta': '1.1.0-beta.1',
+        '1.1.1-beta': '1.2.0-beta',
+        '1.0.0-beta01': '1.0.0-beta02',
+        '2.0.0-beta01': '2.0.0-beta02',
+        '1.0.1-beta01': '1.1.0-beta01',
+        '1.1.0-beta01': '1.1.0-beta02',
+        '1.1.1-beta01': '1.2.0-beta01',
+        '1.0.0-beta2023.1': '1.0.0-beta2023.2',
+        '2.0.0-beta2023.1': '2.0.0-beta2023.2',
+        '1.0.1-beta2023.1': '1.1.0-beta2023.1',
+        '1.1.0-beta2023.1': '1.1.0-beta2023.2',
+        '1.1.1-beta2023.1': '1.2.0-beta2023.1',
+      };
+      for (const old in expectedBumps) {
+        const expected = expectedBumps[old];
+        it(`can bump ${old} to ${expected}`, async () => {
+          const strategy = new PrereleaseVersioningStrategy({
+            prereleaseType: 'beta',
+          });
+          const oldVersion = Version.parse(old);
+          const newVersion = await strategy.bump(oldVersion, commits);
+          expect(newVersion.toString()).to.equal(expected);
+        });
+      }
+      it('can bump a patch pre-major', async () => {
+        const strategy = new PrereleaseVersioningStrategy({
+          bumpPatchForMinorPreMajor: true,
+          prereleaseType: 'beta',
+        });
+        const oldVersion = Version.parse('0.1.2');
+        const newVersion = await strategy.bump(oldVersion, commits);
+        expect(newVersion.toString()).to.equal('0.1.3-beta');
       });
-      const oldVersion = Version.parse('0.1.2');
-      const newVersion = await strategy.bump(oldVersion, commits);
-      expect(newVersion.toString()).to.equal('0.1.3');
     });
   });
 
@@ -172,26 +262,59 @@ describe('PrereleaseVersioningStrategy', () => {
         breaking: false,
       },
     ];
-    const expectedBumps: Record<string, string> = {
-      '1.2.3': '1.2.4',
-      '1.0.0-beta01': '1.0.0-beta02',
-      '2.0.0-beta01': '2.0.0-beta02',
-      '1.0.1-beta01': '1.0.1-beta02',
-      '1.1.0-beta01': '1.1.0-beta02',
-      '1.1.1-beta01': '1.1.1-beta02',
-      '1.0.0-beta1': '1.0.0-beta2',
-      '1.0.0-beta9': '1.0.0-beta10', // (although that would be unfortunate)
-      '1.0.0-beta09': '1.0.0-beta10',
-    };
-    for (const old in expectedBumps) {
-      const expected = expectedBumps[old];
-      it(`can bump ${old} to ${expected}`, async () => {
-        const strategy = new PrereleaseVersioningStrategy();
-        const oldVersion = Version.parse(old);
-        const newVersion = await strategy.bump(oldVersion, commits);
-        expect(newVersion.toString()).to.equal(expected);
-      });
-    }
+    describe('without prerelease type', () => {
+      const expectedBumps: Record<string, string> = {
+        '1.2.3': '1.2.4',
+        '1.0.0-beta01': '1.0.0-beta02',
+        '2.0.0-beta01': '2.0.0-beta02',
+        '1.0.1-beta01': '1.0.1-beta02',
+        '1.1.0-beta01': '1.1.0-beta02',
+        '1.1.1-beta01': '1.1.1-beta02',
+        '1.0.0-beta1': '1.0.0-beta2',
+        '1.0.0-beta9': '1.0.0-beta10', // (although that would be unfortunate)
+        '1.0.0-beta09': '1.0.0-beta10',
+      };
+      for (const old in expectedBumps) {
+        const expected = expectedBumps[old];
+        it(`can bump ${old} to ${expected}`, async () => {
+          const strategy = new PrereleaseVersioningStrategy();
+          const oldVersion = Version.parse(old);
+          const newVersion = await strategy.bump(oldVersion, commits);
+          expect(newVersion.toString()).to.equal(expected);
+        });
+      }
+    });
+    describe('with prerelease type', () => {
+      const expectedBumps: Record<string, string> = {
+        '1.2.3': '1.2.4-beta',
+        '1.2.4-alpha': '1.2.4-alpha.1',
+        '1.2.4-beta': '1.2.4-beta.1',
+        '1.0.0-beta01': '1.0.0-beta02',
+        '2.0.0-beta01': '2.0.0-beta02',
+        '1.0.1-beta01': '1.0.1-beta02',
+        '1.1.0-beta01': '1.1.0-beta02',
+        '1.1.1-beta01': '1.1.1-beta02',
+        '1.0.0-beta1': '1.0.0-beta2',
+        '1.0.0-beta9': '1.0.0-beta10', // (although that would be unfortunate)
+        '1.0.0-beta09': '1.0.0-beta10',
+        '1.0.0-beta2023.1': '1.0.0-beta2023.2',
+        '2.0.0-beta2023.1': '2.0.0-beta2023.2',
+        '1.0.1-beta2023.1': '1.0.1-beta2023.2',
+        '1.1.0-beta2023.1': '1.1.0-beta2023.2',
+        '1.1.1-beta2023.1': '1.1.1-beta2023.2',
+      };
+      for (const old in expectedBumps) {
+        const expected = expectedBumps[old];
+        it(`can bump ${old} to ${expected}`, async () => {
+          const strategy = new PrereleaseVersioningStrategy({
+            prereleaseType: 'beta',
+          });
+          const oldVersion = Version.parse(old);
+          const newVersion = await strategy.bump(oldVersion, commits);
+          expect(newVersion.toString()).to.equal(expected);
+        });
+      }
+    });
   });
 
   describe('with release-as', () => {


### PR DESCRIPTION
Thank you for opening a Pull Request! Before submitting your PR, there are a few things you can do to make sure it goes smoothly:
- [x] Make sure to open an issue as a [bug/issue](https://github.com/googleapis/release-please/issues/new/choose) before writing your code!  That way we can discuss the change, evaluate designs, and agree on the general idea
- [x] Ensure the tests and linter pass
- [x] Code coverage does not decrease (if any source code was changed)
- [x] Appropriate docs were updated (if necessary)

Fixes #2082 🦕 by introducing an argument to the `prerelease` versioning strategy.

It also deals with bumping versions with prerelease, but not having a number in the prerelease part in the following ways  
- `2.0.0-beta` will get bumped to `2.0.0-beta.1` if there are breaking changes or less
- `1.2.0-beta` will get bumped to `1.2.0-beta.1` if there are featurer or less
- `1.2.2-beta` will get bumped to `1.2.2-beta.1` if there are only patches.

The current behaviour of prelrease, ie. bumping `1.1.1-beta01` to `1.1.1-beta02` is preserved.
