### PR TITLE
docs: Update manifest-releaser.md

### DIFF
--- a/docs/manifest-releaser.md
+++ b/docs/manifest-releaser.md
@@ -34,8 +34,7 @@ release-please bootstrap \
 This will open a pull request that configures the initial
 `release-please-config.json` and `.release-please-manifest.json` files.
 
-> For this to work you may need to set "Allow GitHub Actions to create and approve pull requests" under repository Settings > Actions > General.
-
+Note: For this to work you may need to set "Allow GitHub Actions to create and approve pull requests" under repository Settings > Actions > General.
 
 For the full options, see the [CLI documentation](/docs/cli.md#bootstrapping).
 

--- a/docs/manifest-releaser.md
+++ b/docs/manifest-releaser.md
@@ -34,9 +34,9 @@ release-please bootstrap \
 This will open a pull request that configures the initial
 `release-please-config.json` and `.release-please-manifest.json` files.
 
-Note: For this to work you may need to set "Allow GitHub Actions to create and approve pull requests" under repository Settings > Actions > General.
-
 For the full options, see the [CLI documentation](/docs/cli.md#bootstrapping).
+
+Note: For this to work you may need to set "Allow GitHub Actions to create and approve pull requests" under repository Settings > Actions > General.
 
 ### Bootstrap manually
 

--- a/docs/manifest-releaser.md
+++ b/docs/manifest-releaser.md
@@ -34,6 +34,9 @@ release-please bootstrap \
 This will open a pull request that configures the initial
 `release-please-config.json` and `.release-please-manifest.json` files.
 
+> For this to work you may need to set "Allow GitHub Actions to create and approve pull requests" under repository Settings > Actions > General.
+
+
 For the full options, see the [CLI documentation](/docs/cli.md#bootstrapping).
 
 ### Bootstrap manually


### PR DESCRIPTION
I use `release-please` in one of my projects and was at first not able to use the automatic bootstrap functionality. I had to enable the "Allow GitHub Actions to create and approve pull requests" to make it work. I thought it may be a good idea to add this hint to the docs :)

Thank you for opening a Pull Request! Before submitting your PR, there are a few things you can do to make sure it goes smoothly:
- [x] Appropriate docs were updated (if necessary)

