### PR TITLE
docs(readme): add link to release-plz

### DIFF
--- a/README.md
+++ b/README.md
@@ -195,7 +195,7 @@ Release Please automates releases for the following flavors of repositories:
 | `php`               | A repository with a composer.json and a CHANGELOG.md |
 | `python`            | [A Python repository, with a setup.py, setup.cfg, CHANGELOG.md](https://github.com/googleapis/python-storage) and optionally a pyproject.toml and a &lt;project&gt;/\_\_init\_\_.py |
 | `ruby`              | A repository with a version.rb and a CHANGELOG.md |
-| `rust`              | A Rust repository, with a Cargo.toml (either as a crate or workspace, although note that workspaces require a [manifest driven release](https://github.com/googleapis/release-please/blob/main/docs/manifest-releaser.md) and the "cargo-workspace" plugin) and a CHANGELOG.md |
+| `rust`              | A Rust repository, with a Cargo.toml (either as a crate or workspace, although note that workspaces require a [manifest driven release](https://github.com/googleapis/release-please/blob/main/docs/manifest-releaser.md) and the "cargo-workspace" plugin) and a CHANGELOG.md. See also [release-plz](https://release-plz.ieni.dev/). |
 | `sfdx`              | A repository with a [sfdx-project.json](https://developer.salesforce.com/docs/atlas.en-us.sfdx_dev.meta/sfdx_dev/sfdx_dev_ws_config.htm) and a CHANGELOG.md |
 | `simple`            | [A repository with a version.txt and a CHANGELOG.md](https://github.com/googleapis/gapic-generator) |
 | `terraform-module`  | [A terraform module, with a version in the README.md, and a CHANGELOG.md](https://github.com/terraform-google-modules/terraform-google-project-factory) |


### PR DESCRIPTION
Hi 👋
Thanks for creating release-please. I liked the workflow of this tool so much that it inspired me to create [release-plz](https://release-plz.ieni.dev/).
Release-plz is similar to release-please, but it's meant to only work in Rust:
- it's integrated with [crates.io](https://crates.io/): it publishes packages there and it checks if a package is already published (it doesn't rely on git tags for this).
- it uses [cargo-semver-checks](https://github.com/obi1kenobi/cargo-semver-checks) to detect api breaking changes. If so, it bumps the major version.
- No configuration required: you can `git clone` a repository and run `release-plz update` on it and it will update Changelog and Cargo.toml.
- More about this [here](https://release-plz.ieni.dev/docs/why#differences-with-release-please).

I would like to add release-plz to the readme because Rust developers might be interested in this tool.
However, if you prefer not to link to external projects in your readme, I understand.

Again, thanks again for creating this tool. 🙏 