### PR TITLE
feat: customize PR body footer

### DIFF
--- a/__snapshots__/cli.js
+++ b/__snapshots__/cli.js
@@ -31,6 +31,7 @@ Options:
                                 branches              [boolean] [default: false]
   --pull-request-title-pattern  Title pattern to make release PR        [string]
   --pull-request-header         Header for release PR                   [string]
+  --pull-request-footer         Footer for release PR                   [string]
   --path                        release from path other than root directory
                                                                         [string]
   --component                   name of component release is being minted for
@@ -231,6 +232,7 @@ Options:
                                     branches          [boolean] [default: false]
   --pull-request-title-pattern      Title pattern to make release PR    [string]
   --pull-request-header             Header for release PR               [string]
+  --pull-request-footer             Footer for release PR               [string]
   --path                            release from path other than root directory
                                                                         [string]
   --component                       name of component release is being minted

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -63,6 +63,7 @@ Extra options:
 | `--changelog-host` | `string` | Host for commit hyperlinks in the changelog. Defaults to `https://github.com` |
 | `--pull-request-title-pattern` | `string` | Override the pull request title pattern. Defaults to `chore${scope}: release${component} ${version}` |
 | `--pull-request-header` | `string` | Override the pull request header. Defaults to `:robot: I have created a release *beep* *boop*` |
+| `--pull-request-footer` | `string` | Override the pull request footer. Defaults to `This PR was generated with Release Please. See documentation.` |
 | `--extra-files` | `string[]` | Extra file paths for the release strategy to consider |
 | `--version-file` | `string` | Ruby only. Path to the `version.rb` file |
 
@@ -112,6 +113,7 @@ need to specify your release options:
 | `--monorepo-tags` | boolean | Add prefix to tags and branches, allowing multiple libraries to be released from the same repository |
 | `--pull-request-title-pattern` | `string` | Override the pull request title pattern. Defaults to `chore${scope}: release${component} ${version}` |
 | `--pull-request-header` | `string` | Override the pull request header. Defaults to `:robot: I have created a release *beep* *boop*` |
+| `--pull-request-footer` | `string` | Override the pull request footer. Defaults to `This PR was generated with Release Please. See documentation.` |
 | `--signoff` | string | Add [`Signed-off-by`](https://git-scm.com/docs/git-commit#Documentation/git-commit.txt---signoff) line at the end of the commit log message using the user and email provided. (format "Name \<email@example.com\>") |
 | `--extra-files` | `string[]` | Extra file paths for the release strategy to consider |
 | `--version-file` | `string` | Ruby only. Path to the `version.rb` file |
@@ -152,6 +154,7 @@ need to specify your release options:
 | `--monorepo-tags` | boolean | Add prefix to tags and branches, allowing multiple libraries to be released from the same repository |
 | `--pull-request-title-pattern` | `string` | Override the pull request title pattern. Defaults to `chore${scope}: release${component} ${version}` |
 | `--pull-request-header` | `string` | Override the pull request header. Defaults to `:robot: I have created a release *beep* *boop*` |
+| `--pull-request-footer` | `string` | Override the pull request footer. Defaults to `This PR was generated with Release Please. See documentation.` |
 | `--draft` | `boolean` | If set, create releases as drafts |
 | `--prerelease` | `boolean` | If set, create releases that are pre-major or pre-release version marked as pre-release on Github|
 | `--label` | `string` | Comma-separated list of labels to apply to the release pull requests. Defaults to `autorelease: pending` |

--- a/docs/customizing.md
+++ b/docs/customizing.md
@@ -120,6 +120,15 @@ option in the manifest configuration.
 By default, the pull request header is:
 `:robot: I have created a release *beep* *boop*`.
 
+### Pull Request Footer
+
+If you would like to customize the pull request footer, you can use the
+`--pull-request-footer` CLI option or the `pull-request-footer`
+option in the manifest configuration.
+
+By default, the pull request footer is:
+`This PR was generated with Release Please. See documentation.`.
+
 ## Release Lifecycle Labels
 
 By default, we open release pull requests with the `autorelease: pending`

--- a/schemas/config.json
+++ b/schemas/config.json
@@ -103,6 +103,10 @@
           "description": "Customize the release pull request header.",
           "type": "string"
         },
+        "pull-request-footer": {
+          "description": "Customize the release pull request footer.",
+          "type": "string"
+        },
         "separate-pull-requests": {
           "description": "Open a separate release pull request for each component. Defaults to `false`.",
           "type": "boolean"
@@ -404,6 +408,7 @@
     "changelog-path": true,
     "pull-request-title-pattern": true,
     "pull-request-header": true,
+    "pull-request-footer": true,
     "separate-pull-requests": true,
     "tag-separator": true,
     "extra-files": true,

--- a/src/bin/release-please.ts
+++ b/src/bin/release-please.ts
@@ -115,6 +115,7 @@ interface TaggingArgs {
   monorepoTags?: boolean;
   pullRequestTitlePattern?: string;
   pullRequestHeader?: string;
+  pullRequestFooter?: string;
 }
 
 interface CreatePullRequestArgs
@@ -419,6 +420,10 @@ function taggingOptions(yargs: yargs.Argv): yargs.Argv {
     .option('pull-request-header', {
       describe: 'Header for release PR',
       type: 'string',
+    })
+    .option('pull-request-footer', {
+      describe: 'Footer for release PR',
+      type: 'string',
     });
 }
 
@@ -458,6 +463,7 @@ const createReleasePullRequestCommand: yargs.CommandModule<
           changelogHost: argv.changelogHost,
           pullRequestTitlePattern: argv.pullRequestTitlePattern,
           pullRequestHeader: argv.pullRequestHeader,
+          pullRequestFooter: argv.pullRequestFooter,
           changelogSections: argv.changelogSections,
           releaseAs: argv.releaseAs,
           versioning: argv.versioningStrategy,

--- a/src/manifest.ts
+++ b/src/manifest.ts
@@ -108,6 +108,7 @@ export interface ReleaserConfig {
   includeVInTag?: boolean;
   pullRequestTitlePattern?: string;
   pullRequestHeader?: string;
+  pullRequestFooter?: string;
   tagSeparator?: string;
   separatePullRequests?: boolean;
   labels?: string[];
@@ -165,6 +166,7 @@ interface ReleaserConfigJson {
   'changelog-host'?: string;
   'pull-request-title-pattern'?: string;
   'pull-request-header'?: string;
+  'pull-request-footer'?: string;
   'separate-pull-requests'?: boolean;
   'tag-separator'?: string;
   'extra-files'?: ExtraFile[];
@@ -1311,6 +1313,7 @@ function extractReleaserConfig(
     changelogType: config['changelog-type'],
     pullRequestTitlePattern: config['pull-request-title-pattern'],
     pullRequestHeader: config['pull-request-header'],
+    pullRequestFooter: config['pull-request-footer'],
     tagSeparator: config['tag-separator'],
     separatePullRequests: config['separate-pull-requests'],
     labels: config['label']?.split(','),
@@ -1663,6 +1666,8 @@ function mergeReleaserConfig(
       defaultConfig.pullRequestTitlePattern,
     pullRequestHeader:
       pathConfig.pullRequestHeader ?? defaultConfig.pullRequestHeader,
+    pullRequestFooter:
+      pathConfig.pullRequestFooter ?? defaultConfig.pullRequestFooter,
     separatePullRequests:
       pathConfig.separatePullRequests ?? defaultConfig.separatePullRequests,
     skipSnapshot: pathConfig.skipSnapshot ?? defaultConfig.skipSnapshot,

--- a/src/plugins/merge.ts
+++ b/src/plugins/merge.ts
@@ -29,6 +29,7 @@ import {GitHub} from '../github';
 interface MergeOptions {
   pullRequestTitlePattern?: string;
   pullRequestHeader?: string;
+  pullRequestFooter?: string;
   headBranchName?: string;
   forceMerge?: boolean;
 }
@@ -42,6 +43,7 @@ interface MergeOptions {
 export class Merge extends ManifestPlugin {
   private pullRequestTitlePattern?: string;
   private pullRequestHeader?: string;
+  private pullRequestFooter?: string;
   private headBranchName?: string;
   private forceMerge: boolean;
 
@@ -55,6 +57,7 @@ export class Merge extends ManifestPlugin {
     this.pullRequestTitlePattern =
       options.pullRequestTitlePattern ?? MANIFEST_PULL_REQUEST_TITLE_PATTERN;
     this.pullRequestHeader = options.pullRequestHeader;
+    this.pullRequestFooter = options.pullRequestFooter;
     this.headBranchName = options.headBranchName;
     this.forceMerge = options.forceMerge ?? false;
   }
@@ -108,6 +111,7 @@ export class Merge extends ManifestPlugin {
       body: new PullRequestBody(releaseData, {
         useComponents: true,
         header: this.pullRequestHeader,
+        footer: this.pullRequestFooter,
       }),
       updates,
       labels: Array.from(labels),

--- a/src/strategies/base.ts
+++ b/src/strategies/base.ts
@@ -75,6 +75,7 @@ export interface BaseStrategyOptions {
   includeVInTag?: boolean;
   pullRequestTitlePattern?: string;
   pullRequestHeader?: string;
+  pullRequestFooter?: string;
   extraFiles?: ExtraFile[];
   versionFile?: string;
   snapshotLabels?: string[]; // Java-only
@@ -107,6 +108,7 @@ export abstract class BaseStrategy implements Strategy {
   protected initialVersion?: string;
   readonly pullRequestTitlePattern?: string;
   readonly pullRequestHeader?: string;
+  readonly pullRequestFooter?: string;
   readonly extraFiles: ExtraFile[];
   readonly extraLabels: string[];
 
@@ -139,6 +141,7 @@ export abstract class BaseStrategy implements Strategy {
     this.includeVInTag = options.includeVInTag ?? true;
     this.pullRequestTitlePattern = options.pullRequestTitlePattern;
     this.pullRequestHeader = options.pullRequestHeader;
+    this.pullRequestFooter = options.pullRequestFooter;
     this.extraFiles = options.extraFiles || [];
     this.initialVersion = options.initialVersion;
     this.extraLabels = options.extraLabels || [];
@@ -225,7 +228,8 @@ export abstract class BaseStrategy implements Strategy {
     releaseNotesBody: string,
     _conventionalCommits: ConventionalCommit[],
     _latestRelease?: Release,
-    pullRequestHeader?: string
+    pullRequestHeader?: string,
+    pullRequestFooter?: string
   ): Promise<PullRequestBody> {
     return new PullRequestBody(
       [
@@ -235,7 +239,10 @@ export abstract class BaseStrategy implements Strategy {
           notes: releaseNotesBody,
         },
       ],
-      {header: pullRequestHeader}
+      {
+        header: pullRequestHeader,
+        footer: pullRequestFooter,
+      }
     );
   }
 
@@ -326,7 +333,8 @@ export abstract class BaseStrategy implements Strategy {
       releaseNotesBody,
       conventionalCommits,
       latestRelease,
-      this.pullRequestHeader
+      this.pullRequestHeader,
+      this.pullRequestFooter
     );
 
     return {

--- a/src/strategies/dotnet-yoshi.ts
+++ b/src/strategies/dotnet-yoshi.ts
@@ -40,6 +40,8 @@ const DEFAULT_PULL_REQUEST_TITLE_PATTERN =
   'Release${component} version ${version}';
 const DEFAULT_PULL_REQUEST_HEADER =
   ':robot: I have created a release *beep* *boop*';
+const DEFAULT_PULL_REQUEST_FOOTER =
+  'This PR was generated with [Release Please](https://github.com/googleapis/release-please). See [documentation](https://github.com/googleapis/release-please#release-please).'
 const RELEASE_NOTES_HEADER_PATTERN =
   /#{2,3} \[?(\d+\.\d+\.\d+-?[^\]]*)\]?.* \((\d{4}-\d{2}-\d{2})\)/;
 
@@ -61,6 +63,8 @@ export class DotnetYoshi extends BaseStrategy {
       options.pullRequestTitlePattern ?? DEFAULT_PULL_REQUEST_TITLE_PATTERN;
     options.pullRequestHeader =
       options.pullRequestHeader ?? DEFAULT_PULL_REQUEST_HEADER;
+    options.pullRequestFooter =
+      options.pullRequestFooter ?? DEFAULT_PULL_REQUEST_FOOTER;
     options.includeVInTag = options.includeVInTag ?? false;
     super(options);
   }

--- a/src/strategies/dotnet-yoshi.ts
+++ b/src/strategies/dotnet-yoshi.ts
@@ -41,7 +41,7 @@ const DEFAULT_PULL_REQUEST_TITLE_PATTERN =
 const DEFAULT_PULL_REQUEST_HEADER =
   ':robot: I have created a release *beep* *boop*';
 const DEFAULT_PULL_REQUEST_FOOTER =
-  'This PR was generated with [Release Please](https://github.com/googleapis/release-please). See [documentation](https://github.com/googleapis/release-please#release-please).'
+  'This PR was generated with [Release Please](https://github.com/googleapis/release-please). See [documentation](https://github.com/googleapis/release-please#release-please).';
 const RELEASE_NOTES_HEADER_PATTERN =
   /#{2,3} \[?(\d+\.\d+\.\d+-?[^\]]*)\]?.* \((\d{4}-\d{2}-\d{2})\)/;
 

--- a/src/updaters/release-please-config.ts
+++ b/src/updaters/release-please-config.ts
@@ -75,6 +75,7 @@ function releaserConfigToJsonConfig(
     'changelog-host': config.changelogHost,
     'pull-request-title-pattern': config.pullRequestTitlePattern,
     'pull-request-header': config.pullRequestHeader,
+    'pull-request-footer': config.pullRequestFooter,
     'separate-pull-requests': config.separatePullRequests,
     'tag-separator': config.tagSeparator,
     'extra-files': config.extraFiles,

--- a/test/manifest.ts
+++ b/test/manifest.ts
@@ -1649,7 +1649,6 @@ describe('Manifest', () => {
             '.': {
               releaseType: 'simple',
               pullRequestHeader: 'No beep boop for you',
-              pullRequestFooter: 'No reminder for you',
             },
           },
           {
@@ -1662,6 +1661,25 @@ describe('Manifest', () => {
         expect(pullRequest.body.header.toString()).to.eql(
           'No beep boop for you'
         );
+      });
+
+      it('allows customizing pull request footer', async () => {
+        const manifest = new Manifest(
+          github,
+          'main',
+          {
+            '.': {
+              releaseType: 'simple',
+              pullRequestFooter: 'No reminder for you',
+            },
+          },
+          {
+            '.': Version.parse('1.0.0'),
+          }
+        );
+        const pullRequests = await manifest.buildPullRequests();
+        expect(pullRequests).lengthOf(1);
+        const pullRequest = pullRequests[0];
         expect(pullRequest.body.footer.toString()).to.eql(
           'No reminder for you'
         );

--- a/test/manifest.ts
+++ b/test/manifest.ts
@@ -1649,6 +1649,7 @@ describe('Manifest', () => {
             '.': {
               releaseType: 'simple',
               pullRequestHeader: 'No beep boop for you',
+              pullRequestFooter: 'No reminder for you',
             },
           },
           {
@@ -1660,6 +1661,9 @@ describe('Manifest', () => {
         const pullRequest = pullRequests[0];
         expect(pullRequest.body.header.toString()).to.eql(
           'No beep boop for you'
+        );
+        expect(pullRequest.body.footer.toString()).to.eql(
+          'No reminder for you'
         );
       });
     });


### PR DESCRIPTION
The function already exists, but it cannot be changed as a parameter for package users. This update makes the setting available to everyone.

**The `pull-request-footer` option has been added to the configuration file.** When tracked, it completely matches the settings of the `pull-request-header`. The PR generator was already equipped with a `footer` parameter by default, so you just need to pass this setting along.

Fixes #2114 🦕
