### PR TITLE
feat(deps): refactor node-workspace plugin to drop lerna-lite/core

### DIFF
--- a/__snapshots__/node-workspace.js
+++ b/__snapshots__/node-workspace.js
@@ -93,6 +93,37 @@ Release notes for path: ., releaseType: node
 This PR was generated with [Release Please](https://github.com/googleapis/release-please). See [documentation](https://github.com/googleapis/release-please#release-please).
 `
 
+exports['NodeWorkspace plugin run combines node packages 2'] = `
+{
+  "name": "@here/root",
+  "version": "5.5.6",
+  "dependencies": {
+    "@here/pkgA": "^3.3.4",
+    "@here/pkgD": "^4.4.5"
+  }
+}
+`
+
+exports['NodeWorkspace plugin run combines node packages 3'] = `
+{
+  "name": "@here/pkgA",
+  "version": "3.3.4",
+  "dependencies": {
+    "anotherExternal": "^4.3.1"
+  }
+}
+`
+
+exports['NodeWorkspace plugin run combines node packages 4'] = `
+{
+  "name": "@here/pkgD",
+  "version": "4.4.5",
+  "dependencies": {
+    "anotherExternal": "^4.3.1"
+  }
+}
+`
+
 exports['NodeWorkspace plugin run handles a single node package 1'] = `
 :robot: I have created a release *beep* *boop*
 ---

--- a/__snapshots__/package-json.js
+++ b/__snapshots__/package-json.js
@@ -1,3 +1,59 @@
+exports['PackageJson updateContent updates dependency versions 1'] = `
+{
+\t"name": "yargs-parser",
+\t"version": "14.0.0",
+\t"description": "the mighty option parser used by yargs",
+\t"main": "index.js",
+\t"scripts": {
+\t\t"test": "nyc mocha test/*.js",
+\t\t"posttest": "standard",
+\t\t"coverage": "nyc report --reporter=text-lcov | coveralls",
+\t\t"release": "standard-version"
+\t},
+\t"repository": {
+\t\t"url": "git@github.com:yargs/yargs-parser.git"
+\t},
+\t"keywords": [
+\t\t"argument",
+\t\t"parser",
+\t\t"yargs",
+\t\t"command",
+\t\t"cli",
+\t\t"parsing",
+\t\t"option",
+\t\t"args",
+\t\t"argument"
+\t],
+\t"author": "Ben Coe <ben@npmjs.com>",
+\t"license": "ISC",
+\t"devDependencies": {
+\t\t"chai": "^4.2.1",
+\t\t"coveralls": "^3.0.2",
+\t\t"mocha": "^5.2.0",
+\t\t"nyc": "^13.0.1",
+\t\t"standard": "^12.0.1"
+\t},
+\t"dependencies": {
+\t\t"camelcase": "^6.0.0",
+\t\t"decamelize": "^1.2.0"
+\t},
+\t"optionalDependencies": {
+\t\t"foo": "~0.1.0"
+\t},
+\t"peerDependencies": {
+\t\t"bar": ">2.3.4"
+\t},
+\t"files": [
+\t\t"lib",
+\t\t"index.js"
+\t],
+\t"engine": {
+\t\t"node": ">=6"
+\t}
+}
+
+`
+
 exports['PackageJson updateContent updates the package version 1'] = `
 {
 \t"name": "yargs-parser",

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,6 @@
         "@conventional-commits/parser": "^0.4.1",
         "@google-automations/git-file-utils": "^1.2.5",
         "@iarna/toml": "^3.0.0",
-        "@lerna-lite/core": "1.17.0",
         "@octokit/graphql": "^5.0.0",
         "@octokit/request": "^6.0.0",
         "@octokit/request-error": "^3.0.0",
@@ -3656,20 +3655,6 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
       "integrity": "sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw=="
-    },
-    "node_modules/fsevents": {
-      "version": "2.3.2",
-      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
-      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
-      "dev": true,
-      "hasInstallScript": true,
-      "optional": true,
-      "os": [
-        "darwin"
-      ],
-      "engines": {
-        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
-      }
     },
     "node_modules/function-bind": {
       "version": "1.1.1",
@@ -7970,8 +7955,7 @@
       }
     },
     "@lerna-lite/core": {
-      "version": "1.17.0",
-      "resolved": "https://registry.npmjs.org/@lerna-lite/core/-/core-1.17.0.tgz",
+      "version": "https://registry.npmjs.org/@lerna-lite/core/-/core-1.17.0.tgz",
       "integrity": "sha512-lxiEHXOzDF8RYFWjc8IqIr6G4w0JUB174SJD/h2DI/eXN9wjv8tEZjzhOkTTSs45Aoe1qY7BbaeApEulpoYmcA==",
       "requires": {
         "@npmcli/run-script": "^6.0.0",
@@ -10353,13 +10337,6 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
       "integrity": "sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw=="
-    },
-    "fsevents": {
-      "version": "2.3.2",
-      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
-      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
-      "dev": true,
-      "optional": true
     },
     "function-bind": {
       "version": "1.1.1",

--- a/package.json
+++ b/package.json
@@ -69,7 +69,6 @@
     "@conventional-commits/parser": "^0.4.1",
     "@google-automations/git-file-utils": "^1.2.5",
     "@iarna/toml": "^3.0.0",
-    "@lerna-lite/core": "1.17.0",
     "@octokit/graphql": "^5.0.0",
     "@octokit/request": "^6.0.0",
     "@octokit/request-error": "^3.0.0",

--- a/src/plugins/node-workspace.ts
+++ b/src/plugins/node-workspace.ts
@@ -12,20 +12,13 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import {PackageGraph} from '@lerna-lite/core';
-import {
-  Package as LernaPackage,
-  RawManifest as PackageJson,
-} from '@lerna-lite/core';
 import {GitHub} from '../github';
 import {CandidateReleasePullRequest, RepositoryConfig} from '../manifest';
 import {Version, VersionsMap} from '../version';
-import {RawContent} from '../updaters/raw-content';
 import {PullRequestTitle} from '../util/pull-request-title';
 import {PullRequestBody} from '../util/pull-request-body';
 import {ReleasePullRequest} from '../release-pull-request';
 import {BranchName} from '../util/branch-name';
-import {jsonStringify} from '../util/json-stringify';
 import {Changelog} from '../updaters/changelog';
 import {
   WorkspacePlugin,
@@ -36,23 +29,28 @@ import {
   addPath,
 } from './workspace';
 import {PatchVersionUpdate} from '../versioning-strategy';
+import {CompositeUpdater} from '../updaters/composite';
+import {PackageJson, newVersionWithRange} from '../updaters/node/package-json';
+import {Logger} from '../util/logger';
 
-class Package extends LernaPackage {
-  constructor(
-    public readonly rawContent: string,
-    location: string,
-    pkg?: PackageJson
-  ) {
-    super(pkg ?? JSON.parse(rawContent), location);
-  }
+interface ParsedPackageJson {
+  name: string;
+  version: string;
+  dependencies?: Record<string, string>;
+  devDependencies?: Record<string, string>;
+  peerDependencies?: Record<string, string>;
+  optionalDependencies?: Record<string, string>;
+}
 
-  clone() {
-    return new Package(
-      this.rawContent,
-      this.location,
-      this.toJSON() as PackageJson
-    );
-  }
+interface Package {
+  path: string;
+  name: string;
+  version: string;
+  dependencies: Record<string, string>;
+  devDependencies: Record<string, string>;
+  peerDependencies: Record<string, string>;
+  optionalDependencies: Record<string, string>;
+  jsonContent: string;
 }
 
 interface NodeWorkspaceOptions extends WorkspacePluginOptions {
@@ -68,7 +66,6 @@ interface NodeWorkspaceOptions extends WorkspacePluginOptions {
  */
 export class NodeWorkspace extends WorkspacePlugin<Package> {
   private alwaysLinkLocal: boolean;
-  private packageGraph?: PackageGraph;
   constructor(
     github: GitHub,
     targetBranch: string,
@@ -105,22 +102,28 @@ export class NodeWorkspace extends WorkspacePlugin<Package> {
         const packageUpdate = candidate.pullRequest.updates.find(
           update => update.path === packagePath
         );
-        if (packageUpdate?.cachedFileContents) {
-          const pkg = new Package(
-            packageUpdate.cachedFileContents.parsedContent,
-            candidate.path
-          );
-          packagesByPath.set(candidate.path, pkg);
-          candidatesByPackage[pkg.name] = candidate;
-        } else {
-          const contents = await this.github.getFileContentsOnBranch(
+        const contents =
+          packageUpdate?.cachedFileContents ??
+          (await this.github.getFileContentsOnBranch(
             packagePath,
             this.targetBranch
-          );
-          const pkg = new Package(contents.parsedContent, candidate.path);
-          packagesByPath.set(candidate.path, pkg);
-          candidatesByPackage[pkg.name] = candidate;
-        }
+          ));
+        const packageJson: ParsedPackageJson = JSON.parse(
+          contents.parsedContent
+        );
+        const pkg: Package = {
+          name: packageJson.name,
+          path,
+          version: packageJson.version,
+          dependencies: packageJson.dependencies || {},
+          devDependencies: packageJson.devDependencies || {},
+          peerDependencies: packageJson.peerDependencies || {},
+          optionalDependencies: packageJson.optionalDependencies || {},
+          jsonContent: contents.parsedContent,
+        };
+        packagesByPath.set(candidate.path, pkg);
+        candidatesByPackage[pkg.name] = candidate;
+        // }
       } else {
         const packagePath = addPath(path, 'package.json');
         this.logger.debug(
@@ -130,16 +133,23 @@ export class NodeWorkspace extends WorkspacePlugin<Package> {
           packagePath,
           this.targetBranch
         );
-        packagesByPath.set(path, new Package(contents.parsedContent, path));
+        const packageJson: ParsedPackageJson = JSON.parse(
+          contents.parsedContent
+        );
+        const pkg: Package = {
+          name: packageJson.name,
+          path,
+          version: packageJson.version,
+          dependencies: packageJson.dependencies || {},
+          devDependencies: packageJson.devDependencies || {},
+          peerDependencies: packageJson.peerDependencies || {},
+          optionalDependencies: packageJson.optionalDependencies || {},
+          jsonContent: contents.parsedContent,
+        };
+        packagesByPath.set(path, pkg);
       }
     }
     const allPackages = Array.from(packagesByPath.values());
-    this.packageGraph = new PackageGraph(
-      allPackages,
-      'allDependencies',
-      this.alwaysLinkLocal
-    );
-
     return {
       allPackages,
       candidatesByPackage,
@@ -156,46 +166,31 @@ export class NodeWorkspace extends WorkspacePlugin<Package> {
     pkg: Package,
     updatedVersions: VersionsMap
   ): CandidateReleasePullRequest {
-    const graphPackage = this.packageGraph?.get(pkg.name);
-    if (!graphPackage) {
-      throw new Error(`Could not find graph package for ${pkg.name}`);
-    }
-    const updatedPackage = pkg.clone();
     // Update version of the package
-    const newVersion = updatedVersions.get(updatedPackage.name);
-    if (newVersion) {
-      this.logger.info(`Updating ${updatedPackage.name} to ${newVersion}`);
-      updatedPackage.version = newVersion.toString();
+    const newVersion = updatedVersions.get(pkg.name);
+    if (!newVersion) {
+      throw new Error(`Didn't find updated version for ${pkg.name}`);
     }
-    // Update dependency versions
-    for (const [depName, resolved] of graphPackage.localDependencies) {
-      const depVersion = updatedVersions.get(depName);
-      if (depVersion && resolved.type !== 'directory') {
-        const currentVersion = this.combineDeps(pkg)?.[depName];
-        const prefix = currentVersion
-          ? this.detectRangePrefix(currentVersion)
-          : '';
-        updatedPackage.updateLocalDependency(
-          resolved,
-          depVersion.toString(),
-          prefix
-        );
-        this.logger.info(
-          `${pkg.name}.${depName} updated to ${prefix}${depVersion.toString()}`
-        );
-      }
-    }
+    const updatedPackage = {
+      ...pkg,
+      version: newVersion.toString(),
+    };
+
+    const updater = new PackageJson({
+      version: newVersion,
+      versionsMap: updatedVersions,
+    });
     const dependencyNotes = getChangelogDepsNotes(
       pkg,
       updatedPackage,
-      updatedVersions
+      updatedVersions,
+      this.logger
     );
+
     existingCandidate.pullRequest.updates =
       existingCandidate.pullRequest.updates.map(update => {
         if (update.path === addPath(existingCandidate.path, 'package.json')) {
-          update.updater = new RawContent(
-            jsonStringify(updatedPackage.toJSON(), updatedPackage.rawContent)
-          );
+          update.updater = new CompositeUpdater(update.updater, updater);
         } else if (update.updater instanceof Changelog) {
           if (dependencyNotes) {
             update.updater.changelogEntry =
@@ -236,47 +231,28 @@ export class NodeWorkspace extends WorkspacePlugin<Package> {
     pkg: Package,
     updatedVersions: VersionsMap
   ): CandidateReleasePullRequest {
-    const graphPackage = this.packageGraph?.get(pkg.name);
-    if (!graphPackage) {
-      throw new Error(`Could not find graph package for ${pkg.name}`);
-    }
-    const updatedPackage = pkg.clone();
     // Update version of the package
-    const newVersion = updatedVersions.get(updatedPackage.name);
-    if (newVersion) {
-      this.logger.info(`Updating ${updatedPackage.name} to ${newVersion}`);
-      updatedPackage.version = newVersion.toString();
+    const newVersion = updatedVersions.get(pkg.name);
+    if (!newVersion) {
+      throw new Error(`Didn't find updated version for ${pkg.name}`);
     }
-    for (const [depName, resolved] of graphPackage.localDependencies) {
-      const depVersion = updatedVersions.get(depName);
-      if (depVersion && resolved.type !== 'directory') {
-        const currentVersion = this.combineDeps(pkg)?.[depName];
-        const prefix = currentVersion
-          ? this.detectRangePrefix(currentVersion)
-          : '';
-        updatedPackage.updateLocalDependency(
-          resolved,
-          depVersion.toString(),
-          prefix
-        );
-        this.logger.info(
-          `${pkg.name}.${depName} updated to ${prefix}${depVersion.toString()}`
-        );
-      }
-    }
+    const updatedPackage = {
+      ...pkg,
+      version: newVersion.toString(),
+    };
+
     const dependencyNotes = getChangelogDepsNotes(
       pkg,
       updatedPackage,
-      updatedVersions
+      updatedVersions,
+      this.logger
     );
-    const packageJson = updatedPackage.toJSON() as PackageJson;
-    const version = Version.parse(packageJson.version);
     const pullRequest: ReleasePullRequest = {
       title: PullRequestTitle.ofTargetBranch(this.targetBranch),
       body: new PullRequestBody([
         {
           component: updatedPackage.name,
-          version,
+          version: newVersion,
           notes: appendDependenciesSectionToChangelog(
             '',
             dependencyNotes,
@@ -286,17 +262,18 @@ export class NodeWorkspace extends WorkspacePlugin<Package> {
       ]),
       updates: [
         {
-          path: addPath(updatedPackage.location, 'package.json'),
+          path: addPath(updatedPackage.path, 'package.json'),
           createIfMissing: false,
-          updater: new RawContent(
-            jsonStringify(packageJson, updatedPackage.rawContent)
-          ),
+          updater: new PackageJson({
+            version: newVersion,
+            versionsMap: updatedVersions,
+          }),
         },
         {
-          path: addPath(updatedPackage.location, 'CHANGELOG.md'),
+          path: addPath(updatedPackage.path, 'CHANGELOG.md'),
           createIfMissing: false,
           updater: new Changelog({
-            version,
+            version: newVersion,
             changelogEntry: appendDependenciesSectionToChangelog(
               '',
               dependencyNotes,
@@ -307,11 +284,11 @@ export class NodeWorkspace extends WorkspacePlugin<Package> {
       ],
       labels: [],
       headRefName: BranchName.ofTargetBranch(this.targetBranch).toString(),
-      version,
+      version: newVersion,
       draft: false,
     };
     return {
-      path: updatedPackage.location,
+      path: updatedPackage.path,
       pullRequest,
       config: {
         releaseType: 'node',
@@ -357,15 +334,7 @@ export class NodeWorkspace extends WorkspacePlugin<Package> {
   }
 
   protected pathFromPackage(pkg: Package): string {
-    return pkg.location;
-  }
-
-  private detectRangePrefix(version: string): string {
-    return (
-      Object.values(SUPPORTED_RANGE_PREFIXES).find(supportedRangePrefix =>
-        version.startsWith(supportedRangePrefix)
-      ) || ''
-    );
+    return pkg.path;
   }
 
   private combineDeps(packageJson: Package): Record<string, string> {
@@ -377,19 +346,11 @@ export class NodeWorkspace extends WorkspacePlugin<Package> {
   }
 }
 
-enum SUPPORTED_RANGE_PREFIXES {
-  CARET = '^',
-  TILDE = '~',
-  GREATER_THAN = '>',
-  LESS_THAN = '<',
-  EQUAL_OR_GREATER_THAN = '>=',
-  EQUAL_OR_LESS_THAN = '<=',
-}
-
 function getChangelogDepsNotes(
   original: Package,
   updated: Package,
-  updateVersions: VersionsMap
+  updateVersions: VersionsMap,
+  logger: Logger
 ): string {
   let depUpdateNotes = '';
   type DT =
@@ -411,21 +372,20 @@ function getChangelogDepsNotes(
       continue;
     }
     for (const [depName, currentDepVer] of Object.entries(pkgDepTypes)) {
+      const newVersion = updateVersions.get(depName);
+      if (!newVersion) {
+        logger.debug(`${depName} was not bumped, ignoring`);
+        continue;
+      }
       const origDepVer = original[depType]?.[depName];
-      if (currentDepVer !== origDepVer) {
+      const newVersionString = newVersionWithRange(origDepVer, newVersion);
+      if (currentDepVer.startsWith('workspace:')) {
+        depUpdates.push(`\n    * ${depName} bumped to ${newVersionString}`);
+      } else if (newVersionString !== origDepVer) {
         depUpdates.push(
-          `\n    * ${depName} bumped from ${origDepVer} to ${currentDepVer}`
+          `\n    * ${depName} bumped from ${origDepVer} to ${newVersionString}`
         );
         //handle case when "workspace:" version is used
-      } else if (
-        currentDepVer.startsWith('workspace:') &&
-        updateVersions.get(depName) !== undefined
-      ) {
-        depUpdates.push(
-          `\n    * ${depName} bumped to ${updateVersions
-            .get(depName)
-            ?.toString()}`
-        );
       }
     }
     if (depUpdates.length > 0) {

--- a/src/plugins/workspace.ts
+++ b/src/plugins/workspace.ts
@@ -130,7 +130,7 @@ export abstract class WorkspacePlugin<T> extends ManifestPlugin {
       if (existingCandidate) {
         // if already has an pull request, update the changelog and update
         this.logger.info(
-          `Updating exising candidate pull request for ${this.packageNameFromPackage(
+          `Updating existing candidate pull request for ${this.packageNameFromPackage(
             pkg
           )}, path: ${existingCandidate.path}`
         );

--- a/src/updaters/node/package-json.ts
+++ b/src/updaters/node/package-json.ts
@@ -15,8 +15,15 @@
 import {jsonStringify} from '../../util/json-stringify';
 import {logger as defaultLogger, Logger} from '../../util/logger';
 import {DefaultUpdater} from '../default';
+import {VersionsMap, Version} from '../../version';
 
-type LockFile = {version: string};
+type LockFile = {
+  version: string;
+  dependencies?: Record<string, string>;
+  devDependencies?: Record<string, string>;
+  peerDependencies?: Record<string, string>;
+  optionalDependencies?: Record<string, string>;
+};
 
 /**
  * This updates a Node.js package.json file's main version.
@@ -31,6 +38,76 @@ export class PackageJson extends DefaultUpdater {
     const parsed = JSON.parse(content) as LockFile;
     logger.info(`updating from ${parsed.version} to ${this.version}`);
     parsed.version = this.version.toString();
+
+    // If additional dependency versions specified, then update dependency versions
+    // while preserving any valid version range prefixes.
+    if (this.versionsMap) {
+      if (parsed.dependencies) {
+        updateDependencies(parsed.dependencies, this.versionsMap);
+      }
+      if (parsed.devDependencies) {
+        updateDependencies(parsed.devDependencies, this.versionsMap);
+      }
+      if (parsed.peerDependencies) {
+        updateDependencies(parsed.peerDependencies, this.versionsMap);
+      }
+      if (parsed.optionalDependencies) {
+        updateDependencies(parsed.optionalDependencies, this.versionsMap);
+      }
+    }
+
     return jsonStringify(parsed, content);
+  }
+}
+
+enum SUPPORTED_RANGE_PREFIXES {
+  CARET = '^',
+  TILDE = '~',
+  GREATER_THAN = '>',
+  LESS_THAN = '<',
+  EQUAL_OR_GREATER_THAN = '>=',
+  EQUAL_OR_LESS_THAN = '<=',
+}
+function detectRangePrefix(version: string): string {
+  return (
+    Object.values(SUPPORTED_RANGE_PREFIXES).find(supportedRangePrefix =>
+      version.startsWith(supportedRangePrefix)
+    ) || ''
+  );
+}
+/**
+ * Helper to coerce a new version value into a version range that preserves the
+ * version range prefix of the original version.
+ * @param {string} oldVersion Old semver with range
+ * @param {Version} newVersion The new version to update with
+ */
+export function newVersionWithRange(
+  oldVersion: string,
+  newVersion: Version
+): string {
+  const prefix = detectRangePrefix(oldVersion);
+  if (prefix) {
+    return `${prefix}${newVersion}`;
+  }
+  return newVersion.toString();
+}
+/**
+ * Helper function to update dependency versions for all new versions specified
+ * in the updated versions map. Note that this mutates the existing input.
+ * @param {Record<string, string>} dependencies Entries in package.json dependencies
+ *   where the key is the dependency name and the value is the dependency range
+ * @param {VersionsMap} updatedVersions Map of new versions (without dependency range prefixes)
+ */
+function updateDependencies(
+  dependencies: Record<string, string>,
+  updatedVersions: VersionsMap
+) {
+  for (const depName of Object.keys(dependencies)) {
+    const newVersion = updatedVersions.get(depName);
+    if (newVersion) {
+      const oldVersion = dependencies[depName];
+      const newVersionString = newVersionWithRange(oldVersion, newVersion);
+      dependencies[depName] = newVersionString;
+    }
   }
 }

--- a/test/helpers.ts
+++ b/test/helpers.ts
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import {readFileSync, readdirSync, statSync} from 'fs';
+import {readFileSync, readdirSync, statSync, existsSync} from 'fs';
 import {resolve, posix} from 'path';
 import * as crypto from 'crypto';
 import * as sinon from 'sinon';
@@ -112,6 +112,18 @@ export function readPOJO(name: string): object {
     'utf8'
   );
   return JSON.parse(content);
+}
+
+/**
+ * Reads a fixture file as a string or returns empty string if the fixture
+ * does not exist.
+ */
+export function readFixture(fixturesPath: string, fixture: string): string {
+  const file = resolve(fixturesPath, fixture);
+  if (!existsSync(file)) {
+    return '';
+  }
+  return readFileSync(resolve(fixturesPath, fixture), 'utf8');
 }
 
 export function buildMockConventionalCommit(

--- a/test/plugins/node-workspace.ts
+++ b/test/plugins/node-workspace.ts
@@ -29,8 +29,8 @@ import {
   assertNoHasUpdate,
   buildMockCandidatePullRequest,
   buildGitHubFileRaw,
+  readFixture,
 } from '../helpers';
-import {RawContent} from '../../src/updaters/raw-content';
 import snapshot = require('snap-shot-it');
 import {ManifestPlugin} from '../../src/plugin';
 import {Changelog} from '../../src/updaters/changelog';
@@ -73,11 +73,43 @@ function buildMockChangelogUpdate(
   };
 }
 
-function assertHasVersionUpdate(update: Update, expectedVersion: string) {
-  expect(update.updater).instanceof(RawContent);
-  const updater = update.updater as RawContent;
-  const data = JSON.parse(updater.rawContent);
+/**
+ * Helper test to ensure that the file update exists and that
+ * the file is a json file with a .version equal to the provided
+ * version string.
+ *
+ * @param {Update[]} updates List of updates to search for
+ * @param {string} fixture Fixture name
+ * @param {string} expectedVersion Expected version string
+ */
+function assertHasVersionUpdate(
+  updates: Update[],
+  fixture: string,
+  expectedVersion: string
+) {
+  const update = assertHasUpdate(updates, fixture);
+  const originalContent = readFixture(fixturesPath, fixture);
+  const content = update.updater.updateContent(originalContent);
+  const data = JSON.parse(content);
   expect(data.version).to.eql(expectedVersion);
+}
+
+/**
+ * Helper test to snapshot the final contents of a file update.
+ *
+ * @param {Update[]} updates List of updates to search for
+ * @param {string} fixture Fixture name
+ */
+function snapshotUpdate(
+  updates: Update[],
+  file: string,
+  originalContent?: string
+) {
+  if (!originalContent) {
+    originalContent = readFixture(fixturesPath, file);
+  }
+  const update = assertHasUpdate(updates, file);
+  snapshot(update.updater.updateContent(originalContent));
 }
 
 describe('NodeWorkspace plugin', () => {
@@ -176,14 +208,7 @@ describe('NodeWorkspace plugin', () => {
       expect(nodeCandidate).to.not.be.undefined;
       const updates = nodeCandidate!.pullRequest.updates;
       assertHasUpdate(updates, 'node1/package.json');
-
-      const update = assertHasUpdate(
-        updates,
-        'plugin1/package.json',
-        RawContent
-      );
-      const updater = update.updater as RawContent;
-      snapshot(updater.rawContent);
+      snapshotUpdate(updates, 'plugin1/package.json');
     });
     it('combines node packages', async () => {
       const candidates: CandidateReleasePullRequest[] = [
@@ -271,26 +296,11 @@ describe('NodeWorkspace plugin', () => {
       );
       expect(nodeCandidate).to.not.be.undefined;
       const updates = nodeCandidate!.pullRequest.updates;
-      assertHasVersionUpdate(
-        assertHasUpdate(updates, 'node1/package.json', RawContent),
-        '3.3.4'
-      );
-      assertHasVersionUpdate(
-        assertHasUpdate(updates, 'node2/package.json', RawContent),
-        '2.2.3'
-      );
-      assertHasVersionUpdate(
-        assertHasUpdate(updates, 'node3/package.json', RawContent),
-        '1.1.2'
-      );
-      assertHasVersionUpdate(
-        assertHasUpdate(updates, 'node4/package.json', RawContent),
-        '4.4.5'
-      );
-      assertHasVersionUpdate(
-        assertHasUpdate(updates, 'node5/package.json', RawContent),
-        '1.0.1'
-      );
+      assertHasVersionUpdate(updates, 'node1/package.json', '3.3.4');
+      assertHasVersionUpdate(updates, 'node2/package.json', '2.2.3');
+      assertHasVersionUpdate(updates, 'node3/package.json', '1.1.2');
+      assertHasVersionUpdate(updates, 'node4/package.json', '4.4.5');
+      assertHasVersionUpdate(updates, 'node5/package.json', '1.0.1');
       const updater = assertHasUpdate(
         updates,
         '.release-please-manifest.json',
@@ -322,7 +332,7 @@ describe('NodeWorkspace plugin', () => {
             buildMockPackageUpdate('node2/package.json', 'node2/package.json'),
             buildMockChangelogUpdate(
               'node2/CHANGELOG.md',
-              '3.3.4',
+              '2.2.3',
               existingNotes
             ),
           ],
@@ -350,18 +360,9 @@ describe('NodeWorkspace plugin', () => {
       );
       expect(nodeCandidate).to.not.be.undefined;
       const updates = nodeCandidate!.pullRequest.updates;
-      assertHasVersionUpdate(
-        assertHasUpdate(updates, 'node1/package.json', RawContent),
-        '3.3.4'
-      );
-      assertHasVersionUpdate(
-        assertHasUpdate(updates, 'node2/package.json', RawContent),
-        '2.2.3'
-      );
-      assertHasVersionUpdate(
-        assertHasUpdate(updates, 'node3/package.json', RawContent),
-        '1.1.2'
-      );
+      assertHasVersionUpdate(updates, 'node1/package.json', '3.3.4');
+      assertHasVersionUpdate(updates, 'node2/package.json', '2.2.3');
+      assertHasVersionUpdate(updates, 'node3/package.json', '1.1.2');
       assertNoHasUpdate(updates, 'node4/package.json');
       snapshot(dateSafe(nodeCandidate!.pullRequest.body.toString()));
       const update = assertHasUpdate(updates, 'node1/CHANGELOG.md', Changelog);

--- a/test/plugins/node-workspace.ts
+++ b/test/plugins/node-workspace.ts
@@ -189,7 +189,7 @@ describe('NodeWorkspace plugin', () => {
             ),
           ],
         }),
-        buildMockCandidatePullRequest('node1', 'node', '2.2.2', {
+        buildMockCandidatePullRequest('node1', 'node', '3.3.3', {
           component: '@here/pkgA',
           updates: [
             buildMockPackageUpdate('node1/package.json', 'node1/package.json'),
@@ -255,10 +255,10 @@ describe('NodeWorkspace plugin', () => {
       );
       expect(nodeCandidate).to.not.be.undefined;
       const updates = nodeCandidate!.pullRequest.updates;
-      assertHasUpdate(updates, 'package.json');
-      assertHasUpdate(updates, 'node1/package.json');
-      assertHasUpdate(updates, 'node4/package.json');
       snapshot(dateSafe(nodeCandidate!.pullRequest.body.toString()));
+      snapshotUpdate(updates, 'package.json');
+      snapshotUpdate(updates, 'node1/package.json');
+      snapshotUpdate(updates, 'node4/package.json');
     });
     it('walks dependency tree and updates previously untouched packages', async () => {
       const candidates: CandidateReleasePullRequest[] = [

--- a/test/updaters/fixtures/package-with-dependencies.json
+++ b/test/updaters/fixtures/package-with-dependencies.json
@@ -1,0 +1,52 @@
+{
+	"name": "yargs-parser",
+	"version": "13.0.0",
+	"description": "the mighty option parser used by yargs",
+	"main": "index.js",
+	"scripts": {
+		"test": "nyc mocha test/*.js",
+		"posttest": "standard",
+		"coverage": "nyc report --reporter=text-lcov | coveralls",
+		"release": "standard-version"
+	},
+	"repository": {
+		"url": "git@github.com:yargs/yargs-parser.git"
+	},
+	"keywords": [
+		"argument",
+		"parser",
+		"yargs",
+		"command",
+		"cli",
+		"parsing",
+		"option",
+		"args",
+		"argument"
+	],
+	"author": "Ben Coe <ben@npmjs.com>",
+	"license": "ISC",
+	"devDependencies": {
+		"chai": "^4.2.0",
+		"coveralls": "^3.0.2",
+		"mocha": "^5.2.0",
+		"nyc": "^13.0.1",
+		"standard": "^12.0.1"
+	},
+	"dependencies": {
+		"camelcase": "^5.0.0",
+		"decamelize": "^1.2.0"
+	},
+	"optionalDependencies": {
+		"foo": "~0.0.7"
+	},
+	"peerDependencies": {
+		"bar": ">= 1.0.0"
+	},
+	"files": [
+		"lib",
+		"index.js"
+	],
+	"engine": {
+		"node": ">=6"
+	}
+}

--- a/test/updaters/package-json.ts
+++ b/test/updaters/package-json.ts
@@ -17,7 +17,7 @@ import {resolve} from 'path';
 import * as snapshot from 'snap-shot-it';
 import {describe, it} from 'mocha';
 import {PackageJson} from '../../src/updaters/node/package-json';
-import {Version} from '../../src/version';
+import {Version, VersionsMap} from '../../src/version';
 
 const fixturesPath = './test/updaters/fixtures';
 
@@ -30,6 +30,24 @@ describe('PackageJson', () => {
       );
       const packageJson = new PackageJson({
         version: Version.parse('14.0.0'),
+      });
+      const newContent = packageJson.updateContent(oldContent);
+      snapshot(newContent.replace(/\r\n/g, '\n'));
+    });
+
+    it('updates dependency versions', async () => {
+      const oldContent = readFileSync(
+        resolve(fixturesPath, './package-with-dependencies.json'),
+        'utf8'
+      );
+      const versionsMap: VersionsMap = new Map();
+      versionsMap.set('camelcase', Version.parse('6.0.0'));
+      versionsMap.set('chai', Version.parse('4.2.1'));
+      versionsMap.set('foo', Version.parse('0.1.0'));
+      versionsMap.set('bar', Version.parse('2.3.4'));
+      const packageJson = new PackageJson({
+        version: Version.parse('14.0.0'),
+        versionsMap,
       });
       const newContent = packageJson.updateContent(oldContent);
       snapshot(newContent.replace(/\r\n/g, '\n'));


### PR DESCRIPTION
Refactors the node-workspace plugin to  use the internal workspace-plugin graph/dependency logic and built-in
package.json updaters to update the content. We do not need to rely on lerna internals.

Fixes #2116 

feat: PackageJson updater can update dependencies