### PR TITLE
ci: add workflow job for building the action against head

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -58,3 +58,15 @@ jobs:
       - uses: JustinBeckwith/linkinator-action@v1
         with:
           paths: docs/
+  build-action:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          repository: google-github-actions/release-please-action
+          ref: main
+      - uses: actions/setup-node@v3
+        with:
+          node-version: 18
+      - run: npm install --save googleapis/release-please#${{ github.ref }}
+      - run: npm run build


### PR DESCRIPTION
This should help us prevent #2116 in the future. After we fix the build issue, then we can optionally make it a required check.
