### PR TITLE
fix: pass prerelease to buildVersioningStrategy

### DIFF
--- a/src/factories/versioning-strategy-factory.ts
+++ b/src/factories/versioning-strategy-factory.ts
@@ -29,6 +29,7 @@ export interface VersioningStrategyFactoryOptions {
   bumpMinorPreMajor?: boolean;
   bumpPatchForMinorPreMajor?: boolean;
   prereleaseType?: string;
+  prerelease?: boolean;
   github: GitHub;
 }
 

--- a/src/factory.ts
+++ b/src/factory.ts
@@ -120,6 +120,7 @@ export async function buildStrategy(
     bumpMinorPreMajor: options.bumpMinorPreMajor,
     bumpPatchForMinorPreMajor: options.bumpPatchForMinorPreMajor,
     prereleaseType: options.prereleaseType,
+    prerelease: options.prerelease,
   });
   const changelogNotes = buildChangelogNotes({
     type: options.changelogType || 'default',


### PR DESCRIPTION
Thank you for opening a Pull Request! Before submitting your PR, there are a few things you can do to make sure it goes smoothly:
- [x] Make sure to open an issue as a [bug/issue](https://github.com/googleapis/release-please/issues/new/choose) before writing your code!  That way we can discuss the change, evaluate designs, and agree on the general idea
- [x] Ensure the tests and linter pass
- [x] Code coverage does not decrease (if any source code was changed)
- [ ] Appropriate docs were updated (if necessary)

Fixes #2132 🦕

This is a fix for #2132 by passing `prerelease` to `buildVersioningStrategy` and updating the appropriate type.

I did not add `prerelease` as a property to the `DefaultVersioningStrategy` class since I'm only interested in using it to determine the versioning strategy.
