### PR TITLE
fix: backfill files by commit for rebased PRs

### DIFF
--- a/__snapshots__/github.js
+++ b/__snapshots__/github.js
@@ -6,6 +6,16 @@ exports['GitHub commitsSince backfills commit files for pull requests rebased an
   {
     "sha": "b29149f890e6f76ee31ed128585744d4c598924c",
     "message": "feat: feature-branch-rebase-merge commit 1",
+    "pullRequest": {
+      "sha": "b29149f890e6f76ee31ed128585744d4c598924c",
+      "number": 7,
+      "baseBranchName": "main",
+      "headBranchName": "feature-branch-rebase-merge",
+      "title": "feat: feature that will be rebase merged",
+      "body": "",
+      "labels": [],
+      "files": []
+    },
     "files": [
       "abc"
     ]
@@ -13,6 +23,16 @@ exports['GitHub commitsSince backfills commit files for pull requests rebased an
   {
     "sha": "27d7d7232e2e312d1380e906984f0823f5decf61",
     "message": "feat: feature-branch-rebase-merge commit 2",
+    "pullRequest": {
+      "sha": "27d7d7232e2e312d1380e906984f0823f5decf61",
+      "number": 7,
+      "baseBranchName": "main",
+      "headBranchName": "feature-branch-rebase-merge",
+      "title": "feat: feature that will be rebase merged",
+      "body": "",
+      "labels": [],
+      "files": []
+    },
     "files": [
       "def"
     ]

--- a/__snapshots__/github.js
+++ b/__snapshots__/github.js
@@ -2,6 +2,23 @@ exports['GitHub commentOnIssue can create a comment 1'] = {
   "body": "This is a comment"
 }
 
+exports['GitHub commitsSince backfills commit files for pull requests rebased and merged 1'] = [
+  {
+    "sha": "b29149f890e6f76ee31ed128585744d4c598924c",
+    "message": "feat: feature-branch-rebase-merge commit 1",
+    "files": [
+      "abc"
+    ]
+  },
+  {
+    "sha": "27d7d7232e2e312d1380e906984f0823f5decf61",
+    "message": "feat: feature-branch-rebase-merge commit 2",
+    "files": [
+      "def"
+    ]
+  }
+]
+
 exports['GitHub commitsSince backfills commit files for pull requests with lots of files 1'] = [
   {
     "sha": "e6daec403626c9987c7af0d97b34f324cd84320a",

--- a/src/github.ts
+++ b/src/github.ts
@@ -487,21 +487,24 @@ export class GitHub {
         sha: graphCommit.sha,
         message: graphCommit.message,
       };
-      const pullRequest = graphCommit.associatedPullRequests.nodes.find(pr => {
-        return (
-          // Only match the pull request with a merge commit if there is a
-          // single merged commit in the PR. This means merge commits and squash
-          // merges will be matched, but rebase merged PRs will only be matched
-          // if they contain a single commit. This is so PRs that are rebased
-          // and merged will have files backfilled from each commit instead of
-          // the whole PR.
-          pr.mergeCommit &&
-          pr.mergeCommit.oid === graphCommit.sha &&
-          mergeCommitCount[pr.mergeCommit.oid] === 1
-        );
-      });
+      const mergePullRequest = graphCommit.associatedPullRequests.nodes.find(
+        pr => {
+          return (
+            // Only match the pull request with a merge commit if there is a
+            // single merged commit in the PR. This means merge commits and squash
+            // merges will be matched, but rebase merged PRs will only be matched
+            // if they contain a single commit. This is so PRs that are rebased
+            // and merged will have ßSfiles backfilled from each commit instead of
+            // the whole PR.
+            pr.mergeCommit &&
+            pr.mergeCommit.oid === graphCommit.sha &&
+            mergeCommitCount[pr.mergeCommit.oid] === 1
+          );
+        }
+      );
+      const pullRequest =
+        mergePullRequest || graphCommit.associatedPullRequests.nodes[0];
       if (pullRequest) {
-        const files = (pullRequest.files?.nodes || []).map(node => node.path);
         commit.pullRequest = {
           sha: commit.sha,
           number: pullRequest.number,
@@ -510,17 +513,24 @@ export class GitHub {
           title: pullRequest.title,
           body: pullRequest.body,
           labels: pullRequest.labels.nodes.map(node => node.name),
-          files,
+          files: (pullRequest.files?.nodes || []).map(node => node.path),
         };
-        if (pullRequest.files?.pageInfo?.hasNextPage && options.backfillFiles) {
+      }
+      if (mergePullRequest) {
+        if (
+          mergePullRequest.files?.pageInfo?.hasNextPage &&
+          options.backfillFiles
+        ) {
           this.logger.info(
-            `PR #${pullRequest.number} has many files, backfilling`
+            `PR #${mergePullRequest.number} has many files, backfilling`
           );
           commit.files = await this.getCommitFiles(graphCommit.sha);
         } else {
           // We cannot directly fetch files on commits via graphql, only provide file
           // information for commits with associated pull requests
-          commit.files = files;
+          commit.files = (mergePullRequest.files?.nodes || []).map(
+            node => node.path
+          );
         }
       } else if (options.backfillFiles) {
         // In this case, there is no squashed merge commit. This could be a simple

--- a/test/fixtures/commits-since-rebase.json
+++ b/test/fixtures/commits-since-rebase.json
@@ -1,0 +1,88 @@
+{
+  "repository": {
+    "ref": {
+      "target": {
+        "history": {
+          "nodes": [
+            {
+              "associatedPullRequests": {
+                "nodes": [
+                  {
+                    "number": 7,
+                    "title": "feat: feature that will be rebase merged",
+                    "baseRefName": "main",
+                    "headRefName": "feature-branch-rebase-merge",
+                    "labels": {
+                      "nodes": []
+                    },
+                    "body": "",
+                    "mergeCommit": {
+                      "oid": "b29149f890e6f76ee31ed128585744d4c598924c"
+                    },
+                    "files": {
+                      "nodes": []
+                    }
+                  }
+                ]
+              },
+              "sha": "b29149f890e6f76ee31ed128585744d4c598924c",
+              "message": "feat: feature-branch-rebase-merge commit 1"
+            },
+            {
+              "associatedPullRequests": {
+                "nodes": [
+                  {
+                    "number": 7,
+                    "title": "feat: feature that will be rebase merged",
+                    "baseRefName": "main",
+                    "headRefName": "feature-branch-rebase-merge",
+                    "labels": {
+                      "nodes": []
+                    },
+                    "body": "",
+                    "mergeCommit": {
+                      "oid": "b29149f890e6f76ee31ed128585744d4c598924c"
+                    },
+                    "files": {
+                      "nodes": []
+                    }
+                  }
+                ]
+              },
+              "sha": "27d7d7232e2e312d1380e906984f0823f5decf61",
+              "message": "feat: feature-branch-rebase-merge commit 2"
+            },
+            {
+              "associatedPullRequests": {
+                "nodes": [
+                  {
+                    "number": 6,
+                    "title": "feat: other pr",
+                    "baseRefName": "main",
+                    "headRefName": "feature-branch-other",
+                    "labels": {
+                      "nodes": []
+                    },
+                    "body": "",
+                    "mergeCommit": {
+                      "oid": "2b4e0b3be2e231cd87cc44c411bd8f84b4587ab5"
+                    },
+                    "files": {
+                      "nodes": []
+                    }
+                  }
+                ]
+              },
+              "sha": "2b4e0b3be2e231cd87cc44c411bd8f84b4587ab5",
+              "message": "fix: feature-branch-other"
+            }
+          ],
+          "pageInfo": {
+            "hasNextPage": false,
+            "endCursor": "e6daec403626c9987c7af0d97b34f324cd84320a 12"
+          }
+        }
+      }
+    }
+  }
+}

--- a/test/github.ts
+++ b/test/github.ts
@@ -546,6 +546,39 @@ describe('GitHub', () => {
       snapshot(commitsSinceSha);
       req.done();
     });
+
+    it('backfills commit files for pull requests rebased and merged', async () => {
+      const graphql = JSON.parse(
+        readFileSync(resolve(fixturesPath, 'commits-since-rebase.json'), 'utf8')
+      );
+      req
+        .post('/graphql')
+        .reply(200, {
+          data: graphql,
+        })
+        .get(
+          '/repos/fake/fake/commits/b29149f890e6f76ee31ed128585744d4c598924c'
+        )
+        .reply(200, {files: [{filename: 'abc'}]})
+        .get(
+          '/repos/fake/fake/commits/27d7d7232e2e312d1380e906984f0823f5decf61'
+        )
+        .reply(200, {files: [{filename: 'def'}]});
+      const targetBranch = 'main';
+      const commitsSinceSha = await github.commitsSince(
+        targetBranch,
+        commit => {
+          // this commit is the 3rd most recent
+          return commit.sha === '2b4e0b3be2e231cd87cc44c411bd8f84b4587ab5';
+        },
+        {backfillFiles: true}
+      );
+      expect(commitsSinceSha.length).to.eql(2);
+      expect(commitsSinceSha[0].files).to.eql(['abc']);
+      expect(commitsSinceSha[1].files).to.eql(['def']);
+      snapshot(commitsSinceSha);
+      req.done();
+    });
   });
 
   describe('mergeCommitIterator', () => {


### PR DESCRIPTION
Thank you for opening a Pull Request! Before submitting your PR, there are a few things you can do to make sure it goes smoothly:
- [x] Make sure to open an issue as a [bug/issue](https://github.com/googleapis/release-please/issues/new/choose) before writing your code!  That way we can discuss the change, evaluate designs, and agree on the general idea
- [x] Ensure the tests and linter pass
- [x] Code coverage does not decrease (if any source code was changed)
- [ ] Appropriate docs were updated (if necessary)

Fixes #2140 🦕

This has the effect of not associating a PR with any of the commits from a PR that is rebased and merged. Previously it would associate the PR only with the first commit, but this would also add all the files from the PR to that first commit.

A different (or future) solution would be to decouple connecting PRs and files with commits. I considered that but thought that solution would increase the scope too much. I'm open to reworking the PR in that direction though.
