### PR TITLE
fix: pass pull request header and footer options to merge plugin

### DIFF
--- a/__snapshots__/manifest.js
+++ b/__snapshots__/manifest.js
@@ -117,7 +117,7 @@ exports['Manifest buildPullRequests should handle mixing componentless configs 1
 This PR was generated with [Release Please](https://github.com/googleapis/release-please). See [documentation](https://github.com/googleapis/release-please#release-please).
 `
 
-exports['Manifest buildPullRequests should handle multiple package repository 1'] = `
+exports['Manifest buildPullRequests with multiple packages should handle multiple package repository 1'] = `
 :robot: I have created a release *beep* *boop*
 ---
 

--- a/src/manifest.ts
+++ b/src/manifest.ts
@@ -33,7 +33,7 @@ import {
 } from './factory';
 import {Release} from './release';
 import {Strategy} from './strategy';
-import {Merge} from './plugins/merge';
+import {MergeOptions, Merge} from './plugins/merge';
 import {ReleasePleaseManifest} from './updaters/release-please-manifest';
 import {
   DuplicateReleaseError,
@@ -749,10 +749,33 @@ export class Manifest {
     // Combine pull requests into 1 unless configured for separate
     // pull requests
     if (!this.separatePullRequests) {
+      const mergeOptions: MergeOptions = {
+        pullRequestTitlePattern: this.groupPullRequestTitlePattern,
+      };
+      // Find the first repositoryConfig item that has a set value
+      // for the options that can be passed to the merge plugin
+      for (const path in this.repositoryConfig) {
+        const config = this.repositoryConfig[path];
+        if (
+          'pullRequestHeader' in config &&
+          !('pullRequestHeader' in mergeOptions)
+        ) {
+          mergeOptions.pullRequestHeader = config.pullRequestHeader;
+        }
+        if (
+          'pullRequestFooter' in config &&
+          !('pullRequestFooter' in mergeOptions)
+        ) {
+          mergeOptions.pullRequestFooter = config.pullRequestFooter;
+        }
+      }
       this.plugins.push(
-        new Merge(this.github, this.targetBranch, this.repositoryConfig, {
-          pullRequestTitlePattern: this.groupPullRequestTitlePattern,
-        })
+        new Merge(
+          this.github,
+          this.targetBranch,
+          this.repositoryConfig,
+          mergeOptions
+        )
       );
     }
 

--- a/src/plugins/merge.ts
+++ b/src/plugins/merge.ts
@@ -26,7 +26,7 @@ import {Update} from '../update';
 import {mergeUpdates} from '../updaters/composite';
 import {GitHub} from '../github';
 
-interface MergeOptions {
+export interface MergeOptions {
   pullRequestTitlePattern?: string;
   pullRequestHeader?: string;
   pullRequestFooter?: string;

--- a/test/manifest.ts
+++ b/test/manifest.ts
@@ -1750,90 +1750,123 @@ describe('Manifest', () => {
       );
     });
 
-    it('should handle multiple package repository', async () => {
-      mockReleases(sandbox, github, [
-        {
-          id: 123456,
-          sha: 'abc123',
-          tagName: 'pkg1-v1.0.0',
-          url: 'https://github.com/fake-owner/fake-repo/releases/tag/pkg1-v1.0.0',
-        },
-        {
-          id: 654321,
-          sha: 'def234',
-          tagName: 'pkg2-v0.2.3',
-          url: 'https://github.com/fake-owner/fake-repo/releases/tag/pkg2-v0.2.3',
-        },
-      ]);
-      mockCommits(sandbox, github, [
-        {
-          sha: 'aaaaaa',
-          message: 'fix: some bugfix',
-          files: ['path/a/foo'],
-        },
-        {
-          sha: 'abc123',
-          message: 'chore: release main',
-          files: [],
-          pullRequest: {
-            headBranchName: 'release-please/branches/main',
-            baseBranchName: 'main',
-            number: 123,
-            title: 'chore: release main',
-            body: '',
-            labels: [],
-            files: [],
+    describe('with multiple packages', () => {
+      beforeEach(() => {
+        mockReleases(sandbox, github, [
+          {
+            id: 123456,
             sha: 'abc123',
+            tagName: 'pkg1-v1.0.0',
+            url: 'https://github.com/fake-owner/fake-repo/releases/tag/pkg1-v1.0.0',
           },
-        },
-        {
-          sha: 'bbbbbb',
-          message: 'fix: some bugfix',
-          files: ['path/b/foo'],
-        },
-        {
-          sha: 'cccccc',
-          message: 'fix: some bugfix',
-          files: ['path/a/foo'],
-        },
-        {
-          sha: 'def234',
-          message: 'chore: release main',
-          files: [],
-          pullRequest: {
-            headBranchName: 'release-please/branches/main',
-            baseBranchName: 'main',
-            number: 123,
-            title: 'chore: release main',
-            body: '',
-            labels: [],
-            files: [],
+          {
+            id: 654321,
             sha: 'def234',
+            tagName: 'pkg2-v0.2.3',
+            url: 'https://github.com/fake-owner/fake-repo/releases/tag/pkg2-v0.2.3',
           },
-        },
-      ]);
-      const manifest = new Manifest(
-        github,
-        'main',
-        {
-          'path/a': {
-            releaseType: 'simple',
-            component: 'pkg1',
+        ]);
+        mockCommits(sandbox, github, [
+          {
+            sha: 'aaaaaa',
+            message: 'fix: some bugfix',
+            files: ['path/a/foo'],
           },
-          'path/b': {
-            releaseType: 'simple',
-            component: 'pkg2',
+          {
+            sha: 'abc123',
+            message: 'chore: release main',
+            files: [],
+            pullRequest: {
+              headBranchName: 'release-please/branches/main',
+              baseBranchName: 'main',
+              number: 123,
+              title: 'chore: release main',
+              body: '',
+              labels: [],
+              files: [],
+              sha: 'abc123',
+            },
           },
-        },
-        {
-          'path/a': Version.parse('1.0.0'),
-          'path/b': Version.parse('0.2.3'),
-        }
-      );
-      const pullRequests = await manifest.buildPullRequests();
-      expect(pullRequests).lengthOf(1);
-      expect(pullRequests[0].labels).to.eql(['autorelease: pending']);
-      snapshot(dateSafe(pullRequests[0].body.toString()));
+          {
+            sha: 'bbbbbb',
+            message: 'fix: some bugfix',
+            files: ['path/b/foo'],
+          },
+          {
+            sha: 'cccccc',
+            message: 'fix: some bugfix',
+            files: ['path/a/foo'],
+          },
+          {
+            sha: 'def234',
+            message: 'chore: release main',
+            files: [],
+            pullRequest: {
+              headBranchName: 'release-please/branches/main',
+              baseBranchName: 'main',
+              number: 123,
+              title: 'chore: release main',
+              body: '',
+              labels: [],
+              files: [],
+              sha: 'def234',
+            },
+          },
+        ]);
+      });
+      it('should handle multiple package repository', async () => {
+        const manifest = new Manifest(
+          github,
+          'main',
+          {
+            'path/a': {
+              releaseType: 'simple',
+              component: 'pkg1',
+            },
+            'path/b': {
+              releaseType: 'simple',
+              component: 'pkg2',
+            },
+          },
+          {
+            'path/a': Version.parse('1.0.0'),
+            'path/b': Version.parse('0.2.3'),
+          }
+        );
+        const pullRequests = await manifest.buildPullRequests();
+        expect(pullRequests).lengthOf(1);
+        expect(pullRequests[0].labels).to.eql(['autorelease: pending']);
+        snapshot(dateSafe(pullRequests[0].body.toString()));
+      });
+
+      it('should handle pull request header/footer with multiple packages', async () => {
+        const manifest = new Manifest(
+          github,
+          'main',
+          {
+            'path/a': {
+              releaseType: 'simple',
+              component: 'pkg1',
+              pullRequestHeader: 'Header from pkg1',
+            },
+            'path/b': {
+              releaseType: 'simple',
+              component: 'pkg2',
+              pullRequestHeader: 'Header from pkg2',
+              pullRequestFooter: 'Footer from pkg2',
+            },
+          },
+          {
+            'path/a': Version.parse('1.0.0'),
+            'path/b': Version.parse('0.2.3'),
+          }
+        );
+        const pullRequests = await manifest.buildPullRequests();
+        expect(pullRequests).lengthOf(1);
+        const pullRequest = pullRequests[0];
+        expect(pullRequest.body.header.toString()).to.eql('Header from pkg1');
+        expect(pullRequest.body.footer.toString()).to.eql('Footer from pkg2');
+      });
     });
 
     it('should allow creating multiple pull requests', async () => {


### PR DESCRIPTION
Thank you for opening a Pull Request! Before submitting your PR, there are a few things you can do to make sure it goes smoothly:
- [x] Make sure to open an issue as a [bug/issue](https://github.com/googleapis/release-please/issues/new/choose) before writing your code!  That way we can discuss the change, evaluate designs, and agree on the general idea
- [x] Ensure the tests and linter pass
- [x] Code coverage does not decrease (if any source code was changed)
- [ ] Appropriate docs were updated (if necessary)

Fixes #2142  🦕

### Details

This works by looping through `repositoryConfig` and getting the first set value for both `pullRequestHeader` and `pullRequestFooter`. This means they could possibly come from different components in a manifest release.

### Alternate Solutions

I thought about only using config values from `repositoryConfig[ROOT_PROJECT_PATH]`. I didn't have strong feelings either way so I went with the solution I felt would be less surprising. But I'd be open to reworking the PR to this alternate solution.
