### PR TITLE
feat(types): export types exposed by Manifest for use downstream

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -18,7 +18,11 @@ export {
   ReleaserConfig,
   ManifestOptions,
   PluginType,
+  CandidateRelease,
+  CreatedRelease,
 } from './manifest';
+export {ReleasePullRequest} from './release-pull-request';
+export {PullRequest} from './pull-request';
 export {Commit, ConventionalCommit} from './commit';
 export {Strategy} from './strategy';
 export {BaseStrategyOptions, BuildUpdatesOptions} from './strategies/base';

--- a/src/manifest.ts
+++ b/src/manifest.ts
@@ -266,7 +266,7 @@ const DEFAULT_COMMIT_SEARCH_DEPTH = 500;
 
 export const MANIFEST_PULL_REQUEST_TITLE_PATTERN = 'chore: release ${branch}';
 
-interface CreatedRelease extends GitHubRelease {
+export interface CreatedRelease extends GitHubRelease {
   id: number;
   path: string;
   version: string;


### PR DESCRIPTION
This allows the release-please action and other to reference the return types of `createReleases()` and `createPullRequests()`