### PR TITLE
feat: update VERSION file in PHP repo if it exists

### DIFF
--- a/src/strategies/php.ts
+++ b/src/strategies/php.ts
@@ -17,6 +17,7 @@ import {Changelog} from '../updaters/changelog';
 // PHP Specific.
 import {RootComposerUpdatePackages} from '../updaters/php/root-composer-update-packages';
 import {BaseStrategy, BuildUpdatesOptions, BaseStrategyOptions} from './base';
+import {DefaultUpdater} from '../updaters/default';
 import {Update} from '../update';
 import {VersionsMap} from '../version';
 
@@ -64,6 +65,21 @@ export class PHP extends BaseStrategy {
       updater: new RootComposerUpdatePackages({
         version,
         versionsMap,
+      }),
+    });
+
+    const contents = await this.github.getFileContentsOnBranch(
+      this.addPath('VERSION'),
+      this.targetBranch
+    );
+
+    // update VERSION file
+    updates.push({
+      path: this.addPath('VERSION'),
+      createIfMissing: false,
+      cachedFileContents: contents,
+      updater: new DefaultUpdater({
+        version,
       }),
     });
 

--- a/src/strategies/php.ts
+++ b/src/strategies/php.ts
@@ -68,16 +68,10 @@ export class PHP extends BaseStrategy {
       }),
     });
 
-    const contents = await this.github.getFileContentsOnBranch(
-      this.addPath('VERSION'),
-      this.targetBranch
-    );
-
     // update VERSION file
     updates.push({
       path: this.addPath('VERSION'),
       createIfMissing: false,
-      cachedFileContents: contents,
       updater: new DefaultUpdater({
         version,
       }),

--- a/test/strategies/php.ts
+++ b/test/strategies/php.ts
@@ -17,7 +17,7 @@ import {expect} from 'chai';
 import {GitHub} from '../../src/github';
 import {PHP} from '../../src/strategies/php';
 import * as sinon from 'sinon';
-import {assertHasUpdate, buildGitHubFileRaw} from '../helpers';
+import {assertHasUpdate} from '../helpers';
 import {buildMockConventionalCommit} from '../helpers';
 import {TagName} from '../../src/util/tag-name';
 import {Version} from '../../src/version';
@@ -39,17 +39,12 @@ const COMMITS = [
 
 describe('PHP', () => {
   let github: GitHub;
-  let getFileStub: sinon.SinonStub;
   beforeEach(async () => {
     github = await GitHub.create({
       owner: 'googleapis',
       repo: 'php-test-repo',
       defaultBranch: 'main',
     });
-    getFileStub = sandbox.stub(github, 'getFileContentsOnBranch');
-    getFileStub
-      .withArgs('VERSION', 'main')
-      .resolves(buildGitHubFileRaw('1.2.3'));
   });
   afterEach(() => {
     sandbox.restore();


### PR DESCRIPTION
This updates the `php` default strategy to update a `VERSION` file in the root of the repo if it exists. This will be useful for some PHP libraries to track which versions are being used.

