### PR TITLE
build: disable owlbot from touching files in this repo

### DIFF
--- a/owlbot.py
+++ b/owlbot.py
@@ -12,25 +12,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-
-import synthtool.languages.node as node
-
-node.owlbot_main(templates_excludes=[
-  'README.md',
-  'CONTRIBUTING.md',
-  '.eslintignore',
-  '.eslintrc.json',
-  '.mocharc.js',
-  '.prettierignore',
-  '.prettierrc',
-  '.nycrc',
-  '.kokoro/release/publish.cfg',
-  '.kokoro/presubmit/node10/system-test.cfg',
-  '.kokoro/continuous/node10/system-test.cfg',
-  '.kokoro/system-test.sh',
-  '.mocharc.js',
-  '.github/generated-files-bot.yml',
-  '.github/release-please.yml',
-  '.github/sync-repo-settings.yaml',
-  '.github/workflows/ci.yaml',
-])
+# Intentionally left blank. This is a standalone node repo.


### PR DESCRIPTION
Owlbot post-processing is touching the `release-please-config.json` and I don't see an easy way to disable it. This repo does not need owlbot post-processing