### PR TITLE
fix(php): do not add version to root version map

### DIFF
--- a/src/strategies/php-yoshi.ts
+++ b/src/strategies/php-yoshi.ts
@@ -114,7 +114,6 @@ export class PHPYoshi extends BaseStrategy {
           splitCommits[directory]
         );
         versionsMap.set(composer.name, newVersion);
-        versionsMap.set('version', newVersion);
         const partialReleaseNotes = await this.changelogNotes.buildNotes(
           splitCommits[directory],
           {
@@ -170,6 +169,13 @@ export class PHPYoshi extends BaseStrategy {
         createIfMissing: false,
         cachedFileContents: componentInfo.versionContents,
         updater: new DefaultUpdater({
+          version,
+        }),
+      });
+      updates.push({
+        path: this.addPath(`${directory}/composer.json`),
+        createIfMissing: false,
+        updater: new RootComposerUpdatePackages({
           version,
         }),
       });

--- a/src/strategies/php-yoshi.ts
+++ b/src/strategies/php-yoshi.ts
@@ -172,11 +172,14 @@ export class PHPYoshi extends BaseStrategy {
           version,
         }),
       });
+      const directoryVersion: VersionsMap = new Map();
+      directoryVersion.set('version', version);
       updates.push({
         path: this.addPath(`${directory}/composer.json`),
         createIfMissing: false,
         updater: new RootComposerUpdatePackages({
           version,
+          versionsMap: directoryVersion,
         }),
       });
       if (componentInfo.composer.extra?.component?.entry) {

--- a/test/strategies/php-yoshi.ts
+++ b/test/strategies/php-yoshi.ts
@@ -64,7 +64,7 @@ describe('PHPYoshi', () => {
       .resolves(buildGitHubFileRaw('0.1.2'));
     getFileStub
       .withArgs('Client1/composer.json', 'main')
-      .resolves(buildGitHubFileRaw('{"name": "google/client1"}'));
+      .resolves(buildGitHubFileRaw('{"name": "google/client1", "version": "1.2.3"}'));
     getFileStub
       .withArgs('Client2/composer.json', 'main')
       .resolves(buildGitHubFileRaw('{"name": "google/client2"}'));
@@ -164,8 +164,11 @@ describe('PHPYoshi', () => {
       );
       const updates = release!.updates;
       assertHasUpdate(updates, 'Client1/VERSION', DefaultUpdater);
+      assertHasUpdate(updates, 'Client1/composer.json', RootComposerUpdatePackages);
       assertHasUpdate(updates, 'Client2/VERSION', DefaultUpdater);
+      assertHasUpdate(updates, 'Client2/composer.json');
       assertHasUpdate(updates, 'Client3/VERSION', DefaultUpdater);
+      assertHasUpdate(updates, 'Client3/composer.json');
       assertHasUpdate(updates, 'Client3/src/Entry.php', PHPClientVersion);
     });
     it('ignores non client top level directories', async () => {
@@ -194,8 +197,11 @@ describe('PHPYoshi', () => {
       );
       const updates = release!.updates;
       assertHasUpdate(updates, 'Client1/VERSION', DefaultUpdater);
+      assertHasUpdate(updates, 'Client1/composer.json', RootComposerUpdatePackages);
       assertHasUpdate(updates, 'Client2/VERSION', DefaultUpdater);
+      assertHasUpdate(updates, 'Client2/composer.json');
       assertHasUpdate(updates, 'Client3/VERSION', DefaultUpdater);
+      assertHasUpdate(updates, 'Client3/composer.json');
       assertHasUpdate(updates, 'Client3/src/Entry.php', PHPClientVersion);
     });
   });

--- a/test/strategies/php-yoshi.ts
+++ b/test/strategies/php-yoshi.ts
@@ -64,7 +64,9 @@ describe('PHPYoshi', () => {
       .resolves(buildGitHubFileRaw('0.1.2'));
     getFileStub
       .withArgs('Client1/composer.json', 'main')
-      .resolves(buildGitHubFileRaw('{"name": "google/client1", "version": "1.2.3"}'));
+      .resolves(
+        buildGitHubFileRaw('{"name": "google/client1", "version": "1.2.3"}')
+      );
     getFileStub
       .withArgs('Client2/composer.json', 'main')
       .resolves(buildGitHubFileRaw('{"name": "google/client2"}'));
@@ -164,7 +166,11 @@ describe('PHPYoshi', () => {
       );
       const updates = release!.updates;
       assertHasUpdate(updates, 'Client1/VERSION', DefaultUpdater);
-      assertHasUpdate(updates, 'Client1/composer.json', RootComposerUpdatePackages);
+      assertHasUpdate(
+        updates,
+        'Client1/composer.json',
+        RootComposerUpdatePackages
+      );
       assertHasUpdate(updates, 'Client2/VERSION', DefaultUpdater);
       assertHasUpdate(updates, 'Client2/composer.json');
       assertHasUpdate(updates, 'Client3/VERSION', DefaultUpdater);
@@ -197,7 +203,11 @@ describe('PHPYoshi', () => {
       );
       const updates = release!.updates;
       assertHasUpdate(updates, 'Client1/VERSION', DefaultUpdater);
-      assertHasUpdate(updates, 'Client1/composer.json', RootComposerUpdatePackages);
+      assertHasUpdate(
+        updates,
+        'Client1/composer.json',
+        RootComposerUpdatePackages
+      );
       assertHasUpdate(updates, 'Client2/VERSION', DefaultUpdater);
       assertHasUpdate(updates, 'Client2/composer.json');
       assertHasUpdate(updates, 'Client3/VERSION', DefaultUpdater);
@@ -215,16 +225,18 @@ describe('PHPYoshi', () => {
         latestRelease
       );
       const updates = release!.updates;
-      assertHasUpdate(updates, 'Client1/composer.json', RootComposerUpdatePackages);
+      assertHasUpdate(
+        updates,
+        'Client1/composer.json',
+        RootComposerUpdatePackages
+      );
       const client1Composer = updates.find(update => {
         return update.path === 'Client1/composer.json';
       });
       const newContent = client1Composer!.updater.updateContent(
         '{"name":"google/client1","version":"1.2.3"}'
       );
-      expect(newContent).to.eql(
-        '{"name":"google/client1","version":"1.2.4"}'
-      );
+      expect(newContent).to.eql('{"name":"google/client1","version":"1.2.4"}');
     });
   });
   describe('buildRelease', () => {

--- a/test/strategies/php-yoshi.ts
+++ b/test/strategies/php-yoshi.ts
@@ -204,6 +204,28 @@ describe('PHPYoshi', () => {
       assertHasUpdate(updates, 'Client3/composer.json');
       assertHasUpdate(updates, 'Client3/src/Entry.php', PHPClientVersion);
     });
+    it('updates component composer version', async () => {
+      const strategy = new PHPYoshi({
+        targetBranch: 'main',
+        github,
+      });
+      const latestRelease = undefined;
+      const release = await strategy.buildReleasePullRequest(
+        commits,
+        latestRelease
+      );
+      const updates = release!.updates;
+      assertHasUpdate(updates, 'Client1/composer.json', RootComposerUpdatePackages);
+      const client1Composer = updates.find(update => {
+        return update.path === 'Client1/composer.json';
+      });
+      const newContent = client1Composer!.updater.updateContent(
+        '{"name":"google/client1","version":"1.2.3"}'
+      );
+      expect(newContent).to.eql(
+        '{"name":"google/client1","version":"1.2.4"}'
+      );
+    });
   });
   describe('buildRelease', () => {
     it('parses the release notes', async () => {


### PR DESCRIPTION
addresses https://github.com/googleapis/release-please/issues/2198

This is the simplest solution, which will not effect `php.ts`. However, `RootComposerUpdatePackages` contains problems with it's implementation that will be addressed in another PR.