### PR TITLE
feat: set 'version' of composer.json in RootComposerUpdatePackages

### DIFF
--- a/__snapshots__/php-composer-update-packages.js
+++ b/__snapshots__/php-composer-update-packages.js
@@ -1,17 +1,17 @@
 exports['PHPComposer updateContent does not update a version when version is the same 1'] = `
-{"version":"1.0.0","replace":{"version":"1.0.0"}}
+{"version":"1.0.0","replace":{"my/package":"1.0.0"}}
 `
 
 exports['PHPComposer updateContent update all versions in composer.json 1'] = `
-{"version":"1.0.0","replace":{"version":"1.0.0"}}
+{"version":"1.0.0","replace":{"my/package":"1.0.0"}}
 `
 
-exports['PHPComposer updateContent update replace version in composer.json when version is missing 1'] = `
-{"replace":{"version":"1.0.0"}}
+exports['PHPComposer updateContent update replace package in composer.json when package is missing 1'] = `
+{"replace":{"my/package":"1.0.0"}}
 `
 
-exports['PHPComposer updateContent update replace version in composer.json when version is present 1'] = `
-{"replace":{"version":"1.0.0"}}
+exports['PHPComposer updateContent update replace package in composer.json when package is set in version map 1'] = `
+{"replace":{"my/package":"1.0.0"}}
 `
 
 exports['PHPComposer updateContent update root version in composer.json 1'] = `

--- a/__snapshots__/root-composer-update-packages.js
+++ b/__snapshots__/root-composer-update-packages.js
@@ -1,3 +1,7 @@
+exports['composer-update-package.json updateContent does not update version in composer if it does not exist 1'] = `
+{}
+`
+
 exports['composer-update-package.json updateContent updates all versions in root composer file 1'] = `
 {
     "name": "google/cloud",
@@ -255,4 +259,8 @@ exports['composer-update-package.json updateContent updates all versions in root
     }
 }
 
+`
+
+exports['composer-update-package.json updateContent updates version in composer if it exists 1'] = `
+{"version":"1.0.0"}
 `

--- a/src/strategies/php-yoshi.ts
+++ b/src/strategies/php-yoshi.ts
@@ -172,14 +172,11 @@ export class PHPYoshi extends BaseStrategy {
           version,
         }),
       });
-      const directoryVersion: VersionsMap = new Map();
-      directoryVersion.set('version', version);
       updates.push({
         path: this.addPath(`${directory}/composer.json`),
         createIfMissing: false,
         updater: new RootComposerUpdatePackages({
           version,
-          versionsMap: directoryVersion,
         }),
       });
       if (componentInfo.composer.extra?.component?.entry) {

--- a/src/strategies/php.ts
+++ b/src/strategies/php.ts
@@ -47,7 +47,6 @@ export class PHP extends BaseStrategy {
     const updates: Update[] = [];
     const version = options.newVersion;
     const versionsMap: VersionsMap = new Map();
-    versionsMap.set('version', version);
 
     updates.push({
       path: this.addPath(this.changelogPath),

--- a/src/updaters/php/root-composer-update-packages.ts
+++ b/src/updaters/php/root-composer-update-packages.ts
@@ -31,6 +31,11 @@ export class RootComposerUpdatePackages extends DefaultUpdater {
       return content;
     }
     const parsed = JSON.parse(content);
+    if (parsed['version']) {
+      let fromVersion: string = parsed['version'];
+      parsed['version'] = this.version.toString();
+      logger.info(`updating "version" from ${fromVersion} to ${this.version.toString()}`);
+    }
     if (this.versionsMap) {
       for (const [key, version] of this.versionsMap.entries()) {
         const toVersion = version.toString() || '1.0.0';

--- a/src/updaters/php/root-composer-update-packages.ts
+++ b/src/updaters/php/root-composer-update-packages.ts
@@ -26,15 +26,16 @@ export class RootComposerUpdatePackages extends DefaultUpdater {
    * @returns {string} The updated content
    */
   updateContent(content: string, logger: Logger = defaultLogger): string {
-    if (!this.versionsMap || this.versionsMap.size === 0) {
+    if (!this.version && (!this.versionsMap || this.versionsMap.size === 0)) {
       logger.info('no updates necessary');
       return content;
     }
     const parsed = JSON.parse(content);
     if (parsed['version']) {
       let fromVersion: string = parsed['version'];
-      parsed['version'] = this.version.toString();
-      logger.info(`updating "version" from ${fromVersion} to ${this.version.toString()}`);
+      const toVersion = this.version.toString() || '1.0.0';
+      parsed['version'] = toVersion;
+      logger.info(`updating "version" from ${fromVersion} to ${toVersion}`);
     }
     if (this.versionsMap) {
       for (const [key, version] of this.versionsMap.entries()) {

--- a/src/updaters/php/root-composer-update-packages.ts
+++ b/src/updaters/php/root-composer-update-packages.ts
@@ -32,7 +32,7 @@ export class RootComposerUpdatePackages extends DefaultUpdater {
     }
     const parsed = JSON.parse(content);
     if (parsed['version']) {
-      let fromVersion: string = parsed['version'];
+      const fromVersion: string = parsed['version'];
       const toVersion = this.version.toString() || '1.0.0';
       parsed['version'] = toVersion;
       logger.info(`updating "version" from ${fromVersion} to ${toVersion}`);

--- a/test/updaters/php-composer-update-packages.ts
+++ b/test/updaters/php-composer-update-packages.ts
@@ -21,11 +21,13 @@ import {Version, VersionsMap} from '../../src/version';
 describe('PHPComposer', () => {
   describe('updateContent', () => {
     it('does not update a version when version is the same', async () => {
-      const oldContent = '{"version":"1.0.0","replace":{"version":"1.0.0"}}';
+      const oldContent = '{"version":"1.0.0","replace":{"my/package":"1.0.0"}}';
 
       const version = Version.parse('1.0.0');
 
       const versionsMap: VersionsMap = new Map();
+
+      versionsMap.set('my/package', version);
 
       const newContent = new RootComposerUpdatePackages({
         version,
@@ -33,20 +35,20 @@ describe('PHPComposer', () => {
       }).updateContent(oldContent);
 
       expect(newContent).to.eq(
-        '{"version":"1.0.0","replace":{"version":"1.0.0"}}'
+        '{"version":"1.0.0","replace":{"my/package":"1.0.0"}}'
       );
 
       snapshot(newContent);
     });
 
     it('update all versions in composer.json', async () => {
-      const oldContent = '{"version":"0.0.0","replace":{"version":"0.0.0"}}';
+      const oldContent = '{"version":"0.0.0","replace":{"my/package":"0.0.0"}}';
 
       const version = Version.parse('1.0.0');
 
       const versionsMap: VersionsMap = new Map();
 
-      versionsMap.set('version', version);
+      versionsMap.set('my/package', version);
 
       const newContent = new RootComposerUpdatePackages({
         version,
@@ -54,7 +56,7 @@ describe('PHPComposer', () => {
       }).updateContent(oldContent);
 
       expect(newContent).to.eq(
-        '{"version":"1.0.0","replace":{"version":"1.0.0"}}'
+        '{"version":"1.0.0","replace":{"my/package":"1.0.0"}}'
       );
 
       snapshot(newContent);
@@ -79,40 +81,40 @@ describe('PHPComposer', () => {
       snapshot(newContent);
     });
 
-    it('update replace version in composer.json when version is present', async () => {
-      const oldContent = '{"replace":{"version":"0.0.0"}}';
+    it('update replace package in composer.json when package is set in version map', async () => {
+      const oldContent = '{"replace":{"my/package":"0.0.0"}}';
 
       const version = Version.parse('1.0.0');
 
       const versionsMap: VersionsMap = new Map();
 
-      versionsMap.set('version', version);
+      versionsMap.set('my/package', version);
 
       const newContent = new RootComposerUpdatePackages({
         version,
         versionsMap,
       }).updateContent(oldContent);
 
-      expect(newContent).to.eq('{"replace":{"version":"1.0.0"}}');
+      expect(newContent).to.eq('{"replace":{"my/package":"1.0.0"}}');
 
       snapshot(newContent);
     });
 
-    it('update replace version in composer.json when version is missing', async () => {
+    it('update replace package in composer.json when package is missing', async () => {
       const oldContent = '{"replace":{}}';
 
       const version = Version.parse('1.0.0');
 
       const versionsMap: VersionsMap = new Map();
 
-      versionsMap.set('version', version);
+      versionsMap.set('my/package', version);
 
       const newContent = new RootComposerUpdatePackages({
         version,
         versionsMap,
       }).updateContent(oldContent);
 
-      expect(newContent).to.eq('{"replace":{"version":"1.0.0"}}');
+      expect(newContent).to.eq('{"replace":{"my/package":"1.0.0"}}');
 
       snapshot(newContent);
     });

--- a/test/updaters/root-composer-update-packages.ts
+++ b/test/updaters/root-composer-update-packages.ts
@@ -43,9 +43,7 @@ describe('composer-update-package.json', () => {
       const composer = new RootComposerUpdatePackages({
         version: Version.parse('1.0.0'),
       });
-      const newContent = composer.updateContent(
-        '{"version": "0.8.0"}'
-      );
+      const newContent = composer.updateContent('{"version": "0.8.0"}');
       expect(newContent).to.eql('{"version":"1.0.0"}');
       snapshot(newContent);
     });
@@ -53,9 +51,7 @@ describe('composer-update-package.json', () => {
       const composer = new RootComposerUpdatePackages({
         version: Version.parse('1.0.0'),
       });
-      const newContent = composer.updateContent(
-        '{}'
-      );
+      const newContent = composer.updateContent('{}');
       expect(newContent).to.eql('{}');
       snapshot(newContent);
     });

--- a/test/updaters/root-composer-update-packages.ts
+++ b/test/updaters/root-composer-update-packages.ts
@@ -16,6 +16,7 @@ import {readFileSync} from 'fs';
 import {resolve} from 'path';
 import * as snapshot from 'snap-shot-it';
 import {describe, it} from 'mocha';
+import {expect} from 'chai';
 import {RootComposerUpdatePackages} from '../../src/updaters/php/root-composer-update-packages';
 import {Version} from '../../src/version';
 
@@ -36,6 +37,26 @@ describe('composer-update-package.json', () => {
         versionsMap: versions,
       });
       const newContent = composer.updateContent(oldContent);
+      snapshot(newContent);
+    });
+    it('updates version in composer if it exists', async () => {
+      const composer = new RootComposerUpdatePackages({
+        version: Version.parse('1.0.0'),
+      });
+      const newContent = composer.updateContent(
+        '{"version": "0.8.0"}'
+      );
+      expect(newContent).to.eql('{"version":"1.0.0"}');
+      snapshot(newContent);
+    });
+    it('does not update version in composer if it does not exist', async () => {
+      const composer = new RootComposerUpdatePackages({
+        version: Version.parse('1.0.0'),
+      });
+      const newContent = composer.updateContent(
+        '{}'
+      );
+      expect(newContent).to.eql('{}');
       snapshot(newContent);
     });
   });


### PR DESCRIPTION
addresses https://github.com/googleapis/release-please/issues/2198

Marked as a `feat` since it changes the behavior of `RootComposerUpdatePackage` by always updating `version` in `composer.json`. 

**IMPORTANT**: The behavior of the php strategy (`src/strategies/php.ts`) will **not** change, as `version` was already being set in the `versionsMap`. The only difference in the php strategy is in the case where `composer.json` includes a `replace` section: the "version" key will no longer be added to it. This is the desired behavior, as adding such a string to `replace` results in a composer exception.