### PR TITLE
Support multiple stable release branches / consider all branches when looking for previous release shas

### DIFF
--- a/src/bin/release-please.ts
+++ b/src/bin/release-please.ts
@@ -73,6 +73,8 @@ interface VersioningArgs {
   latestTagVersion?: string;
   latestTagSha?: string;
   latestTagName?: string;
+
+  includeAllReleases?: boolean;
 }
 
 interface ManifestConfigArgs {
@@ -345,6 +347,12 @@ function pullRequestStrategyOptions(yargs: yargs.Argv): yargs.Argv {
       describe: 'Override the detected latest tag name',
       type: 'string',
     })
+    .option('include-all-releases', {
+      describe:
+        'Include release shas from all branches when determining latest release',
+      default: false,
+      type: 'boolean',
+    })
     .middleware(_argv => {
       const argv = _argv as CreatePullRequestArgs;
 
@@ -471,6 +479,7 @@ const createReleasePullRequestCommand: yargs.CommandModule<
           versionFile: argv.versionFile,
           includeComponentInTag: argv.monorepoTags,
           includeVInTag: argv.includeVInTags,
+          includeAllReleases: argv.includeAllReleases,
         },
         extractManifestOptions(argv),
         argv.path
@@ -489,7 +498,9 @@ const createReleasePullRequestCommand: yargs.CommandModule<
     }
 
     if (argv.dryRun) {
-      const pullRequests = await manifest.buildPullRequests();
+      const pullRequests = await manifest.buildPullRequests(
+        argv.includeAllReleases
+      );
       console.log(`Would open ${pullRequests.length} pull requests`);
       console.log('fork:', manifest.fork);
       for (const pullRequest of pullRequests) {
@@ -524,7 +535,9 @@ const createReleasePullRequestCommand: yargs.CommandModule<
         }
       }
     } else {
-      const pullRequestNumbers = await manifest.createPullRequests();
+      const pullRequestNumbers = await manifest.createPullRequests(
+        argv.includeAllReleases
+      );
       console.log(pullRequestNumbers);
     }
   },

--- a/src/bin/release-please.ts
+++ b/src/bin/release-please.ts
@@ -74,7 +74,7 @@ interface VersioningArgs {
   latestTagSha?: string;
   latestTagName?: string;
 
-  includeAllReleases?: boolean;
+  considerAllBranches?: boolean;
 }
 
 interface ManifestConfigArgs {
@@ -347,9 +347,9 @@ function pullRequestStrategyOptions(yargs: yargs.Argv): yargs.Argv {
       describe: 'Override the detected latest tag name',
       type: 'string',
     })
-    .option('include-all-releases', {
+    .option('consider-all-branches', {
       describe:
-        'Include release shas from all branches when determining latest release',
+        'Consider commits from all branches when determining changes for the latest release',
       default: false,
       type: 'boolean',
     })
@@ -479,7 +479,7 @@ const createReleasePullRequestCommand: yargs.CommandModule<
           versionFile: argv.versionFile,
           includeComponentInTag: argv.monorepoTags,
           includeVInTag: argv.includeVInTags,
-          includeAllReleases: argv.includeAllReleases,
+          considerAllBranches: argv.considerAllBranches,
         },
         extractManifestOptions(argv),
         argv.path
@@ -499,7 +499,7 @@ const createReleasePullRequestCommand: yargs.CommandModule<
 
     if (argv.dryRun) {
       const pullRequests = await manifest.buildPullRequests(
-        argv.includeAllReleases
+        argv.considerAllBranches
       );
       console.log(`Would open ${pullRequests.length} pull requests`);
       console.log('fork:', manifest.fork);
@@ -536,7 +536,7 @@ const createReleasePullRequestCommand: yargs.CommandModule<
       }
     } else {
       const pullRequestNumbers = await manifest.createPullRequests(
-        argv.includeAllReleases
+        argv.considerAllBranches
       );
       console.log(pullRequestNumbers);
     }

--- a/src/manifest.ts
+++ b/src/manifest.ts
@@ -598,7 +598,7 @@ export class Manifest {
     const releasePullRequestsBySha: Record<string, PullRequest> = {};
     // only consider commits across all branches when there has been a previous release
     // otherwise, there would be nothing to compare against
-    if (considerAllBranches && releasesByPath.length > 0) {
+    if (considerAllBranches && Object.keys(releasesByPath).length > 0) {
       for (const path in releasesByPath) {
         const release = releasesByPath[path];
         this.logger.info(


### PR DESCRIPTION
Thank you for opening a Pull Request! Before submitting your PR, there are a few things you can do to make sure it goes smoothly:
- [X] Make sure to open an issue as a [bug/issue](https://github.com/googleapis/release-please/issues/new/choose) before writing your code!  That way we can discuss the change, evaluate designs, and agree on the general idea
- [ ] Ensure the tests and linter pass
- [ ] Code coverage does not decrease (if any source code was changed)
- [ ] Appropriate docs were updated (if necessary)

Fixes #2202 🦕

We are currently using this fork for our release process and it appears to be working as expected, but I'm sure there are edge cases that aren't being addressed yet.

This PR add a flag `--consider-all-branches` that, when specified, will use GitHub's compare commits API to compare the commits between head of the branch being released, and the found sha of the previous release, allowing the previous release's sha to be on a different branch. This allows, for example, to have a branch like `release-1.7.x`, with the latest release being, say, `1.7.4`, and then release a new minor version (`1.8.0`) from a branch like `release-1.8.x`, and have it correctly show the changelog of commits since `1.7.4`, even though that tag is on a different branch.

This PR isn't complete yet, and there's a lot of test coverage missing, but I wanted to get consensus on the approach before investing more time. Thanks!