### PR TITLE
fix: release-please should find the component even if it is ignored in the release tag

### DIFF
--- a/__snapshots__/github-changelog-notes.js
+++ b/__snapshots__/github-changelog-notes.js
@@ -1,5 +1,5 @@
 exports['GitHubChangelogNotes buildNotes should build release notes from GitHub 1'] = `
-## 1.2.3 (2/1/2024)
+## 1.2.3 (1983-10-10)
 
 ##Changes in Release v1.0.0 ... ##Contributors @monalisa
 `

--- a/__snapshots__/github-changelog-notes.js
+++ b/__snapshots__/github-changelog-notes.js
@@ -1,5 +1,5 @@
 exports['GitHubChangelogNotes buildNotes should build release notes from GitHub 1'] = `
-## 1.2.3 (1983-10-10)
+## 1.2.3 (2/1/2024)
 
 ##Changes in Release v1.0.0 ... ##Contributors @monalisa
 `

--- a/__snapshots__/manifest.js
+++ b/__snapshots__/manifest.js
@@ -93,7 +93,7 @@ exports['Manifest buildPullRequests should handle mixing componentless configs 1
 ---
 
 
-<details><summary>1.0.1</summary>
+<details><summary>pkg1: 1.0.1</summary>
 
 ## [1.0.1](https://github.com/fake-owner/fake-repo/compare/v1.0.0...v1.0.1) (1983-10-10)
 

--- a/src/strategies/base.ts
+++ b/src/strategies/base.ts
@@ -160,10 +160,9 @@ export abstract class BaseStrategy implements Strategy {
    * @returns {string}
    */
   async getComponent(): Promise<string | undefined> {
-    if (!this.includeComponentInTag) {
-      return '';
-    }
-    return this.component || (await this.getDefaultComponent());
+    return !this.includeComponentInTag
+      ? this.component
+      : await this.getDefaultComponent();
   }
 
   async getDefaultComponent(): Promise<string | undefined> {

--- a/src/strategies/base.ts
+++ b/src/strategies/base.ts
@@ -160,7 +160,7 @@ export abstract class BaseStrategy implements Strategy {
    * @returns {string}
    */
   async getComponent(): Promise<string | undefined> {
-    return this.component ?? (await this.getDefaultComponent());
+    return this.component || (await this.getDefaultComponent());
   }
 
   async getDefaultComponent(): Promise<string | undefined> {

--- a/src/strategies/base.ts
+++ b/src/strategies/base.ts
@@ -160,6 +160,9 @@ export abstract class BaseStrategy implements Strategy {
    * @returns {string}
    */
   async getComponent(): Promise<string | undefined> {
+    // if (!this.includeComponentInTag) {
+    //   return '';
+    // }
     return this.component || (await this.getDefaultComponent());
   }
 
@@ -621,7 +624,7 @@ export abstract class BaseStrategy implements Strategy {
       releaseData = pullRequestBody.releaseData.find(datum => {
         return (
           this.normalizeComponent(datum.component) ===
-          this.normalizeComponent(component)
+          this.normalizeComponent(this.includeComponentInTag ? component : '')
         );
       });
 

--- a/src/strategies/base.ts
+++ b/src/strategies/base.ts
@@ -160,9 +160,7 @@ export abstract class BaseStrategy implements Strategy {
    * @returns {string}
    */
   async getComponent(): Promise<string | undefined> {
-    return !this.includeComponentInTag
-      ? this.component
-      : await this.getDefaultComponent();
+    return this.component ?? (await this.getDefaultComponent());
   }
 
   async getDefaultComponent(): Promise<string | undefined> {

--- a/src/strategies/base.ts
+++ b/src/strategies/base.ts
@@ -160,9 +160,6 @@ export abstract class BaseStrategy implements Strategy {
    * @returns {string}
    */
   async getComponent(): Promise<string | undefined> {
-    // if (!this.includeComponentInTag) {
-    //   return '';
-    // }
     return this.component || (await this.getDefaultComponent());
   }
 

--- a/test/strategies/base.ts
+++ b/test/strategies/base.ts
@@ -63,6 +63,20 @@ describe('Strategy', () => {
       const pullRequest = await strategy.buildReleasePullRequest([]);
       expect(pullRequest).to.be.undefined;
     });
+    it('skips component in release tag if ignored', async () => {
+      const strategy = new TestStrategy({
+        targetBranch: 'main',
+        github,
+        component: 'google-cloud-automl',
+        includeComponentInTag: false,
+      });
+      const commits = buildMockConventionalCommit(
+        'chore: relea\n\nRelease-As: 2.3.4'
+      );
+      const release = await strategy.buildReleasePullRequest(commits);
+      expect(release?.body.releaseData).to.not.include('google-cloud-automl');
+      expect(release?.title.component).to.include('google-cloud-automl');
+    });
     it('allows overriding initial version', async () => {
       const strategy = new TestStrategy({
         targetBranch: 'main',


### PR DESCRIPTION
There is a bug in base.ts that will not get the component correctly if it includeComponentInTag === false. Manifest seems to depend on this bug, so I've just moved the logic that returns an empty string in component to Manifest.