### PR TITLE
fix: when includeComponentInTag is false, there should be no component in the branch name

### DIFF
--- a/src/strategies/base.ts
+++ b/src/strategies/base.ts
@@ -173,6 +173,9 @@ export abstract class BaseStrategy implements Strategy {
   }
 
   async getBranchComponent(): Promise<string | undefined> {
+    if (!this.includeComponentInTag) {
+      return '';
+    }
     return this.component || (await this.getDefaultComponent());
   }
 

--- a/test/manifest.ts
+++ b/test/manifest.ts
@@ -5057,8 +5057,7 @@ describe('Manifest', () => {
         [],
         [
           {
-            headBranchName:
-              'release-please--branches--main--components',
+            headBranchName: 'release-please--branches--main--components',
             baseBranchName: 'main',
             number: 1234,
             title: 'chore(main): release v1.3.1',

--- a/test/manifest.ts
+++ b/test/manifest.ts
@@ -3487,7 +3487,7 @@ describe('Manifest', () => {
         );
         const mainPullRequest = pullRequests[1];
         expect(mainPullRequest.headRefName).to.eql(
-          'release-please--branches--main--components--d'
+          'release-please--branches--main'
         );
       });
     });
@@ -4667,7 +4667,7 @@ describe('Manifest', () => {
         [],
         [
           {
-            headBranchName: 'release-please--branches--main--components--foo',
+            headBranchName: 'release-please--branches--main',
             baseBranchName: 'main',
             number: 1234,
             title: 'chore(main): release 3.2.7',
@@ -5058,7 +5058,7 @@ describe('Manifest', () => {
         [
           {
             headBranchName:
-              'release-please--branches--main--components--release-brancher',
+              'release-please--branches--main--components',
             baseBranchName: 'main',
             number: 1234,
             title: 'chore(main): release v1.3.1',
@@ -5313,7 +5313,7 @@ describe('Manifest', () => {
         [
           {
             headBranchName:
-              'release-please--branches--hotfix/v3.1.0-bug--components--my-package-name',
+              'release-please--branches--hotfix/v3.1.0-bug--components',
             baseBranchName: 'hotfix/v3.1.0-bug',
             number: 1234,
             title: '[HOTFIX] - chore(hotfix/v3.1.0-bug): release 3.1.0-hotfix1',


### PR DESCRIPTION
I was investigating why release-please did not open a PR here: https://github.com/googleapis/gax-nodejs/pull/1553

The CLI fails with the warning: 
```
⚠ PR component: undefined does not match configured component: google-gax
```
(here): https://github.com/googleapis/release-please/blob/72b0ab360c3d6635397e8b02f4d3f9f53932e23c/src/strategies/base.ts#L615

That is true, since the branch does not contain the component:
<img width="994" alt="Screenshot 2024-02-01 at 1 44 57 AM" src="https://github.com/googleapis/release-please/assets/55454395/c1140cb8-9008-4a7d-b155-642c9678238e">

It kind of makes sense that the branchName wouldn't contain the component, since we're setting that in the config (https://github.com/googleapis/gax-nodejs/blob/c65cee0fd56ff2682d5cfb91ca639ee98e93f568/release-please-config.json#L11)

We can mirror what `getComponent` has, here: https://github.com/googleapis/release-please/blob/72b0ab360c3d6635397e8b02f4d3f9f53932e23c/src/strategies/base.ts#L163 in `getBranchComponent`