### PR TITLE
fix: use package name to build aggregate if present

### DIFF
--- a/__snapshots__/merge.js
+++ b/__snapshots__/merge.js
@@ -54,3 +54,22 @@ Release notes for path: node, releaseType: node
 ---
 This PR was generated with [Release Please](https://github.com/googleapis/release-please). See [documentation](https://github.com/googleapis/release-please#release-please).
 `
+
+exports['Merge plugin run merges multiple pull requests into an aggregate and uses packageName as default for branch name if present 1'] = `
+:robot: I have created a release *beep* *boop*
+---
+
+
+<details><summary>python-pkg: 1.0.0</summary>
+
+Release notes for path: python, releaseType: python
+</details>
+
+<details><summary>@here/pkgA: 3.3.4</summary>
+
+Release notes for path: node, releaseType: node
+</details>
+
+---
+This PR was generated with [Release Please](https://github.com/googleapis/release-please). See [documentation](https://github.com/googleapis/release-please#release-please).
+`

--- a/src/manifest.ts
+++ b/src/manifest.ts
@@ -776,6 +776,9 @@ export class Manifest {
         ) {
           mergeOptions.pullRequestFooter = config.pullRequestFooter;
         }
+        if ('packageName' in config) {
+          mergeOptions.packageName = config.packageName;
+        }
       }
       this.plugins.push(
         new Merge(

--- a/src/plugins/merge.ts
+++ b/src/plugins/merge.ts
@@ -120,7 +120,6 @@ export class Merge extends ManifestPlugin {
         this.headBranchName ??
         (this.packageName
           ? BranchName.ofComponentTargetBranch(
-              // eslint-disable-next-line @typescript-eslint/no-non-null-asserted-optional-chain
               this.packageName,
               this.targetBranch
             ).toString()


### PR DESCRIPTION
We've been having an ongoing bug, where release-please does not create a branch with the component name for the release (example: https://github.com/googleapis/gax-nodejs/pull/1560)

This is weird, because the release-itself has the correct branch name up to this line: https://github.com/googleapis/release-please/blob/72b0ab360c3d6635397e8b02f4d3f9f53932e23c/src/manifest.ts#L749

But this correct name gets lost after the `Merge` plugin is run: https://github.com/googleapis/release-please/blob/72b0ab360c3d6635397e8b02f4d3f9f53932e23c/src/manifest.ts#L795

The least disruptive solution I found is to mirror how the (correct) branch name gets selected in `base.ts`: https://github.com/googleapis/release-please/blob/72b0ab360c3d6635397e8b02f4d3f9f53932e23c/src/strategies/base.ts#L302

Base looks for a component or packageName to[ determine the type of branch](https://github.com/googleapis/release-please/blob/72b0ab360c3d6635397e8b02f4d3f9f53932e23c/src/strategies/base.ts#L169). I think the merge strategy should do the same.

See a longer explanation of this bug (which I don't think this totally resolves, but at least preserves some functionality: https://github.com/googleapis/release-please/issues/2214