### PR TITLE
docs: remove reference to support contracts

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -6,20 +6,7 @@ labels: 'type: bug, priority: p2'
 
 Thanks for stopping by to let us know something could be better!
 
-**PLEASE READ**: If you have a support contract with Google, please create an issue in the [support console](https://cloud.google.com/support/) instead of filing on GitHub. This will ensure a timely response.
-
-1) Is this a client library issue or a product issue?
-This is the client library for . We will only be able to assist with issues that pertain to the behaviors of this library. If the issue you're experiencing is due to the behavior of the product itself, please visit the [ Support page]() to reach the most relevant engineers.
-
-2) Did someone already solve this?
-  - Search the issues already opened: https://github.com/googleapis/release-please/issues
-  - Search the issues on our "catch-all" repository: https://github.com/googleapis/google-cloud-node
-  - Search or ask on StackOverflow (engineers monitor these tags): http://stackoverflow.com/questions/tagged/google-cloud-platform+node.js
-
-3) Do you have a support contract?
-Please create an issue in the [support console](https://cloud.google.com/support/) to ensure a timely response.
-
-If the support paths suggested above still do not result in a resolution, please provide the following details.
+Please provide the following details.
 
 #### Environment details
 

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,4 +1,0 @@
-contact_links:
-  - name: Google Cloud Support
-    url: https://cloud.google.com/support/
-    about: If you have a support contract with Google, please use the Google Cloud Support portal.

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -6,8 +6,6 @@ labels: 'type: feature request, priority: p3'
 
 Thanks for stopping by to let us know something could be better!
 
-**PLEASE READ**: If you have a support contract with Google, please create an issue in the [support console](https://cloud.google.com/support/) instead of filing on GitHub. This will ensure a timely response.
-
  **Is your feature request related to a problem? Please describe.**
 A clear and concise description of what the problem is. Ex. I'm always frustrated when [...]
  **Describe the solution you'd like**

--- a/.github/ISSUE_TEMPLATE/question.md
+++ b/.github/ISSUE_TEMPLATE/question.md
@@ -8,5 +8,3 @@ Thanks for stopping by to ask us a question! Please make sure to include:
 - What you're trying to do
 - What code you've already tried
 - Any error messages you're getting
-
-**PLEASE READ**: If you have a support contract with Google, please create an issue in the [support console](https://cloud.google.com/support/) instead of filing on GitHub. This will ensure a timely response.

--- a/.github/ISSUE_TEMPLATE/support_request.md
+++ b/.github/ISSUE_TEMPLATE/support_request.md
@@ -1,7 +1,0 @@
----
-name: Support request
-about: If you have a support contract with Google, please create an issue in the Google Cloud Support console.
-
----
-
-**PLEASE READ**: If you have a support contract with Google, please create an issue in the [support console](https://cloud.google.com/support/) instead of filing on GitHub. This will ensure a timely response.

--- a/README.md
+++ b/README.md
@@ -275,3 +275,7 @@ For common issues and help troubleshooting your configuration, see [Troubleshoot
 Apache Version 2.0
 
 See [LICENSE](https://github.com/googleapis/release-please/blob/main/LICENSE)
+
+## Disclaimer
+
+This is not an official Google product.

--- a/owlbot.py
+++ b/owlbot.py
@@ -12,12 +12,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import synthtool.languages.node as node
-
-node.owlbot_main(templates_excludes=[
-    ".github/ISSUE_TEMPLATE/bug_report.md",
-    ".github/ISSUE_TEMPLATE/config.yml",
-    ".github/ISSUE_TEMPLATE/feature_request.md",
-    ".github/ISSUE_TEMPLATE/question.md",
-    ".github/ISSUE_TEMPLATE/support_request.md",
-])
+# Intentionally left blank. This is a standalone node repo.

--- a/owlbot.py
+++ b/owlbot.py
@@ -12,4 +12,12 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# Intentionally left blank. This is a standalone node repo.
+import synthtool.languages.node as node
+
+node.owlbot_main(templates_excludes=[
+    ".github/ISSUE_TEMPLATE/bug_report.md",
+    ".github/ISSUE_TEMPLATE/config.yml",
+    ".github/ISSUE_TEMPLATE/feature_request.md",
+    ".github/ISSUE_TEMPLATE/question.md",
+    ".github/ISSUE_TEMPLATE/support_request.md",
+])


### PR DESCRIPTION
Release Please is an OSS project released as a community contribution. It is not part of the Google Cloud SDK.

---

Release please was using the default templates for support requests. This created confusion for customers.