### PR TITLE
feat: update VERSION file in php-yoshi repo if it exists

### DIFF
--- a/src/strategies/php-yoshi.ts
+++ b/src/strategies/php-yoshi.ts
@@ -252,11 +252,11 @@ export class PHPYoshi extends BaseStrategy {
 
     // update VERSION file
     updates.push({
-        path: this.addPath('VERSION'),
-        createIfMissing: false,
-        updater: new DefaultUpdater({
-            version,
-        }),
+      path: this.addPath('VERSION'),
+      createIfMissing: false,
+      updater: new DefaultUpdater({
+        version,
+      }),
     });
 
     // update the aggregate package information in the root composer.json

--- a/src/strategies/php-yoshi.ts
+++ b/src/strategies/php-yoshi.ts
@@ -250,6 +250,15 @@ export class PHPYoshi extends BaseStrategy {
       }),
     });
 
+    // update VERSION file
+    updates.push({
+        path: this.addPath('VERSION'),
+        createIfMissing: false,
+        updater: new DefaultUpdater({
+            version,
+        }),
+    });
+
     // update the aggregate package information in the root composer.json
     updates.push({
       path: this.addPath('composer.json'),

--- a/test/strategies/php-yoshi.ts
+++ b/test/strategies/php-yoshi.ts
@@ -151,8 +151,10 @@ describe('PHPYoshi', () => {
         latestRelease
       );
       const updates = release!.updates;
+      expect(updates).lengthOf(3);
       assertHasUpdate(updates, 'CHANGELOG.md', Changelog);
       assertHasUpdate(updates, 'composer.json', RootComposerUpdatePackages);
+      assertHasUpdate(updates, 'VERSION', DefaultUpdater);
     });
     it('finds touched components', async () => {
       const strategy = new PHPYoshi({

--- a/test/strategies/php-yoshi.ts
+++ b/test/strategies/php-yoshi.ts
@@ -151,7 +151,6 @@ describe('PHPYoshi', () => {
         latestRelease
       );
       const updates = release!.updates;
-      expect(updates).lengthOf(3);
       assertHasUpdate(updates, 'CHANGELOG.md', Changelog);
       assertHasUpdate(updates, 'composer.json', RootComposerUpdatePackages);
       assertHasUpdate(updates, 'VERSION', DefaultUpdater);


### PR DESCRIPTION
Php-yoshi releases only track the `VERSION` file in subdirectories and skips tracking it for the root. This is the same as PR #2153 but for `yoshi-php` releases instead of `php`.