### PR TITLE
fix: Disable updating peer dependencies when updatePeerDependencies is false.

### DIFF
--- a/__snapshots__/package-json.js
+++ b/__snapshots__/package-json.js
@@ -1,3 +1,59 @@
+exports['PackageJson updateContent does not update peer dependencies by default 1'] = `
+{
+\t"name": "yargs-parser",
+\t"version": "14.0.0",
+\t"description": "the mighty option parser used by yargs",
+\t"main": "index.js",
+\t"scripts": {
+\t\t"test": "nyc mocha test/*.js",
+\t\t"posttest": "standard",
+\t\t"coverage": "nyc report --reporter=text-lcov | coveralls",
+\t\t"release": "standard-version"
+\t},
+\t"repository": {
+\t\t"url": "git@github.com:yargs/yargs-parser.git"
+\t},
+\t"keywords": [
+\t\t"argument",
+\t\t"parser",
+\t\t"yargs",
+\t\t"command",
+\t\t"cli",
+\t\t"parsing",
+\t\t"option",
+\t\t"args",
+\t\t"argument"
+\t],
+\t"author": "Ben Coe <ben@npmjs.com>",
+\t"license": "ISC",
+\t"devDependencies": {
+\t\t"chai": "^4.2.1",
+\t\t"coveralls": "^3.0.2",
+\t\t"mocha": "^5.2.0",
+\t\t"nyc": "^13.0.1",
+\t\t"standard": "^12.0.1"
+\t},
+\t"dependencies": {
+\t\t"camelcase": "^6.0.0",
+\t\t"decamelize": "^1.2.0"
+\t},
+\t"optionalDependencies": {
+\t\t"foo": "~0.1.0"
+\t},
+\t"peerDependencies": {
+\t\t"bar": ">= 1.0.0"
+\t},
+\t"files": [
+\t\t"lib",
+\t\t"index.js"
+\t],
+\t"engine": {
+\t\t"node": ">=6"
+\t}
+}
+
+`
+
 exports['PackageJson updateContent updates dependency versions 1'] = `
 {
 \t"name": "yargs-parser",

--- a/src/plugins/node-workspace.ts
+++ b/src/plugins/node-workspace.ts
@@ -311,6 +311,7 @@ export class NodeWorkspace extends WorkspacePlugin<Package> {
           updater: new PackageJson({
             version: newVersion,
             versionsMap: updatedVersions,
+            updatePeerDependencies: this.updatePeerDependencies,
           }),
         },
         {
@@ -319,6 +320,7 @@ export class NodeWorkspace extends WorkspacePlugin<Package> {
           updater: new PackageJson({
             version: newVersion,
             versionsMap: updatedVersions,
+            updatePeerDependencies: this.updatePeerDependencies,
           }),
         },
         {

--- a/src/plugins/node-workspace.ts
+++ b/src/plugins/node-workspace.ts
@@ -191,6 +191,7 @@ export class NodeWorkspace extends WorkspacePlugin<Package> {
     const updater = new PackageJson({
       version: newVersion,
       versionsMap: updatedVersions,
+      updatePeerDependencies: this.updatePeerDependencies,
     });
     const dependencyNotes = getChangelogDepsNotes(
       pkg,

--- a/src/updaters/node/package-json.ts
+++ b/src/updaters/node/package-json.ts
@@ -15,7 +15,7 @@
 import {jsonStringify} from '../../util/json-stringify';
 import {logger as defaultLogger, Logger} from '../../util/logger';
 import {Version, VersionsMap} from '../../version';
-import {DefaultUpdater} from '../default';
+import {DefaultUpdater, UpdateOptions} from '../default';
 
 export type PackageJsonDescriptor = {
   name?: string;
@@ -28,10 +28,20 @@ export type PackageJsonDescriptor = {
   optionalDependencies?: Record<string, string>;
 };
 
+export interface PackageJsonOptions extends UpdateOptions {
+  updatePeerDependencies?: boolean;
+}
+
 /**
  * This updates a Node.js package.json file's main version.
  */
 export class PackageJson extends DefaultUpdater {
+  private updatePeerDependencies = false;
+
+  constructor(options: PackageJsonOptions) {
+    super(options);
+    this.updatePeerDependencies = options.updatePeerDependencies || false;
+  }
   /**
    * Given initial file contents, return updated contents.
    * @param {string} content The initial content
@@ -52,7 +62,7 @@ export class PackageJson extends DefaultUpdater {
       if (parsed.devDependencies) {
         updateDependencies(parsed.devDependencies, this.versionsMap);
       }
-      if (parsed.peerDependencies) {
+      if (parsed.peerDependencies && this.updatePeerDependencies) {
         updateDependencies(parsed.peerDependencies, this.versionsMap);
       }
       if (parsed.optionalDependencies) {

--- a/test/updaters/package-json.ts
+++ b/test/updaters/package-json.ts
@@ -48,6 +48,25 @@ describe('PackageJson', () => {
       const packageJson = new PackageJson({
         version: Version.parse('14.0.0'),
         versionsMap,
+        updatePeerDependencies: true,
+      });
+      const newContent = packageJson.updateContent(oldContent);
+      snapshot(newContent.replace(/\r\n/g, '\n'));
+    });
+
+    it('does not update peer dependencies by default', async () => {
+      const oldContent = readFileSync(
+        resolve(fixturesPath, './package-with-dependencies.json'),
+        'utf8'
+      );
+      const versionsMap: VersionsMap = new Map();
+      versionsMap.set('camelcase', Version.parse('6.0.0'));
+      versionsMap.set('chai', Version.parse('4.2.1'));
+      versionsMap.set('foo', Version.parse('0.1.0'));
+      versionsMap.set('bar', Version.parse('2.3.4'));
+      const packageJson = new PackageJson({
+        version: Version.parse('14.0.0'),
+        versionsMap,
       });
       const newContent = packageJson.updateContent(oldContent);
       snapshot(newContent.replace(/\r\n/g, '\n'));


### PR DESCRIPTION
The "updatePeerDependencies" option currently operates as a "considerPeerDependencies" option. What this means is that if a package only has a peer dependency on another, then that will not be considered and no update will be made (as if there was no dependency). If a package has a peer dependency as well as another dependency, for instance a dev dependency, then the peer dependency is updated regardless.

This propagates the "updatePeerDependencies" option to the PackageJson updater so that it can omit updates to the peer dependencies.

It isn't completely clear what the intended behavior here is. This update behavior matches my current use-case, but it is possible it could be a problem for others. In which case there could be two different options (but the current name does seem like it would impact peer dependency updates.)

Thank you for opening a Pull Request! Before submitting your PR, there are a few things you can do to make sure it goes smoothly:
- [x] Make sure to open an issue as a [bug/issue](https://github.com/googleapis/release-please/issues/new/choose) before writing your code!  That way we can discuss the change, evaluate designs, and agree on the general idea
- [x] Ensure the tests and linter pass
- [x] Code coverage does not decrease (if any source code was changed)
- [na] Appropriate docs were updated (if necessary)

Fixes #2269
 🦕
