### PR TITLE
test: add a test for parsing commit messages with code

### DIFF
--- a/test/commits.ts
+++ b/test/commits.ts
@@ -90,6 +90,18 @@ describe('parseConventionalCommits', () => {
     expect(conventionalCommits[0].references[0].action).to.eql('Fixes');
   });
 
+  it('parse commits with code examples', async () => {
+    const commits = [buildCommitFromFixture('bug-with-code')];
+    const conventionalCommits = parseConventionalCommits(commits);
+    expect(conventionalCommits).lengthOf(1);
+    expect(conventionalCommits[0].type).to.eql('fix');
+    expect(conventionalCommits[0].breaking).to.be.false;
+    expect(conventionalCommits[0].references).lengthOf(1);
+    expect(conventionalCommits[0].references[0].prefix).to.eql('#');
+    expect(conventionalCommits[0].references[0].issue).to.eql('123');
+    expect(conventionalCommits[0].references[0].action).to.eql('Fixes');
+  });
+
   it('captures git trailers', async () => {
     const commits = [buildCommitFromFixture('git-trailers-with-breaking')];
     const conventionalCommits = parseConventionalCommits(commits);

--- a/test/fixtures/commit-messages/bug-with-code.txt
+++ b/test/fixtures/commit-messages/bug-with-code.txt
@@ -1,0 +1,9 @@
+fix: some fix
+
+Example:
+
+```
+page.on('request', (request) => {})
+```
+
+Fixes #123


### PR DESCRIPTION
Issue https://github.com/googleapis/release-please/issues/2272 

The test is currently failing.