### PR TITLE
fix(ci): use correct release-please-action domain after organization url was changed

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -63,7 +63,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
         with:
-          repository: google-github-actions/release-please-action
+          repository: googleapis/release-please-action
           ref: main
       - uses: actions/setup-node@v3
         with:

--- a/README.md
+++ b/README.md
@@ -207,7 +207,7 @@ There are a variety of ways you can deploy release-please:
 
 ### GitHub Action (recommended)
 
-The easiest way to run Release Please is as a GitHub action. Please see [google-github-actions/release-please-action](https://github.com/google-github-actions/release-please-action) for installation and configuration instructions.
+The easiest way to run Release Please is as a GitHub action. Please see [googleapis/release-please-action](https://github.com/googleapis/release-please-action) for installation and configuration instructions.
 
 ### Running as CLI
 

--- a/docs/manifest-releaser.md
+++ b/docs/manifest-releaser.md
@@ -375,7 +375,7 @@ jobs:
   release-please:
     runs-on: ubuntu-latest
     steps:
-      - uses: google-github-actions/release-please-action@v2
+      - uses: googleapis/release-please-action@v2
         id: release
         with:
           command: manifest


### PR DESCRIPTION
See https://github.com/googleapis/release-please-action/issues/980.

- [X] Make sure to open an issue as a [bug/issue](https://github.com/googleapis/release-please/issues/new/choose) before writing your code!  That way we can discuss the change, evaluate designs, and agree on the general idea
- [X] Ensure the tests and linter pass
- [X] Code coverage does not decrease (if any source code was changed)
- [X] Appropriate docs were updated (if necessary)

Fixes #2288 🦕
