### PR TITLE
docs(schemas/config.json): don't require `section` property for `changelog-sections`

### DIFF
--- a/schemas/config.json
+++ b/schemas/config.json
@@ -47,7 +47,7 @@
                 "type": "boolean"
               }
             },
-            "required": ["type", "section"]
+            "required": ["type"]
           }
         },
         "release-as": {


### PR DESCRIPTION
If I'm reading https://github.com/conventional-changelog/conventional-changelog-config-spec/blob/master/versions/2.2.0/README.md#types correctly this shouldn't be a required property. Or maybe I'm just confusing myself 😓 . If something is hidden it doesn't need a section title correct?