### PR TITLE
feat: support BEGIN_VERSION_OVERRIDE in php-yoshi

### DIFF
--- a/src/strategies/php-yoshi.ts
+++ b/src/strategies/php-yoshi.ts
@@ -80,6 +80,15 @@ export class PHPYoshi extends BaseStrategy {
       return undefined;
     }
 
+    const versionOverrides: {[key: string]: string} = {};
+    commits.forEach(commit => {
+      Object.entries(
+        parseVersionOverrides(commit.pullRequest?.body || '')
+      ).forEach(([directory, version]) => {
+        versionOverrides[directory] = version;
+      });
+    });
+
     const newVersion = latestRelease
       ? await this.versioningStrategy.bump(
           latestRelease.tag.version,
@@ -100,7 +109,6 @@ export class PHPYoshi extends BaseStrategy {
           this.addPath(`${directory}/VERSION`),
           this.targetBranch
         );
-        const version = Version.parse(contents.parsedContent);
         const composer = await this.github.getFileJson<ComposerJson>(
           this.addPath(`${directory}/composer.json`),
           this.targetBranch
@@ -109,10 +117,12 @@ export class PHPYoshi extends BaseStrategy {
           versionContents: contents,
           composer,
         };
-        const newVersion = await this.versioningStrategy.bump(
-          version,
-          splitCommits[directory]
-        );
+        const newVersion = versionOverrides[directory]
+          ? Version.parse(versionOverrides[directory])
+          : await this.versioningStrategy.bump(
+              Version.parse(contents.parsedContent),
+              splitCommits[directory]
+            );
         versionsMap.set(composer.name, newVersion);
         const partialReleaseNotes = await this.changelogNotes.buildNotes(
           splitCommits[directory],
@@ -271,6 +281,24 @@ export class PHPYoshi extends BaseStrategy {
 
     return updates;
   }
+}
+
+function parseVersionOverrides(body: string): {[key: string]: string} {
+  // look for 'BEGIN_VERSION_OVERRIDE' section of pull request body
+  const versionOverrides: {[key: string]: string} = {};
+  if (body) {
+    const overrideMessage = (body.split('BEGIN_VERSION_OVERRIDE')[1] || '')
+      .split('END_VERSION_OVERRIDE')[0]
+      .trim();
+    if (overrideMessage) {
+      overrideMessage.split('\n').forEach(line => {
+        const [directory, version] = line.split(':');
+        versionOverrides[directory.trim()] = version.trim();
+      });
+      return versionOverrides;
+    }
+  }
+  return versionOverrides;
 }
 
 function updatePHPChangelogEntry(

--- a/src/strategies/php-yoshi.ts
+++ b/src/strategies/php-yoshi.ts
@@ -295,7 +295,6 @@ function parseVersionOverrides(body: string): {[key: string]: string} {
         const [directory, version] = line.split(':');
         versionOverrides[directory.trim()] = version.trim();
       });
-      return versionOverrides;
     }
   }
   return versionOverrides;

--- a/test/strategies/php-yoshi.ts
+++ b/test/strategies/php-yoshi.ts
@@ -18,7 +18,7 @@ import {GitHub} from '../../src/github';
 import {PHPYoshi} from '../../src/strategies/php-yoshi';
 import * as sinon from 'sinon';
 import {assertHasUpdate, buildGitHubFileRaw, dateSafe} from '../helpers';
-import {buildMockConventionalCommit} from '../helpers';
+import {buildMockConventionalCommit, buildMockCommit} from '../helpers';
 import {TagName} from '../../src/util/tag-name';
 import {Version} from '../../src/version';
 import {Changelog} from '../../src/updaters/changelog';
@@ -29,6 +29,7 @@ import snapshot = require('snap-shot-it');
 import {readFileSync} from 'fs';
 import {resolve} from 'path';
 import {FileNotFoundError} from '../../src/errors';
+import {parseConventionalCommits} from '../../src/commit';
 
 const sandbox = sinon.createSandbox();
 
@@ -238,6 +239,34 @@ describe('PHPYoshi', () => {
         '{"name":"google/client1","version":"1.2.3"}'
       );
       expect(newContent).to.eql('{"name":"google/client1","version":"1.2.4"}');
+    });
+    it('can override the version from BEGIN_VERSION_OVERRIDE body', async () => {
+      const commit = buildMockCommit('chore: some commit');
+      const body =
+        'BEGIN_VERSION_OVERRIDE\nClient1: 1.3.0\nClient2: 2.0.0-RC1\nEND_VERSION_OVERRIDE';
+      commit.pullRequest = {
+        headBranchName: 'fix-something',
+        baseBranchName: 'main',
+        number: 123,
+        title: 'chore: some commit',
+        labels: [],
+        files: [],
+        body,
+      };
+      // Add a commit with a version override
+      commits.push(...parseConventionalCommits([commit]));
+
+      const strategy = new PHPYoshi({
+        targetBranch: 'main',
+        github,
+      });
+
+      const release = await strategy.buildReleasePullRequest(commits);
+      const updates = release!.updates;
+      const client1Version = assertHasUpdate(updates, 'Client1/VERSION');
+      const client2Version = assertHasUpdate(updates, 'Client2/VERSION');
+      expect(client1Version.updater.updateContent('')).to.eql('1.3.0\n');
+      expect(client2Version.updater.updateContent('')).to.eql('2.0.0-RC1\n');
     });
   });
   describe('buildRelease', () => {


### PR DESCRIPTION
Allow for adding `BEGIN_VERSION_OVERRIDE` to PHP release in order to override the release version from the PR for specific components. 

Example PR body:

```
// normal PR body (from owlbot or otherwise)

// at the end of the PR

BEGIN_VERSION_OVERRIDE
PubSub: 2.0.0-RC1
Core: 1.45.0
END_VERSION_OVERRIDE
```

