### PR TITLE
fix: respect signoff in manifest config

### DIFF
--- a/schemas/config.json
+++ b/schemas/config.json
@@ -377,6 +377,10 @@
             ]
           }
         },
+        "signoff": {
+          "description": "Text to be used as Signed-off-by in the commit.",
+          "type": "string"
+        },
         "group-pull-request-title-pattern": {
           "description": "When grouping multiple release pull requests use this pattern for the title.",
           "type": "string"
@@ -412,6 +416,7 @@
     "last-release-sha": true,
     "always-link-local": true,
     "plugins": true,
+    "signoff": true,
     "group-pull-request-title-pattern": true,
     "release-search-depth": true,
     "commit-search-depth": true,

--- a/src/manifest.ts
+++ b/src/manifest.ts
@@ -121,7 +121,6 @@ export interface ReleaserConfig {
   releaseLabels?: string[];
   extraLabels?: string[];
   initialVersion?: string;
-  signoff?: string;
 
   // Changelog options
   changelogSections?: ChangelogSection[];
@@ -161,7 +160,6 @@ interface ReleaserConfigJson {
   'changelog-sections'?: ChangelogSection[];
   'release-as'?: string;
   'skip-github-release'?: boolean;
-  signoff?: string;
   draft?: boolean;
   prerelease?: boolean;
   'draft-pull-request'?: boolean;
@@ -255,6 +253,7 @@ export interface ManifestConfig extends ReleaserConfigJson {
   'last-release-sha'?: string;
   'always-link-local'?: boolean;
   plugins?: PluginType[];
+  signoff?: string;
   'group-pull-request-title-pattern'?: string;
   'release-search-depth'?: number;
   'commit-search-depth'?: number;
@@ -1372,7 +1371,6 @@ function extractReleaserConfig(
     skipSnapshot: config['skip-snapshot'],
     initialVersion: config['initial-version'],
     excludePaths: config['exclude-paths'],
-    signoff: config['signoff'],
   };
 }
 
@@ -1417,6 +1415,7 @@ async function parseConfig(
     separatePullRequests: config['separate-pull-requests'],
     groupPullRequestTitlePattern: config['group-pull-request-title-pattern'],
     plugins: config['plugins'],
+    signoff: config['signoff'],
     labels: configLabel?.split(','),
     releaseLabels: configReleaseLabel?.split(','),
     snapshotLabels: configSnapshotLabel?.split(','),


### PR DESCRIPTION
Thank you for opening a Pull Request! Before submitting your PR, there are a few things you can do to make sure it goes smoothly:
- [x] Make sure to open an issue as a [bug/issue](https://github.com/googleapis/release-please/issues/new/choose) before writing your code!  That way we can discuss the change, evaluate designs, and agree on the general idea
- [x] Ensure the tests and linter pass
- [x] Code coverage does not decrease (if any source code was changed)
- [x] Appropriate docs were updated (if necessary)

Fixes #2333 and #2280 🦕

Changes the implementation of #2246 since signoff is only applicapbe to root in manifest config.

Output of debug-config after PR
```
...
separatePullRequests: true,
fork: false,
signoffUser: 'foo <foo@users.noreply.github.com>',
releaseLabels: [ 'autorelease: tagged' ],
labels: [ 'autorelease: pending' ],
...
```
