### PR TITLE
feat: add additional-paths property to manifest releaser

### DIFF
--- a/__snapshots__/cli.js
+++ b/__snapshots__/cli.js
@@ -190,7 +190,7 @@ Options:
                                     the first major release
                                                       [boolean] [default: false]
   --prerelease-type                 type of the prerelease, e.g., alpha [string]
-  --extra-files                     extra files for the strategy to consider
+  --extra-files                     extra files for the strategy to update
                                                                         [string]
   --version-file                    path to version file to update, e.g.,
                                     version.rb                          [string]

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -64,7 +64,7 @@ Extra options:
 | `--pull-request-title-pattern` | `string` | Override the pull request title pattern. Defaults to `chore${scope}: release${component} ${version}` |
 | `--pull-request-header` | `string` | Override the pull request header. Defaults to `:robot: I have created a release *beep* *boop*` |
 | `--pull-request-footer` | `string` | Override the pull request footer. Defaults to `This PR was generated with Release Please. See documentation.` |
-| `--extra-files` | `string[]` | Extra file paths for the release strategy to consider |
+| `--extra-files` | `string[]` | Extra file paths for the release strategy to update |
 | `--version-file` | `string` | Ruby only. Path to the `version.rb` file |
 
 ## Creating/updating release PRs
@@ -115,7 +115,7 @@ need to specify your release options:
 | `--pull-request-header` | `string` | Override the pull request header. Defaults to `:robot: I have created a release *beep* *boop*` |
 | `--pull-request-footer` | `string` | Override the pull request footer. Defaults to `This PR was generated with Release Please. See documentation.` |
 | `--signoff` | string | Add [`Signed-off-by`](https://git-scm.com/docs/git-commit#Documentation/git-commit.txt---signoff) line at the end of the commit log message using the user and email provided. (format "Name \<email@example.com\>") |
-| `--extra-files` | `string[]` | Extra file paths for the release strategy to consider |
+| `--extra-files` | `string[]` | Extra file paths for the release strategy to update |
 | `--version-file` | `string` | Ruby only. Path to the `version.rb` file |
 | `--skip-labeling` | `boolean` | If set, labels will not be applied to pull requests |
 | `--include-v-in-tags` | `boolean` | Include "v" in tag versions. Defaults to `true`. |

--- a/docs/manifest-releaser.md
+++ b/docs/manifest-releaser.md
@@ -267,6 +267,8 @@ defaults (those are documented in comments)
       "release-type": "node",
       // exclude commits from that path from processing
       "exclude-paths": ["path/to/myPyPkgA"]
+      // include commits from that path in processing
+      "additional-paths": ["path/to/externalPkgB"]
     },
 
     // path segment should be relative to repository root

--- a/schemas/config.json
+++ b/schemas/config.json
@@ -199,6 +199,13 @@
             "type": "string"
           }
         },
+        "additional-paths": {
+          "description": "Path of commits, from outside the package, to be included in parsing.",
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
         "version-file": {
           "description": "Path to the specialize version file. Used by `ruby` and `simple` strategies.",
           "type": "string"
@@ -443,6 +450,7 @@
     "version-file": true,
     "snapshot-label": true,
     "initial-version": true,
-    "exclude-paths": true
+    "exclude-paths": true,
+    "additional-paths": true
   }
 }

--- a/src/bin/release-please.ts
+++ b/src/bin/release-please.ts
@@ -282,7 +282,7 @@ function pullRequestStrategyOptions(yargs: yargs.Argv): yargs.Argv {
       type: 'string',
     })
     .option('extra-files', {
-      describe: 'extra files for the strategy to consider',
+      describe: 'extra files for the strategy to update',
       type: 'string',
       coerce(arg?: string) {
         if (arg) {

--- a/src/manifest.ts
+++ b/src/manifest.ts
@@ -137,6 +137,7 @@ export interface ReleaserConfig {
   skipSnapshot?: boolean;
   // Manifest only
   excludePaths?: string[];
+  additionalPaths?: string[];
 }
 
 export interface CandidateReleasePullRequest {
@@ -183,6 +184,7 @@ interface ReleaserConfigJson {
   'skip-snapshot'?: boolean; // Java-only
   'initial-version'?: string;
   'exclude-paths'?: string[]; // manifest-only
+  'additional-paths'?: string[]; // manifest-only
 }
 
 export interface ManifestOptions {
@@ -1372,6 +1374,7 @@ function extractReleaserConfig(
     skipSnapshot: config['skip-snapshot'],
     initialVersion: config['initial-version'],
     excludePaths: config['exclude-paths'],
+    additionalPaths: config['additional-paths'],
     signoff: config['signoff'],
   };
 }
@@ -1727,6 +1730,8 @@ function mergeReleaserConfig(
     initialVersion: pathConfig.initialVersion ?? defaultConfig.initialVersion,
     extraLabels: pathConfig.extraLabels ?? defaultConfig.extraLabels,
     excludePaths: pathConfig.excludePaths ?? defaultConfig.excludePaths,
+    additionalPaths:
+      pathConfig.additionalPaths ?? defaultConfig.additionalPaths,
   };
 }
 

--- a/src/manifest.ts
+++ b/src/manifest.ts
@@ -660,7 +660,12 @@ export class Manifest {
     this.logger.info(`Splitting ${commits.length} commits by path`);
     const cs = new CommitSplit({
       includeEmpty: true,
-      packagePaths: Object.keys(this.repositoryConfig),
+      packagePaths: Object.fromEntries(
+        Object.entries(this.repositoryConfig).map(([path, config]) => [
+          path,
+          config.additionalPaths || [],
+        ])
+      ),
     });
     const splitCommits = cs.split(commits);
 

--- a/src/util/commit-split.ts
+++ b/src/util/commit-split.ts
@@ -14,7 +14,7 @@
 
 import {Commit} from '../commit';
 import {ROOT_PROJECT_PATH} from '../manifest';
-import {normalizePaths} from './commit-utils';
+import {normalizePath, normalizePaths} from './commit-utils';
 
 export interface CommitSplitOptions {
   // Include empty git commits: each empty commit is included
@@ -58,7 +58,7 @@ export class CommitSplit {
       this.packagePaths = Object.fromEntries(
         Object.entries(opts.packagePaths)
           .map(([path, additionalPaths]) => [
-            normalizePaths([path]).pop(),
+            normalizePath(path),
             normalizePaths(additionalPaths),
           ])
           .filter(([path]) => {

--- a/src/util/commit-utils.ts
+++ b/src/util/commit-utils.ts
@@ -13,18 +13,20 @@
 // limitations under the License.
 
 export const normalizePaths = (paths: string[]) => {
-  return paths.map(path => {
-    // normalize so that all paths have leading and trailing slashes for
-    // non-overlap validation.
-    // NOTE: GitHub API always returns paths using the `/` separator,
-    // regardless of what platform the client code is running on
-    let newPath = path.replace(/\/$/, '');
-    newPath = newPath.replace(/^\//, '');
-    newPath = newPath.replace(/$/, '/');
-    newPath = newPath.replace(/^/, '/');
-    // store them with leading and trailing slashes removed.
-    newPath = newPath.replace(/\/$/, '');
-    newPath = newPath.replace(/^\//, '');
-    return newPath;
-  });
+  return paths.map(normalizePath);
+};
+
+export const normalizePath = (path: string) => {
+  // normalize so that all paths have leading and trailing slashes for
+  // non-overlap validation.
+  // NOTE: GitHub API always returns paths using the `/` separator,
+  // regardless of what platform the client code is running on
+  let newPath = path.replace(/\/$/, '');
+  newPath = newPath.replace(/^\//, '');
+  newPath = newPath.replace(/$/, '/');
+  newPath = newPath.replace(/^/, '/');
+  // store them with leading and trailing slashes removed.
+  newPath = newPath.replace(/\/$/, '');
+  newPath = newPath.replace(/^\//, '');
+  return newPath;
 };

--- a/test/fixtures/manifest/config/additional-paths.json
+++ b/test/fixtures/manifest/config/additional-paths.json
@@ -1,0 +1,8 @@
+{
+  "release-type": "simple",
+  "packages": {
+    "apps/my-app": {
+      "additional-paths": ["libs/my-lib"]
+    }
+  }
+}

--- a/test/manifest.ts
+++ b/test/manifest.ts
@@ -3547,6 +3547,59 @@ describe('Manifest', () => {
         );
       });
     });
+
+    it('should update manifest for commits in additionalPaths', async () => {
+      mockReleases(sandbox, github, []);
+      mockTags(sandbox, github, [
+        {
+          name: 'apps-myapp-v1.0.0',
+          sha: 'abc123',
+        },
+      ]);
+      mockCommits(sandbox, github, [
+        {
+          sha: 'aaaaaa',
+          message: 'fix: my-lib bugfix',
+          files: ['libs/my-lib/test.txt'],
+        },
+        {
+          sha: 'abc123',
+          message: 'chore: release main',
+          files: [],
+          pullRequest: {
+            headBranchName: 'release-please/branches/main/components/myapp',
+            baseBranchName: 'main',
+            number: 123,
+            title: 'chore: release main',
+            body: '',
+            labels: [],
+            files: [],
+            sha: 'abc123',
+          },
+        },
+      ]);
+      const manifest = new Manifest(
+        github,
+        'main',
+        {
+          'apps/my-app': {
+            releaseType: 'simple',
+            component: 'myapp',
+            additionalPaths: ['libs/my-lib'],
+          },
+        },
+        {
+          'apps/my-app': Version.parse('1.0.0'),
+        }
+      );
+      const pullRequests = await manifest.buildPullRequests();
+      expect(pullRequests).lengthOf(1);
+      const pullRequest = pullRequests[0];
+      expect(pullRequest.version?.toString()).to.eql('1.0.1');
+      expect(pullRequest.headRefName).to.eql(
+        'release-please--branches--main--components--myapp'
+      );
+    });
   });
 
   describe('createPullRequests', () => {

--- a/test/manifest.ts
+++ b/test/manifest.ts
@@ -535,6 +535,34 @@ describe('Manifest', () => {
         'path-ignore',
       ]);
     });
+    it('should read additional paths from manifest', async () => {
+      const getFileContentsStub = sandbox.stub(
+        github,
+        'getFileContentsOnBranch'
+      );
+      getFileContentsStub
+        .withArgs('release-please-config.json', 'main')
+        .resolves(
+          buildGitHubFileContent(
+            fixturesPath,
+            'manifest/config/additional-paths.json'
+          )
+        )
+        .withArgs('.release-please-manifest.json', 'main')
+        .resolves(
+          buildGitHubFileContent(
+            fixturesPath,
+            'manifest/versions/versions.json'
+          )
+        );
+      const manifest = await Manifest.fromManifest(
+        github,
+        github.repository.defaultBranch
+      );
+      expect(
+        manifest.repositoryConfig['apps/my-app'].additionalPaths
+      ).to.deep.equal(['libs/my-lib']);
+    });
     it('should build simple plugins from manifest', async () => {
       const getFileContentsStub = sandbox.stub(
         github,

--- a/test/util/commit-split.ts
+++ b/test/util/commit-split.ts
@@ -46,7 +46,7 @@ describe('CommitSplit', () => {
   });
   it('uses path prefixes', () => {
     const commitSplit = new CommitSplit({
-      packagePaths: ['pkg5', 'pkg6/pkg5'],
+      packagePaths: {pkg5: [], 'pkg6/pkg5': []},
     });
     const splitCommits = commitSplit.split(commits);
     expect(splitCommits['pkg1']).to.be.undefined;
@@ -70,7 +70,7 @@ describe('CommitSplit', () => {
       },
     ];
     const commitSplit = new CommitSplit({
-      packagePaths: ['core', 'core/subpackage'],
+      packagePaths: {core: [], 'core/subpackage': []},
     });
     const splitCommits = commitSplit.split(commits);
     expect(splitCommits['core']).lengthOf(1);
@@ -90,7 +90,7 @@ describe('CommitSplit', () => {
     it('should separate commits with limited list of paths', () => {
       const commitSplit = new CommitSplit({
         includeEmpty: true,
-        packagePaths: ['pkg1', 'pkg4'],
+        packagePaths: {pkg1: [], pkg4: []},
       });
       const splitCommits = commitSplit.split(commits);
       expect(splitCommits['pkg1']).lengthOf(3);
@@ -114,7 +114,7 @@ describe('CommitSplit', () => {
     it('should separate commits with limited list of paths', () => {
       const commitSplit = new CommitSplit({
         includeEmpty: false,
-        packagePaths: ['pkg1', 'pkg4'],
+        packagePaths: {pkg1: [], pkg4: []},
       });
       const splitCommits = commitSplit.split(commits);
       expect(splitCommits['pkg1']).lengthOf(2);


### PR DESCRIPTION
Thank you for opening a Pull Request! Before submitting your PR, there are a few things you can do to make sure it goes smoothly:
- [x] Make sure to open an issue as a [bug/issue](https://github.com/googleapis/release-please/issues/new/choose) before writing your code!  That way we can discuss the change, evaluate designs, and agree on the general idea
- [x] Ensure the tests and linter pass
- [x] Code coverage does not decrease (if any source code was changed)
- [x] Appropriate docs were updated (if necessary)

Fixes #1921 🦕

---

This PR adds an `additional-paths` property to the manifest releaser.

Additional paths are useful for monorepos where a package might depend files from other directories.

For example, if we want to trigger a release in `apps/my-app-2` when commits are found in `libs/my-lib`:

```
apps/
    my-app-1
    my-app-2
libs/
    my-lib
```

```jsonc
{
  "packages": {
    "apps/my-app-1": {},
    "apps/my-app-2": {
      "additional-paths": ["libs/my-lib"] // additional-paths would be a new config option
    }
  }
}
```

Best reviewed commit-by-commit.