### PR TITLE
fix: don't escape html tags inside of inline code in release notes

### DIFF
--- a/__snapshots__/default-changelog-notes.js
+++ b/__snapshots__/default-changelog-notes.js
@@ -153,6 +153,15 @@ exports['DefaultChangelogNotes buildNotes with commit parsing should handle html
 * render all imagesets as &lt;picture&gt; ([383fb14](https://github.com/googleapis/java-asset/commit/383fb14708ae91f7bb7e64bf0bacab38))
 `
 
+exports['DefaultChangelogNotes buildNotes with commit parsing should handle html tags as inline code 1'] = `
+## [1.2.3](https://github.com/googleapis/java-asset/compare/v1.2.2...v1.2.3) (1983-10-10)
+
+
+### Features
+
+* render all imagesets as &lt;picture&gt; \`<picture>\` \`\` \`<picture>\` \`\` ([82fcfaf](https://github.com/googleapis/java-asset/commit/82fcfaf039487566a6e2d49a215afe09))
+`
+
 exports['DefaultChangelogNotes buildNotes with commit parsing should handle inline bug links 1'] = `
 ## [1.2.3](https://github.com/googleapis/java-asset/compare/v1.2.2...v1.2.3) (1983-10-10)
 

--- a/src/changelog-notes/default.ts
+++ b/src/changelog-notes/default.ts
@@ -123,5 +123,7 @@ function replaceIssueLink(
 }
 
 function htmlEscape(message: string): string {
-  return message.replace('<', '&lt;').replace('>', '&gt;');
+  return message.replace(/``[^`].*[^`]``|`[^`]*`|<|>/g, match =>
+    match.length > 1 ? match : match === '<' ? '&lt;' : '&gt;'
+  );
 }

--- a/test/changelog-notes/default-changelog-notes.ts
+++ b/test/changelog-notes/default-changelog-notes.ts
@@ -276,6 +276,20 @@ describe('DefaultChangelogNotes', () => {
         expect(notes).to.is.string;
         safeSnapshot(notes);
       });
+      it('should handle html tags as inline code', async () => {
+        const commits = [
+          buildMockCommit(
+            'feat: render all imagesets as <picture> `<picture>` `` `<picture>` ``'
+          ),
+        ];
+        const changelogNotes = new DefaultChangelogNotes();
+        const notes = await changelogNotes.buildNotes(
+          parseConventionalCommits(commits),
+          notesOptions
+        );
+        expect(notes).to.is.string;
+        safeSnapshot(notes);
+      });
       // it('ignores reverted commits', async () => {
       //   const commits = [buildCommitFromFixture('multiple-messages')];
       //   const changelogNotes = new DefaultChangelogNotes();


### PR DESCRIPTION
This makes sure to only escape HTML tags that are not within inline code blocks as these are handled explicitly and not rendered the same way they are outside of code blocks.

Fixes #2366  🦕

Example, a commit such as the following:

```
feat: render all imagesets as <picture> `<picture>` `` `<picture>` ``
```

would render as the following markdown:

render all imagesets as &lt;picture&gt; `<picture>` `` `<picture>` ``
