### PR TITLE
fix: when parsing multiple messages from a single commit, require 2 newlines

### DIFF
--- a/src/commit.ts
+++ b/src/commit.ts
@@ -389,7 +389,7 @@ function splitMessages(message: string): string[] {
 
   const conventionalCommits = messages[0]
     .split(
-      /\n(?=(?:feat|fix|docs|style|refactor|perf|test|build|ci|chore|revert)(?:\(.*?\))?: )/
+      /\n\n(?=(?:feat|fix|docs|style|refactor|perf|test|build|ci|chore|revert)(?:\(.*?\))?: )/
     )
     .filter(Boolean);
   return [...conventionalCommits, ...messages.slice(1)];

--- a/test/commits.ts
+++ b/test/commits.ts
@@ -57,6 +57,14 @@ describe('parseConventionalCommits', () => {
     expect(conventionalCommits[1].scope).is.null;
   });
 
+  it('can parse multiple commits skipping line breaks', async () => {
+    const commits = [buildCommitFromFixture('dependabot')];
+    const conventionalCommits = parseConventionalCommits(commits);
+    expect(conventionalCommits).lengthOf(1);
+    expect(conventionalCommits[0].type).to.equal('fix');
+    expect(conventionalCommits[0].scope).is.null;
+  });
+
   it('handles BREAKING CHANGE body', async () => {
     const commits = [buildCommitFromFixture('breaking-body')];
     const conventionalCommits = parseConventionalCommits(commits);

--- a/test/fixtures/commit-messages/dependabot.txt
+++ b/test/fixtures/commit-messages/dependabot.txt
@@ -1,0 +1,102 @@
+fix: bump release-please from 16.13.0 to 16.14.0 (#1032)
+
+Bumps [release-please](https://github.com/googleapis/release-please)
+from 16.13.0 to 16.14.0.
+<details>
+<summary>Release notes</summary>
+<p><em>Sourced from <a
+href="https://github.com/googleapis/release-please/releases">release-please's
+releases</a>.</em></p>
+<blockquote>
+<h2>v16.14.0</h2>
+<h2><a
+href="https://github.com/googleapis/release-please/compare/v16.13.0...v16.14.0">16.14.0</a>
+(2024-09-17)</h2>
+<h3>Features</h3>
+<ul>
+<li>handle multiple commits in a single message (<a
+href="https://redirect.github.com/googleapis/release-please/issues/2358">#2358</a>)
+(<a
+href="https://github.com/googleapis/release-please/commit/ec41c38422fc23c6671f4ee7e4f09e9e120ab751">ec41c38</a>)</li>
+</ul>
+</blockquote>
+</details>
+<details>
+<summary>Changelog</summary>
+<p><em>Sourced from <a
+href="https://github.com/googleapis/release-please/blob/main/CHANGELOG.md">release-please's
+changelog</a>.</em></p>
+<blockquote>
+<h2><a
+href="https://github.com/googleapis/release-please/compare/v16.13.0...v16.14.0">16.14.0</a>
+(2024-09-17)</h2>
+<h3>Features</h3>
+<ul>
+<li>handle multiple commits in a single message (<a
+href="https://redirect.github.com/googleapis/release-please/issues/2358">#2358</a>)
+(<a
+href="https://github.com/googleapis/release-please/commit/ec41c38422fc23c6671f4ee7e4f09e9e120ab751">ec41c38</a>)</li>
+</ul>
+</blockquote>
+</details>
+<details>
+<summary>Commits</summary>
+<ul>
+<li><a
+href="https://github.com/googleapis/release-please/commit/288949797c6bfd95e08d74a6222e7d26e0020a7c"><code>2889497</code></a>
+chore(main): release 16.14.0 (<a
+href="https://redirect.github.com/googleapis/release-please/issues/2383">#2383</a>)</li>
+<li><a
+href="https://github.com/googleapis/release-please/commit/ec41c38422fc23c6671f4ee7e4f09e9e120ab751"><code>ec41c38</code></a>
+feat: handle multiple commits in a single message (<a
+href="https://redirect.github.com/googleapis/release-please/issues/2358">#2358</a>)</li>
+<li>See full diff in <a
+href="https://github.com/googleapis/release-please/compare/v16.13.0...v16.14.0">compare
+view</a></li>
+</ul>
+</details>
+<br />
+
+
+[![Dependabot compatibility
+score](https://dependabot-badges.githubapp.com/badges/compatibility_score?dependency-name=release-please&package-manager=npm_and_yarn&previous-version=16.13.0&new-version=16.14.0)](https://docs.github.com/en/github/managing-security-vulnerabilities/about-dependabot-security-updates#about-compatibility-scores)
+
+Dependabot will resolve any conflicts with this PR as long as you don't
+alter it yourself. You can also trigger a rebase manually by commenting
+`@dependabot rebase`.
+
+[//]: # (dependabot-automerge-start)
+[//]: # (dependabot-automerge-end)
+
+---
+
+<details>
+<summary>Dependabot commands and options</summary>
+<br />
+
+You can trigger Dependabot actions by commenting on this PR:
+- `@dependabot rebase` will rebase this PR
+- `@dependabot recreate` will recreate this PR, overwriting any edits
+that have been made to it
+- `@dependabot merge` will merge this PR after your CI passes on it
+- `@dependabot squash and merge` will squash and merge this PR after
+your CI passes on it
+- `@dependabot cancel merge` will cancel a previously requested merge
+and block automerging
+- `@dependabot reopen` will reopen this PR if it is closed
+- `@dependabot close` will close this PR and stop Dependabot recreating
+it. You can achieve the same result by closing it manually
+- `@dependabot show <dependency name> ignore conditions` will show all
+of the ignore conditions of the specified dependency
+- `@dependabot ignore this major version` will close this PR and stop
+Dependabot creating any more for this major version (unless you reopen
+the PR or upgrade to it yourself)
+- `@dependabot ignore this minor version` will close this PR and stop
+Dependabot creating any more for this minor version (unless you reopen
+the PR or upgrade to it yourself)
+- `@dependabot ignore this dependency` will close this PR and stop
+Dependabot creating any more for this dependency (unless you reopen the
+PR or upgrade to it yourself)
+
+
+</details>


### PR DESCRIPTION
Without this, we parse inadvertent commit messages from commits like dependabot [example](https://github.com/googleapis/release-please-action/commit/b2a986c7e2f041e21005c546b2e03e9722e45bad)
