### PR TITLE
fix: dart pubspec updater with prerelease

### DIFF
--- a/__snapshots__/pubspec-yaml.js
+++ b/__snapshots__/pubspec-yaml.js
@@ -1,16 +1,4 @@
-exports['PubspecYaml updateContent leaves malformatted build numbers alone in pubspec.yaml file 1'] = `
-name: hello_world
-description: Hello World
-publish_to: 'none' # Remove this line if you wish to publish to pub.dev
-
-version: 0.6.0+abc
-
-environment:
-  sdk: '>=2.12.0 <3.0.0'
-
-`
-
-exports['PubspecYaml updateContent updates version in pubspec.yaml file 1'] = `
+exports['PubspecYaml updateContent updates version in ./pubspec.yaml 1'] = `
 name: hello_world
 description: Hello World
 publish_to: 'none' # Remove this line if you wish to publish to pub.dev
@@ -22,12 +10,60 @@ environment:
 
 `
 
-exports['PubspecYaml updateContent updates version with build number in pubspec.yaml file 1'] = `
+exports['PubspecYaml updateContent updates version in ./pubspec_with_build_no.yaml 1'] = `
 name: hello_world
 description: Hello World
 publish_to: 'none' # Remove this line if you wish to publish to pub.dev
 
 version: 0.6.0+13
+
+environment:
+  sdk: '>=2.12.0 <3.0.0'
+
+`
+
+exports['PubspecYaml updateContent updates version in ./pubspec_with_build_no_bad.yaml 1'] = `
+name: hello_world
+description: Hello World
+publish_to: 'none' # Remove this line if you wish to publish to pub.dev
+
+version: 0.6.0+abc
+
+environment:
+  sdk: '>=2.12.0 <3.0.0'
+
+`
+
+exports['PubspecYaml updateContent updates version in ./pubspec_with_prerelease.yaml 1'] = `
+name: hello_world
+description: Hello World
+publish_to: 'none' # Remove this line if you wish to publish to pub.dev
+
+version: 0.5.0-dev02
+
+environment:
+  sdk: '>=2.12.0 <3.0.0'
+
+`
+
+exports['PubspecYaml updateContent updates version in ./pubspec_with_prerelease_and_build_no.yaml 1'] = `
+name: hello_world
+description: Hello World
+publish_to: 'none' # Remove this line if you wish to publish to pub.dev
+
+version: 0.5.0-dev02+13
+
+environment:
+  sdk: '>=2.12.0 <3.0.0'
+
+`
+
+exports['PubspecYaml updateContent updates version in ./pubspec_with_prerelease_and_build_no_bad.yaml 1'] = `
+name: hello_world
+description: Hello World
+publish_to: 'none' # Remove this line if you wish to publish to pub.dev
+
+version: 0.5.0-dev02+abc
 
 environment:
   sdk: '>=2.12.0 <3.0.0'

--- a/src/updaters/dart/pubspec-yaml.ts
+++ b/src/updaters/dart/pubspec-yaml.ts
@@ -26,11 +26,14 @@ export class PubspecYaml extends DefaultUpdater {
    */
 
   updateContent(content: string, logger: Logger = defaultLogger): string {
-    const oldVersion = content.match(/^version: ([0-9.]+)\+?(.*$)/m);
+    // https://semver.org/#is-there-a-suggested-regular-expression-regex-to-check-a-semver-string
+    const oldVersion = content.match(
+      /^version: ((?:0|[1-9]\d*)\.(?:0|[1-9]\d*)\.(?:0|[1-9]\d*)(?:-(?:(?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*)(?:\.(?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*))*))?)(?:\+([0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?$/m
+    );
     let buildNumber = '';
 
     if (oldVersion) {
-      buildNumber = oldVersion[2];
+      buildNumber = oldVersion[2] || '';
       const parsedBuild = parseInt(buildNumber);
       if (!isNaN(parsedBuild)) {
         buildNumber = `+${parsedBuild + 1}`;

--- a/test/updaters/fixtures/pubspec_with_prerelease.yaml
+++ b/test/updaters/fixtures/pubspec_with_prerelease.yaml
@@ -1,0 +1,8 @@
+name: hello_world
+description: Hello World
+publish_to: 'none' # Remove this line if you wish to publish to pub.dev
+
+version: 0.5.0-dev01
+
+environment:
+  sdk: '>=2.12.0 <3.0.0'

--- a/test/updaters/fixtures/pubspec_with_prerelease_and_build_no.yaml
+++ b/test/updaters/fixtures/pubspec_with_prerelease_and_build_no.yaml
@@ -1,0 +1,8 @@
+name: hello_world
+description: Hello World
+publish_to: 'none' # Remove this line if you wish to publish to pub.dev
+
+version: 0.5.0-dev01+12
+
+environment:
+  sdk: '>=2.12.0 <3.0.0'

--- a/test/updaters/fixtures/pubspec_with_prerelease_and_build_no_bad.yaml
+++ b/test/updaters/fixtures/pubspec_with_prerelease_and_build_no_bad.yaml
@@ -1,0 +1,8 @@
+name: hello_world
+description: Hello World
+publish_to: 'none' # Remove this line if you wish to publish to pub.dev
+
+version: 0.5.0-dev01+abc
+
+environment:
+  sdk: '>=2.12.0 <3.0.0'

--- a/test/updaters/pubspec-yaml.ts
+++ b/test/updaters/pubspec-yaml.ts
@@ -21,42 +21,40 @@ import {Version} from '../../src/version';
 
 const fixturesPath = './test/updaters/fixtures';
 
+interface TestCase {
+  filePath: string;
+  versionString: string;
+}
+
+const testCases: TestCase[] = [
+  {filePath: './pubspec.yaml', versionString: '0.6.0'},
+  {filePath: './pubspec_with_build_no.yaml', versionString: '0.6.0'},
+  {filePath: './pubspec_with_build_no_bad.yaml', versionString: '0.6.0'},
+  {filePath: './pubspec_with_prerelease.yaml', versionString: '0.5.0-dev02'},
+  {
+    filePath: './pubspec_with_prerelease_and_build_no.yaml',
+    versionString: '0.5.0-dev02',
+  },
+  {
+    filePath: './pubspec_with_prerelease_and_build_no_bad.yaml',
+    versionString: '0.5.0-dev02',
+  },
+];
+
 describe('PubspecYaml', () => {
   describe('updateContent', () => {
-    it('updates version in pubspec.yaml file', async () => {
-      const oldContent = readFileSync(
-        resolve(fixturesPath, './pubspec.yaml'),
-        'utf8'
-      ).replace(/\r\n/g, '\n'); // required for windows
-      const version = new PubspecYaml({
-        version: Version.parse('0.6.0'),
+    testCases.forEach(({filePath, versionString}) => {
+      it(`updates version in ${filePath}`, async () => {
+        const oldContent = readFileSync(
+          resolve(fixturesPath, filePath),
+          'utf8'
+        ).replace(/\r\n/g, '\n'); // required for windows
+        const version = new PubspecYaml({
+          version: Version.parse(versionString),
+        });
+        const newContent = version.updateContent(oldContent);
+        snapshot(newContent);
       });
-      const newContent = version.updateContent(oldContent);
-      snapshot(newContent);
-    });
-
-    it('updates version with build number in pubspec.yaml file', async () => {
-      const oldContent = readFileSync(
-        resolve(fixturesPath, './pubspec_with_build_no.yaml'),
-        'utf8'
-      ).replace(/\r\n/g, '\n'); // required for windows
-      const version = new PubspecYaml({
-        version: Version.parse('0.6.0'),
-      });
-      const newContent = version.updateContent(oldContent);
-      snapshot(newContent);
-    });
-
-    it('leaves malformatted build numbers alone in pubspec.yaml file', async () => {
-      const oldContent = readFileSync(
-        resolve(fixturesPath, './pubspec_with_build_no_bad.yaml'),
-        'utf8'
-      ).replace(/\r\n/g, '\n'); // required for windows
-      const version = new PubspecYaml({
-        version: Version.parse('0.6.0'),
-      });
-      const newContent = version.updateContent(oldContent);
-      snapshot(newContent);
     });
   });
 });


### PR DESCRIPTION
Dart pubspec updater supports versions which includes prerelease version.

Thank you for opening a Pull Request! Before submitting your PR, there are a few things you can do to make sure it goes smoothly:
- [x] Make sure to open an issue as a [bug/issue](https://github.com/googleapis/release-please/issues/new/choose) before writing your code!  That way we can discuss the change, evaluate designs, and agree on the general idea
- [x] Ensure the tests and linter pass
- [x] Code coverage does not decrease (if any source code was changed)
- [x] Appropriate docs were updated (if necessary)

Fixes #2400 🦕
