### PR TITLE
feat(python): read version-file from manifest

### DIFF
--- a/src/strategies/base.ts
+++ b/src/strategies/base.ts
@@ -120,6 +120,7 @@ export abstract class BaseStrategy implements Strategy {
   readonly componentNoSpace?: boolean;
   readonly extraFiles: ExtraFile[];
   readonly extraLabels: string[];
+  readonly versionFile?: string;
   protected dateFormat: string;
   protected includeCommitAuthors?: boolean;
 
@@ -159,6 +160,7 @@ export abstract class BaseStrategy implements Strategy {
     this.extraFiles = options.extraFiles || [];
     this.initialVersion = options.initialVersion;
     this.extraLabels = options.extraLabels || [];
+    this.versionFile = options.versionFile;
     this.dateFormat = options.dateFormat || DEFAULT_DATE_FORMAT;
     this.includeCommitAuthors = options.includeCommitAuthors;
   }

--- a/src/strategies/python.ts
+++ b/src/strategies/python.ts
@@ -106,7 +106,15 @@ export class Python extends BaseStrategy {
     if (!projectName) {
       this.logger.warn('No project/component found.');
     } else {
-      [projectName, projectName.replace(/-/g, '_')]
+      if (this.versionFile) {
+        const versionFilePath = this.addPath(this.versionFile);
+        updates.push({
+          path: versionFilePath,
+          createIfMissing: true,
+          updater: new PythonFileWithVersion({version}),
+        });
+      } else {
+        [projectName, projectName.replace(/-/g, '_')]
         .flatMap(packageName => [
           `${packageName}/__init__.py`,
           `src/${packageName}/__init__.py`,
@@ -118,6 +126,7 @@ export class Python extends BaseStrategy {
             updater: new PythonFileWithVersion({version}),
           })
         );
+      }
     }
 
     // There should be only one version.py, but foreach in case that is incorrect


### PR DESCRIPTION
### Why this change?

I wanted to write the version string to `__about__.py` instead of the default `__init__.py` file for release-type `python`. Writing the version string to `__about__.py` is quite common in the python community.

After fiddling around, I noticed that the `version-file` value from the manifest JSON is not read and could've been used so to specify the path to `__about__.py`.

### What was changed?

- Read the manifest's `version-file` value and push the version string to it.
- If no `version-file` was provided, fall back to previous behavior.


___

Thank you for opening a Pull Request! Before submitting your PR, there are a few things you can do to make sure it goes smoothly:
- [x] Make sure to open an issue as a [bug/issue](https://github.com/googleapis/release-please/issues/new/choose) before writing your code!  That way we can discuss the change, evaluate designs, and agree on the general idea
- [ ] Ensure the tests and linter pass
- [ ] Code coverage does not decrease (if any source code was changed)
- [ ] Appropriate docs were updated (if necessary)

Fixes #2433
