### PR TITLE
feat: allow date updating in generic strategy

### DIFF
--- a/__snapshots__/cli.js
+++ b/__snapshots__/cli.js
@@ -216,6 +216,8 @@ Options:
   --latest-tag-sha                  Override the detected latest tag SHA[string]
   --latest-tag-name                 Override the detected latest tag name
                                                                         [string]
+  --date-format                     format in strftime format for updating dates
+                                                             [default: "string"]
   --label                           comma-separated list of labels to add to
                                     from release PR
                                                [default: "autorelease: pending"]

--- a/__snapshots__/generic.js
+++ b/__snapshots__/generic.js
@@ -21,6 +21,15 @@ public final class Version {
   public static String VERSION = "2.3.4";
   // {x-release-please-end}
 
+  // {x-release-please-start-date}
+  public static String DATE = "01-12-2023";
+  // {x-release-please-end}
+ 
+  // {x-release-please-start-version-date}
+  public static String NEW_DATE = "01-12-2023";
+  public static String NEW_VERSION = "2.3.4";
+  // {x-release-please-end}
+
   // {x-release-please-start-major}
   public static String MAJOR = "2";
   // {x-release-please-end}
@@ -37,6 +46,9 @@ public final class Version {
   public static String INLINE_MAJOR = "2"; // {x-release-please-major}
   public static String INLINE_MINOR = "3"; // {x-release-please-minor}
   public static String INLINE_PATCH = "4"; // {x-release-please-patch}
+
+  public static String RELEASE_DATE = "01-12-2023"; // {x-release-please-date}
+  public static String RELEASE_INFO = "v2.3.4 01-12-2023"; // {x-release-please-version-date}
 }
 
 `

--- a/schemas/config.json
+++ b/schemas/config.json
@@ -119,6 +119,10 @@
           "description": "Customize the separator between the component and version in the GitHub tag.",
           "type": "string"
         },
+        "date-format": {
+          "description": "Date format given as a strftime expression for the generic strategy.",
+          "type": "string"
+        },
         "extra-files": {
           "description": "Specify extra generic files to replace versions.",
           "type": "array",
@@ -476,6 +480,7 @@
     "separate-pull-requests": true,
     "always-update": true,
     "tag-separator": true,
+    "date-format": true,
     "extra-files": true,
     "version-file": true,
     "snapshot-label": true,

--- a/src/bin/release-please.ts
+++ b/src/bin/release-please.ts
@@ -346,6 +346,10 @@ function pullRequestStrategyOptions(yargs: yargs.Argv): yargs.Argv {
       describe: 'Override the detected latest tag name',
       type: 'string',
     })
+    .option('date-format', {
+      describe: 'format in strftime format for updating dates',
+      default: 'string',
+    })
     .middleware(_argv => {
       const argv = _argv as CreatePullRequestArgs;
 

--- a/src/manifest.ts
+++ b/src/manifest.ts
@@ -122,6 +122,7 @@ export interface ReleaserConfig {
   releaseLabels?: string[];
   extraLabels?: string[];
   initialVersion?: string;
+  dateFormat?: string;
 
   // Changelog options
   changelogSections?: ChangelogSection[];
@@ -183,6 +184,7 @@ interface ReleaserConfigJson {
   'skip-snapshot'?: boolean; // Java-only
   'initial-version'?: string;
   'exclude-paths'?: string[]; // manifest-only
+  'date-format'?: string;
 }
 
 export interface ManifestOptions {
@@ -207,6 +209,7 @@ export interface ManifestOptions {
   releaseSearchDepth?: number;
   commitSearchDepth?: number;
   logger?: Logger;
+  dateFormat?: string;
 }
 
 export interface ReleaserPackageConfig extends ReleaserConfigJson {
@@ -1397,6 +1400,7 @@ function extractReleaserConfig(
     skipSnapshot: config['skip-snapshot'],
     initialVersion: config['initial-version'],
     excludePaths: config['exclude-paths'],
+    dateFormat: config['date-format'],
   };
 }
 
@@ -1755,6 +1759,7 @@ function mergeReleaserConfig(
     initialVersion: pathConfig.initialVersion ?? defaultConfig.initialVersion,
     extraLabels: pathConfig.extraLabels ?? defaultConfig.extraLabels,
     excludePaths: pathConfig.excludePaths ?? defaultConfig.excludePaths,
+    dateFormat: pathConfig.dateFormat ?? defaultConfig.dateFormat,
   };
 }
 

--- a/src/strategies/java.ts
+++ b/src/strategies/java.ts
@@ -140,7 +140,13 @@ export class Java extends BaseStrategy {
       commits: [],
     });
     const updatesWithExtras = mergeUpdates(
-      updates.concat(...(await this.extraFileUpdates(newVersion, versionsMap)))
+      updates.concat(
+        ...(await this.extraFileUpdates(
+          newVersion,
+          versionsMap,
+          this.dateFormat
+        ))
+      )
     );
     return {
       title: pullRequestTitle,

--- a/src/updaters/generic.ts
+++ b/src/updaters/generic.ts
@@ -20,12 +20,19 @@ const VERSION_REGEX =
   /(?<major>\d+)\.(?<minor>\d+)\.(?<patch>\d+)(-(?<preRelease>[\w.]+))?(\+(?<build>[-\w.]+))?/;
 const SINGLE_VERSION_REGEX = /\b\d+\b/;
 const INLINE_UPDATE_REGEX =
-  /x-release-please-(?<scope>major|minor|patch|version)/;
+  /x-release-please-(?<scope>major|minor|patch|version-date|version|date)/;
 const BLOCK_START_REGEX =
-  /x-release-please-start-(?<scope>major|minor|patch|version)/;
+  /x-release-please-start-(?<scope>major|minor|patch|version-date|version|date)/;
 const BLOCK_END_REGEX = /x-release-please-end/;
+const DATE_FORMAT_REGEX = /%[Ymd]/g;
 
-type BlockScope = 'major' | 'minor' | 'patch' | 'version';
+type BlockScope =
+  | 'major'
+  | 'minor'
+  | 'patch'
+  | 'version'
+  | 'date'
+  | 'version-date';
 
 /**
  * Options for the Generic updater.
@@ -34,6 +41,8 @@ export interface GenericUpdateOptions extends UpdateOptions {
   inlineUpdateRegex?: RegExp;
   blockStartRegex?: RegExp;
   blockEndRegex?: RegExp;
+  date?: Date;
+  dateFormat?: string;
 }
 
 /**
@@ -52,17 +61,23 @@ export interface GenericUpdateOptions extends UpdateOptions {
  * 4. `x-release-please-patch` if this string is found on the line,
  *    then replace an integer looking value with the next version's
  *    patch
+ * 5. `x-release-please-date` if this string is found on the line,
+ *    then replace the date with the date of the last commit
+ * 6. `x-release-please-version-date` if this string is found on the line,
+ *    then replace the both date and version
  *
  * You can also use a block-based replacement. Content between the
  * opening `x-release-please-start-version` and `x-release-please-end` will
  * be considered for version replacement. You can also open these blocks
- * with `x-release-please-start-<major|minor|patch>` to replace single
- * numbers
+ * with `x-release-please-start-<major|minor|patch|version-date>` to replace
+ * single numbers
  */
 export class Generic extends DefaultUpdater {
   private readonly inlineUpdateRegex: RegExp;
   private readonly blockStartRegex: RegExp;
   private readonly blockEndRegex: RegExp;
+  private readonly date: Date;
+  private readonly dateFormat: string;
 
   constructor(options: GenericUpdateOptions) {
     super(options);
@@ -70,6 +85,8 @@ export class Generic extends DefaultUpdater {
     this.inlineUpdateRegex = options.inlineUpdateRegex ?? INLINE_UPDATE_REGEX;
     this.blockStartRegex = options.blockStartRegex ?? BLOCK_START_REGEX;
     this.blockEndRegex = options.blockEndRegex ?? BLOCK_END_REGEX;
+    this.date = options.date ?? new Date();
+    this.dateFormat = options.dateFormat ?? '%Y-%m-%d';
   }
 
   /**
@@ -88,8 +105,33 @@ export class Generic extends DefaultUpdater {
     const newLines: string[] = [];
     let blockScope: BlockScope | undefined;
 
-    function replaceVersion(line: string, scope: BlockScope, version: Version) {
+    function replaceVersion(
+      line: string,
+      scope: BlockScope,
+      version: Version,
+      date: Date,
+      dateFormat: string
+    ) {
+      const dateRegex = createDateRegex(dateFormat);
+      const formattedDate = formatDate(dateFormat, date);
+
       switch (scope) {
+        case 'date':
+          if (isValidDate(formattedDate, dateFormat)) {
+            newLines.push(line.replace(dateRegex, formattedDate));
+          } else {
+            logger.warn(`Invalid date format: ${formattedDate}`);
+            newLines.push(line);
+          }
+          return;
+        case 'version-date':
+          if (isValidDate(formattedDate, dateFormat)) {
+            line = line.replace(dateRegex, formattedDate);
+          } else {
+            logger.warn(`Invalid date format: ${formattedDate}`);
+          }
+          newLines.push(line.replace(VERSION_REGEX, version.toString()));
+          return;
         case 'major':
           newLines.push(line.replace(SINGLE_VERSION_REGEX, `${version.major}`));
           return;
@@ -115,11 +157,19 @@ export class Generic extends DefaultUpdater {
         replaceVersion(
           line,
           (match.groups?.scope || 'version') as BlockScope,
-          this.version
+          this.version,
+          this.date,
+          this.dateFormat
         );
       } else if (blockScope) {
         // in a block, so try to replace versions
-        replaceVersion(line, blockScope, this.version);
+        replaceVersion(
+          line,
+          blockScope,
+          this.version,
+          this.date,
+          this.dateFormat
+        );
         if (line.match(this.blockEndRegex)) {
           blockScope = undefined;
         }
@@ -139,4 +189,49 @@ export class Generic extends DefaultUpdater {
 
     return newLines.join('\n');
   }
+}
+
+function createDateRegex(format: string): RegExp {
+  const regexString = format.replace(DATE_FORMAT_REGEX, match => {
+    switch (match) {
+      case '%Y':
+        return '(\\d{4})';
+      case '%m':
+        return '(\\d{2})';
+      case '%d':
+        return '(\\d{2})';
+      default:
+        return match;
+    }
+  });
+  return new RegExp(regexString);
+}
+
+function formatDate(format: string, date: Date): string {
+  return format.replace(DATE_FORMAT_REGEX, match => {
+    switch (match) {
+      case '%Y':
+        return date.getFullYear().toString();
+      case '%m':
+        return ('0' + (date.getMonth() + 1)).slice(-2);
+      case '%d':
+        return ('0' + date.getDate()).slice(-2);
+      default:
+        return match;
+    }
+  });
+}
+
+function isValidDate(dateString: string, format: string): boolean {
+  const dateParts = dateString.match(/\d+/g);
+  if (!dateParts) return false;
+
+  const year = parseInt(dateParts[format.indexOf('%Y') / 3], 10);
+  const month = parseInt(dateParts[format.indexOf('%m') / 3], 10);
+  const day = parseInt(dateParts[format.indexOf('%d') / 3], 10);
+
+  if (year < 1 || month < 1 || month > 12 || day < 1 || day > 31) return false;
+
+  const daysInMonth = new Date(year, month, 0).getDate();
+  return day <= daysInMonth;
 }

--- a/src/updaters/release-please-config.ts
+++ b/src/updaters/release-please-config.ts
@@ -82,6 +82,7 @@ function releaserConfigToJsonConfig(
     'extra-files': config.extraFiles,
     'version-file': config.versionFile,
     'snapshot-label': config.snapshotLabels?.join(','), // Java-only
+    'date-format': config.dateFormat,
   };
   return jsonConfig;
 }

--- a/test/updaters/fixtures/Version.java
+++ b/test/updaters/fixtures/Version.java
@@ -20,6 +20,15 @@ public final class Version {
   public static String VERSION = "1.2.3-SNAPSHOT";
   // {x-release-please-end}
 
+  // {x-release-please-start-date}
+  public static String DATE = "10-09-2100";
+  // {x-release-please-end}
+ 
+  // {x-release-please-start-version-date}
+  public static String NEW_DATE = "01-01-0100";
+  public static String NEW_VERSION = "3.2.0-SNAPSHOT";
+  // {x-release-please-end}
+
   // {x-release-please-start-major}
   public static String MAJOR = "1";
   // {x-release-please-end}
@@ -36,4 +45,7 @@ public final class Version {
   public static String INLINE_MAJOR = "1"; // {x-release-please-major}
   public static String INLINE_MINOR = "2"; // {x-release-please-minor}
   public static String INLINE_PATCH = "3"; // {x-release-please-patch}
+
+  public static String RELEASE_DATE = "11-12-2014"; // {x-release-please-date}
+  public static String RELEASE_INFO = "v1.2.3 11-12-2014"; // {x-release-please-version-date}
 }

--- a/test/updaters/generic.ts
+++ b/test/updaters/generic.ts
@@ -29,9 +29,12 @@ describe('Generic', () => {
         'utf8'
       ).replace(/\r\n/g, '\n');
       const versions = new Map<string, Version>();
+      const currentDate = new Date(Date.parse('2023-12-01'));
       const pom = new Generic({
         versionsMap: versions,
         version: Version.parse('v2.3.4'),
+        date: currentDate,
+        dateFormat: '%d-%m-%Y',
       });
       const newContent = pom.updateContent(oldContent);
       snapshot(newContent);


### PR DESCRIPTION
Allow updating of dates using the generic updater, by adding a x-release-please-date or x-release-please-version-date (to update both version and date) to a file anywhere.

The implementation is still very basic. The date is retrieved by just checking the current date, but a better approach would be to look at the timestamp of the previous feat/fix or breaking change for a conventional commit, I think.

I've added an option --date-format to specify the date format. There are no assertions with respect to this right now, and the regex matching can be improved in several ways.

One option I considered was to try to auto-detect the date format, but I think this is bound to be problematic because there are ambiguities in date formatting.

Fixes #1798 🦕
