### PR TITLE
feat: add `generic-sha` updater

### DIFF
--- a/docs/customizing.md
+++ b/docs/customizing.md
@@ -203,6 +203,33 @@ force the [Generic](/src/updaters/generic.ts) updater, you must use type
 }
 ```
 
+If you want to use the [GenericSha](/src/updaters/generic-sha.ts) updater, you must use type
+`"sha"`. This updater updates your commit sha reference, together with your version (if exists).
+
+You can annotate a line (inline) via:
+
+* `x-release-please-sha`
+
+For these annotations, we will try to replace the value on that line only.
+
+You can annotate a block by starting with a line containing:
+
+* `x-release-please-start-sha`
+
+and close the block with a line containing `x-release-please-end`. Within
+the block, we will attempt to replace version values.
+
+```json
+{
+  "extra-files": [
+    {
+      "type": "sha",
+      "path": "path/to/file.yml"
+    }
+  ]
+}
+```
+
 ## Updating arbitrary JSON files
 
 For files with the `.json` extension, the `version` property is updated.

--- a/schemas/config.json
+++ b/schemas/config.json
@@ -501,6 +501,6 @@
     "initial-version": true,
     "exclude-paths": true,
     "component-no-space": false,
-    "tag-head-sha": false
+    "tag-head-sha": true
   }
 }

--- a/schemas/config.json
+++ b/schemas/config.json
@@ -82,6 +82,10 @@
           "description": "When tagging a release, include `v` in the tag. Defaults to `false`.",
           "type": "boolean"
         },
+        "tag-head-sha": {
+          "description": "Tag head sha of the PR with the change. Defaults to `false`.",
+          "type": "boolean"
+        },
         "changelog-type": {
           "description": "The type of changelog to use. Defaults to `default`.",
           "type": "string",
@@ -496,6 +500,7 @@
     "snapshot-label": true,
     "initial-version": true,
     "exclude-paths": true,
-    "component-no-space": false
+    "component-no-space": false,
+    "tag-head-sha": false
   }
 }

--- a/schemas/config.json
+++ b/schemas/config.json
@@ -211,6 +211,21 @@
                   }
                 },
                 "required": ["type", "path"]
+              },
+              {
+                "description": "An extra arbitrary file that includes release-please sha updater's annotation.",
+                "type": "object",
+                "properties": {
+                  "type": {
+                    "description": "The file format type.",
+                    "enum": ["sha"]
+                  },
+                  "path": {
+                    "description": "The path to the file.",
+                    "type": "string"
+                  }
+                },
+                "required": ["type", "path"]
               }
             ]
           }

--- a/src/bin/release-please.ts
+++ b/src/bin/release-please.ts
@@ -431,6 +431,12 @@ function taggingOptions(yargs: yargs.Argv): yargs.Argv {
         'release-please automatically adds ` ` (space) in front of parsed ${component}. Should this be disabled?',
       type: 'boolean',
       default: false,
+    })
+    .option('tag-head-sha', {
+      describe:
+        'tag the head of the branch with the updated code - not the squashed commit',
+      type: 'boolean',
+      default: false,
     });
 }
 

--- a/src/bin/release-please.ts
+++ b/src/bin/release-please.ts
@@ -485,6 +485,7 @@ const createReleasePullRequestCommand: yargs.CommandModule<
           versionFile: argv.versionFile,
           includeComponentInTag: argv.monorepoTags,
           includeVInTag: argv.includeVInTags,
+          tagHeadSha: argv.tagHeadSha,
         },
         extractManifestOptions(argv),
         argv.path

--- a/src/bin/release-please.ts
+++ b/src/bin/release-please.ts
@@ -485,7 +485,6 @@ const createReleasePullRequestCommand: yargs.CommandModule<
           versionFile: argv.versionFile,
           includeComponentInTag: argv.monorepoTags,
           includeVInTag: argv.includeVInTags,
-          tagHeadSha: argv.tagHeadSha,
         },
         extractManifestOptions(argv),
         argv.path

--- a/src/manifest.ts
+++ b/src/manifest.ts
@@ -56,6 +56,7 @@ type ExtraGenericFile = {
 type ExtraShaFile = {
   type: 'sha';
   path: string;
+  glob?: boolean;
 };
 type ExtraJsonFile = {
   type: 'json';

--- a/src/manifest.ts
+++ b/src/manifest.ts
@@ -53,6 +53,10 @@ type ExtraGenericFile = {
   path: string;
   glob?: boolean;
 };
+type ExtraShaFile = {
+  type: 'sha';
+  path: string;
+};
 type ExtraJsonFile = {
   type: 'json';
   path: string;
@@ -85,6 +89,7 @@ type ExtraTomlFile = {
 export type ExtraFile =
   | string
   | ExtraGenericFile
+  | ExtraShaFile
   | ExtraJsonFile
   | ExtraYamlFile
   | ExtraXmlFile

--- a/src/manifest.ts
+++ b/src/manifest.ts
@@ -143,6 +143,8 @@ export interface ReleaserConfig {
   skipSnapshot?: boolean;
   // Manifest only
   excludePaths?: string[];
+
+  tagHeadSha?: boolean;
 }
 
 export interface CandidateReleasePullRequest {
@@ -189,6 +191,7 @@ interface ReleaserConfigJson {
   'skip-snapshot'?: boolean; // Java-only
   'initial-version'?: string;
   'exclude-paths'?: string[]; // manifest-only
+  'tag-head-sha'?: boolean;
 }
 
 export interface ManifestOptions {
@@ -1403,6 +1406,7 @@ function extractReleaserConfig(
     skipSnapshot: config['skip-snapshot'],
     initialVersion: config['initial-version'],
     excludePaths: config['exclude-paths'],
+    tagHeadSha: config['tag-head-sha'],
   };
 }
 

--- a/src/manifest.ts
+++ b/src/manifest.ts
@@ -1765,6 +1765,7 @@ function mergeReleaserConfig(
     initialVersion: pathConfig.initialVersion ?? defaultConfig.initialVersion,
     extraLabels: pathConfig.extraLabels ?? defaultConfig.extraLabels,
     excludePaths: pathConfig.excludePaths ?? defaultConfig.excludePaths,
+    tagHeadSha: pathConfig.tagHeadSha ?? defaultConfig.tagHeadSha,
   };
 }
 

--- a/src/strategies/base.ts
+++ b/src/strategies/base.ts
@@ -85,6 +85,7 @@ export interface BaseStrategyOptions {
   logger?: Logger;
   initialVersion?: string;
   extraLabels?: string[];
+  tagHeadSha?: boolean;
 }
 
 /**
@@ -114,6 +115,7 @@ export abstract class BaseStrategy implements Strategy {
   readonly componentNoSpace?: boolean;
   readonly extraFiles: ExtraFile[];
   readonly extraLabels: string[];
+  readonly tagHeadSha?: boolean;
 
   readonly changelogNotes: ChangelogNotes;
 
@@ -149,6 +151,7 @@ export abstract class BaseStrategy implements Strategy {
     this.extraFiles = options.extraFiles || [];
     this.initialVersion = options.initialVersion;
     this.extraLabels = options.extraLabels || [];
+    this.tagHeadSha = options.tagHeadSha;
   }
 
   /**
@@ -691,11 +694,18 @@ export abstract class BaseStrategy implements Strategy {
       component && this.includeComponentInTag
         ? `${component}: v${version.toString()}`
         : `v${version.toString()}`;
+    const githubSourceSha = process.env.GITHUB_SOURCE_SHA;
+    var newSha = ''
+    if (this.tagHeadSha && githubSourceSha !== undefined) {
+      newSha = githubSourceSha
+    } else {
+      newSha = mergedPullRequest.sha
+    }
     return {
       name: releaseName,
       tag,
       notes: notes || '',
-      sha: mergedPullRequest.sha,
+      sha: newSha,
     };
   }
 

--- a/src/strategies/base.ts
+++ b/src/strategies/base.ts
@@ -701,6 +701,7 @@ export abstract class BaseStrategy implements Strategy {
     } else {
       newSha = mergedPullRequest.sha
     }
+    this.logger.info(`tag-head-sha: ${this.tagHeadSha}, SHA used: ${newSha}`)
     return {
       name: releaseName,
       tag,

--- a/src/strategies/base.ts
+++ b/src/strategies/base.ts
@@ -696,7 +696,7 @@ export abstract class BaseStrategy implements Strategy {
         : `v${version.toString()}`;
     const githubSourceSha = process.env.GITHUB_SOURCE_SHA;
     var newSha = ''
-    if (this.tagHeadSha && githubSourceSha !== undefined) {
+    if (githubSourceSha !== undefined) {
       newSha = githubSourceSha
     } else {
       newSha = mergedPullRequest.sha

--- a/src/strategies/base.ts
+++ b/src/strategies/base.ts
@@ -39,6 +39,7 @@ import {CompositeUpdater, mergeUpdates} from '../updaters/composite';
 import {Generic} from '../updaters/generic';
 import {GenericJson} from '../updaters/generic-json';
 import {GenericXml} from '../updaters/generic-xml';
+import {GenericSha} from '../updaters/generic-sha';
 import {PomXml} from '../updaters/java/pom-xml';
 import {GenericYaml} from '../updaters/generic-yaml';
 import {GenericToml} from '../updaters/generic-toml';
@@ -403,6 +404,13 @@ export abstract class BaseStrategy implements Strategy {
                 path: this.addPath(path),
                 createIfMissing: false,
                 updater: new Generic({version, versionsMap}),
+              });
+              break;
+            case 'sha':
+              extraFileUpdates.push({
+                path: this.addPath(path),
+                createIfMissing: false,
+                updater: new GenericSha({version, versionsMap}),
               });
               break;
             case 'json':

--- a/src/updaters/generic-sha.ts
+++ b/src/updaters/generic-sha.ts
@@ -89,7 +89,7 @@ export class GenericSha extends DefaultUpdater {
           return;
         case 'version':
           // replace version numbers (e.g., # v1.0.0) with the new version
-          newLines.push(line.replace(VERSION_REGEX, `# ${version}`));
+          newLines.push(line.replace(VERSION_REGEX, `# v${version}`));
           return;
         default:
           logger.warn(`unknown block scope: ${scope}`);

--- a/src/updaters/generic-sha.ts
+++ b/src/updaters/generic-sha.ts
@@ -1,0 +1,117 @@
+import { DefaultUpdater, UpdateOptions } from './default';
+import { logger as defaultLogger, Logger } from '../util/logger';
+
+const COMMIT_SHA_REGEX = /\b([a-f0-9]{7,40})\b/; // Regex to match commit SHAs
+const VERSION_REGEX = /#\s*v?\d+\.\d+\.\d+/;
+const INLINE_UPDATE_REGEX = /x-release-please-(?<scope>sha)/;
+const BLOCK_START_REGEX = /x-release-please-start-sha/;
+const BLOCK_END_REGEX = /x-release-please-end/;
+
+type BlockScope = 'sha' | 'version';;
+
+/**
+ * Options for the Generic updater for commit SHAs.
+ */
+export interface GenericShaUpdateOptions extends UpdateOptions {
+  inlineUpdateRegex?: RegExp;
+  blockStartRegex?: RegExp;
+  blockEndRegex?: RegExp;
+}
+
+export class GenericSha extends DefaultUpdater {
+  private readonly inlineUpdateRegex: RegExp;
+  private readonly blockStartRegex: RegExp;
+  private readonly blockEndRegex: RegExp;
+
+  private sha: string;
+
+  constructor(options: GenericShaUpdateOptions) {
+    super(options);
+
+    this.inlineUpdateRegex = options.inlineUpdateRegex ?? INLINE_UPDATE_REGEX;
+    this.blockStartRegex = options.blockStartRegex ?? BLOCK_START_REGEX;
+    this.blockEndRegex = options.blockEndRegex ?? BLOCK_END_REGEX;
+
+    this.sha = this.getLatestCommitSha();
+  }
+
+  /**
+   * Fetches the latest commit SHA from the GitHub Actions environment.
+   * @returns {string} The latest commit SHA
+   */
+  private getLatestCommitSha(): string {
+    // fetch the latest commit SHA from GitHub Actions environment variable
+    const sha = process.env.GITHUB_CURRENT_SHA;
+    if (!sha) {
+      throw new Error('GITHUB_SHA is not available. Make sure this is run in a GitHub Actions environment.');
+    }
+    return sha;
+  }
+
+  /**
+   * Given initial file contents, return updated contents with commit SHA.
+   * @param {string} content The initial content
+   * @returns {string} The updated content
+   */
+  updateContent(
+    content: string | undefined,
+    logger: Logger = defaultLogger
+  ): string {
+    logger.debug(`updateContent: ${content}`)
+    if (!content) {
+      return '';
+    }
+
+    const newLines: string[] = [];
+    let blockScope: BlockScope | undefined;
+
+    const version = this.version.toString(); 
+
+    function replaceContent(line: string, scope: BlockScope, sha: string, version: string) {
+      switch (scope) {
+        case 'sha':
+          // replace commit SHA with the latest commit SHA
+          newLines.push(line.replace(COMMIT_SHA_REGEX, sha));
+          return;
+        case 'version':
+          // replace version numbers (e.g., # v1.0.0) with the new version
+          newLines.push(line.replace(VERSION_REGEX, `# ${version}`));
+          return;
+        default:
+          logger.warn(`unknown block scope: ${scope}`);
+          newLines.push(line);
+      }
+    }
+
+    content.split(/\r?\n/).forEach(line => {
+      let match = line.match(this.inlineUpdateRegex);
+      if (match) {
+        replaceContent(
+          line,
+          (match.groups?.scope || 'sha') as BlockScope,
+          this.sha,
+          version
+        );
+      } else if (blockScope) {
+        // in a block, so try to replace versions
+        replaceContent(line, blockScope, this.sha, version);
+        if (line.match(this.blockEndRegex)) {
+          blockScope = undefined;
+        }
+      } else {
+        // look for block start line
+        match = line.match(this.blockStartRegex);
+        if (match) {
+          if (match.groups?.scope) {
+            blockScope = match.groups.scope as BlockScope;
+          } else {
+            blockScope = 'version'; // default to 'version' scope
+          }
+        }
+        newLines.push(line);
+      }
+    });
+
+    return newLines.join('\n');
+  }
+}

--- a/src/updaters/generic-sha.ts
+++ b/src/updaters/generic-sha.ts
@@ -55,9 +55,9 @@ export class GenericSha extends DefaultUpdater {
    */
   private getLatestCommitSha(): string {
     // fetch the latest commit SHA from GitHub Actions environment variable
-    const sha = process.env.GITHUB_CURRENT_SHA;
+    const sha = process.env.GITHUB_SOURCE_SHA;
     if (!sha) {
-      throw new Error('GITHUB_SHA is not available. Make sure this is run in a GitHub Actions environment.');
+      throw new Error('GITHUB_SOURCE_SHA is not available. Make sure this is run in a GitHub Actions environment.');
     }
     return sha;
   }

--- a/src/updaters/generic-sha.ts
+++ b/src/updaters/generic-sha.ts
@@ -1,3 +1,17 @@
+// Copyright 2024 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 import { DefaultUpdater, UpdateOptions } from './default';
 import { logger as defaultLogger, Logger } from '../util/logger';
 

--- a/src/updaters/generic-sha.ts
+++ b/src/updaters/generic-sha.ts
@@ -21,7 +21,7 @@ const INLINE_UPDATE_REGEX = /x-release-please-(?<scope>sha)/;
 const BLOCK_START_REGEX = /x-release-please-start-sha/;
 const BLOCK_END_REGEX = /x-release-please-end/;
 
-type BlockScope = 'sha' | 'version';;
+type BlockScope = 'sha' | 'version';
 
 /**
  * Options for the Generic updater for commit SHAs.
@@ -71,7 +71,6 @@ export class GenericSha extends DefaultUpdater {
     content: string | undefined,
     logger: Logger = defaultLogger
   ): string {
-    logger.debug(`updateContent: ${content}`)
     if (!content) {
       return '';
     }
@@ -84,12 +83,7 @@ export class GenericSha extends DefaultUpdater {
     function replaceContent(line: string, scope: BlockScope, sha: string, version: string) {
       switch (scope) {
         case 'sha':
-          // replace commit SHA with the latest commit SHA
-          newLines.push(line.replace(COMMIT_SHA_REGEX, sha));
-          return;
-        case 'version':
-          // replace version numbers (e.g., # v1.0.0) with the new version
-          newLines.push(line.replace(VERSION_REGEX, `# v${version}`));
+            newLines.push(line.replace(COMMIT_SHA_REGEX, sha).replace(VERSION_REGEX, `# v${version}`))
           return;
         default:
           logger.warn(`unknown block scope: ${scope}`);
@@ -119,7 +113,7 @@ export class GenericSha extends DefaultUpdater {
           if (match.groups?.scope) {
             blockScope = match.groups.scope as BlockScope;
           } else {
-            blockScope = 'version'; // default to 'version' scope
+            blockScope = 'sha'; // default to 'sha' scope
           }
         }
         newLines.push(line);

--- a/src/updaters/release-please-config.ts
+++ b/src/updaters/release-please-config.ts
@@ -82,6 +82,7 @@ function releaserConfigToJsonConfig(
     'extra-files': config.extraFiles,
     'version-file': config.versionFile,
     'snapshot-label': config.snapshotLabels?.join(','), // Java-only
+    'tag-head-sha': config.tagHeadSha,
   };
   return jsonConfig;
 }


### PR DESCRIPTION
This PR is about adding a `generic-sha` updater for `extra-files` which can update `sha` references as well, instead of only updating semver-like versions. More info in the issue below! 

- [x] Make sure to open an issue as a [bug/issue](https://github.com/googleapis/release-please/issues/new/choose) before writing your code!  That way we can discuss the change, evaluate designs, and agree on the general idea
- [ ] Ensure the tests and linter pass
- [ ] Code coverage does not decrease (if any source code was changed)
- [x] Appropriate docs were updated (if necessary)

Fixes #https://github.com/googleapis/release-please/issues/2444 🦕
