### PR TITLE
feat: adds "semver" versioning-strategy 

### DIFF
--- a/__snapshots__/cli.js
+++ b/__snapshots__/cli.js
@@ -201,7 +201,7 @@ Options:
                                     generated?        [boolean] [default: false]
   --versioning-strategy             strategy used for bumping versions
         [choices: "always-bump-major", "always-bump-minor", "always-bump-patch",
-                   "default", "prerelease", "service-pack"] [default: "default"]
+         "default", "prerelease", "semver", "service-pack"] [default: "default"]
   --changelog-path                  where can the CHANGELOG be found in the
                                     project?  [string] [default: "CHANGELOG.md"]
   --changelog-type                  type of changelog to build

--- a/src/factories/versioning-strategy-factory.ts
+++ b/src/factories/versioning-strategy-factory.ts
@@ -21,6 +21,7 @@ import {ServicePackVersioningStrategy} from '../versioning-strategies/service-pa
 import {GitHub} from '../github';
 import {ConfigurationError} from '../errors';
 import {PrereleaseVersioningStrategy} from '../versioning-strategies/prerelease';
+import {SemverVersioningStrategy} from '../versioning-strategies/semver';
 
 export type VersioningStrategyType = string;
 
@@ -44,6 +45,7 @@ const versioningTypes: Record<string, VersioningStrategyBuilder> = {
   'always-bump-major': options => new AlwaysBumpMajor(options),
   'service-pack': options => new ServicePackVersioningStrategy(options),
   prerelease: options => new PrereleaseVersioningStrategy(options),
+  semver: options => new SemverVersioningStrategy(options),
 };
 
 export function buildVersioningStrategy(

--- a/src/versioning-strategies/semver.ts
+++ b/src/versioning-strategies/semver.ts
@@ -1,0 +1,75 @@
+import * as semver from 'semver';
+import {Version} from '../version';
+import {VersionUpdater} from '../versioning-strategy';
+
+interface Commit {
+  type: string;
+  breaking: boolean;
+}
+
+const inc = (version: string, type: semver.ReleaseType, _tag?: string) => {
+  const parsed = new semver.SemVer(version);
+  const implicitTag =
+    parsed.prerelease.length > 1 ? parsed.prerelease[0]?.toString() : undefined;
+  const tag = _tag || implicitTag;
+  const next = new semver.SemVer(version).inc(type, tag);
+  const isFreshMajor = parsed.minor === 0 && parsed.patch === 0;
+  const isFreshMinor = parsed.patch === 0;
+  if (
+    parsed.prerelease.length &&
+    next.prerelease.length &&
+    ((type === 'premajor' && isFreshMajor) ||
+      (type === 'preminor' && isFreshMinor) ||
+      type === 'prepatch')
+  ) {
+    return semver.inc(version, 'prerelease', tag);
+  }
+  return semver.inc(version, type, tag);
+};
+
+const parseCommits = (commits: Commit[]) => {
+  let release: semver.ReleaseType = 'patch';
+  for (const commit of commits) {
+    if (commit.breaking) {
+      release = 'major';
+      break;
+    } else if (['feat', 'feature'].includes(commit.type)) {
+      release = 'minor';
+    }
+  }
+  return release;
+};
+
+class SemverVersioningStrategy {
+  options: {prerelease?: boolean; prereleaseType?: string};
+
+  constructor(options: {prerelease?: boolean; prereleaseType?: string}) {
+    this.options = options;
+  }
+
+  determineReleaseType(_version: Version, _commits: Commit[]): VersionUpdater {
+    const options = this.options;
+    class Shell implements VersionUpdater {
+      bump(_version: Version) {
+        return new SemverVersioningStrategy(options).bump(_version, _commits);
+      }
+    }
+    return new Shell();
+  }
+
+  bump(currentVersion: Version, commits: Commit[]): Version {
+    const prerelease = this.options.prerelease;
+    const tag = this.options.prereleaseType;
+    const releaseType = parseCommits(commits);
+    const addPreIfNeeded: semver.ReleaseType = prerelease
+      ? `pre${releaseType}`
+      : releaseType;
+    const version = inc(currentVersion.toString(), addPreIfNeeded, tag);
+    if (!version) {
+      throw new Error('Could not bump version');
+    }
+    return Version.parse(version);
+  }
+}
+
+export {SemverVersioningStrategy};

--- a/test/versioning-strategies/semver.ts
+++ b/test/versioning-strategies/semver.ts
@@ -1,0 +1,101 @@
+import {describe, it} from 'mocha';
+import {SemverVersioningStrategy} from '../../src/versioning-strategies/semver';
+import {ConventionalCommit} from '../../src';
+import {Version} from '../../src/version';
+import {expect} from 'chai';
+
+const commit: ConventionalCommit = {
+  type: 'chore',
+  breaking: false,
+  notes: [],
+  references: [],
+  scope: '',
+  bareMessage: '',
+  sha: '',
+  message: '',
+};
+
+const g = (v: Partial<ConventionalCommit>) => ({...commit, ...v});
+
+const COMMITS = {
+  major: [{type: 'feat'}, {}, {}, {breaking: true}].map(g),
+  minor: [{}, {}, {type: 'feat'}].map(g),
+  patch: [{}, {type: 'chore'}, {type: 'fix'}].map(g),
+};
+
+const checks = [
+  // Normal releases
+  ['2.0.0', 'major', false, undefined, '3.0.0'],
+  ['2.0.0', 'minor', false, undefined, '2.1.0'],
+  ['2.0.0', 'patch', false, undefined, '2.0.1'],
+  // premajor -> normal
+  ['2.0.0-pre.1', 'major', false, undefined, '2.0.0'],
+  ['2.0.0-pre.5', 'minor', false, undefined, '2.0.0'],
+  ['2.0.0-pre.4', 'patch', false, undefined, '2.0.0'],
+  // preminor -> normal
+  ['2.1.0-pre.1', 'major', false, undefined, '3.0.0'],
+  ['2.1.0-pre.5', 'minor', false, undefined, '2.1.0'],
+  ['2.1.0-pre.4', 'patch', false, undefined, '2.1.0'],
+  // prepatch -> normal
+  ['2.0.1-pre.1', 'major', false, undefined, '3.0.0'],
+  ['2.0.1-pre.5', 'minor', false, undefined, '2.1.0'],
+  ['2.0.1-pre.4', 'patch', false, undefined, '2.0.1'],
+  // Prereleases
+  ['2.0.0', 'major', true, 'pre', '3.0.0-pre.0'],
+  ['2.0.0', 'minor', true, 'pre', '2.1.0-pre.0'],
+  ['2.0.0', 'patch', true, 'pre', '2.0.1-pre.0'],
+  // premajor - prereleases
+  ['2.0.0-pre.1', 'major', true, undefined, '2.0.0-pre.2'],
+  ['2.0.0-pre.1', 'minor', true, undefined, '2.0.0-pre.2'],
+  ['2.0.0-pre.1', 'patch', true, undefined, '2.0.0-pre.2'],
+  // preminor - prereleases
+  ['2.1.0-pre.1', 'major', true, undefined, '3.0.0-pre.0'],
+  ['2.1.0-pre.1', 'minor', true, undefined, '2.1.0-pre.2'],
+  ['2.1.0-pre.1', 'patch', true, undefined, '2.1.0-pre.2'],
+  // prepatch - prereleases
+  ['2.0.1-pre.1', 'major', true, undefined, '3.0.0-pre.0'],
+  ['2.0.1-pre.1', 'minor', true, undefined, '2.1.0-pre.0'],
+  ['2.0.1-pre.1', 'patch', true, undefined, '2.0.1-pre.2'],
+  // different prerelease identifiers
+  ['2.0.0-beta.1', 'major', true, undefined, '2.0.0-beta.2'],
+  ['2.0.0-alpha.1', 'major', true, undefined, '2.0.0-alpha.2'],
+  ['2.0.0-rc.1', 'major', true, undefined, '2.0.0-rc.2'],
+  ['2.0.0-0', 'major', true, undefined, '2.0.0-1'],
+  // leaves prerelease
+  ['2.0.0-beta.1', 'major', false, undefined, '2.0.0'],
+  ['2.0.0-alpha.1', 'major', false, undefined, '2.0.0'],
+  ['2.0.0-rc.1', 'major', false, undefined, '2.0.0'],
+  ['2.0.0-0', 'major', false, undefined, '2.0.0'],
+] satisfies [
+  string,
+  keyof typeof COMMITS,
+  boolean,
+  string | undefined,
+  string
+][];
+
+describe('SemverVersioningStrategy', () => {
+  for (const [
+    version,
+    commits,
+    prerelease,
+    prereleaseType,
+    expected,
+  ] of checks) {
+    const name = [version, commits, prerelease, prereleaseType, expected];
+    const id = name
+      .map(v => (typeof v === 'undefined' ? 'undefined' : v))
+      .join(',');
+    it(`${id}`, () => {
+      const r = new SemverVersioningStrategy({prerelease, prereleaseType}).bump(
+        Version.parse(version),
+        COMMITS[commits]
+      );
+      expect(
+        `${r.major}.${r.minor}.${r.patch}${
+          r.preRelease ? `-${r.preRelease}` : ''
+        }`
+      ).to.equal(expected, id);
+    });
+  }
+});


### PR DESCRIPTION
First off 🫶 thank you for woking on release-please it makes our lives much easier.

I work on the `npm` cli which uses `release-please`. I think its safe to say we're power users and rely on the `prerelease` functionality.

This PR adds a proper "semver" strategy. There's a lot of issues related to `prereleases` when it comes to the existing  `PrereleaseVersioningStrategy` and `DefaultVersioningStrategy` (more below), these can be fixed but I think still will not do "proper" / "intended" semver incrementation.

There are also issues with semver itself which we aim to fix in https://www.npmjs.com/package/semver in a future release, this pr shims that functionality for now with a custom `semver.inc`  impementation.

I'll copy some of my findings from https://github.com/npm/template-oss/pull/495 but keep in mind the context:

* I was unable to get a repo *into* prerelease using the latest version of release-please on my personal project `reggi/packages`.
* And the `npm/cli` has been stuck in prerelease mode. It was able to get itself into prerelease because of the wrapper around release-please we have in this repo. (trail: [npm/cli workflow](https://github.com/npm/cli/blob/latest/.github/workflows/release.yml#L54), [Strategy Turnery](https://github.com/npm/template-oss/blob/abdc9398f47d4761d589617235bee0fdb4827128/lib/release/release-please.js#L56))

I do not believe release please has this `options.prerelease ternary anymore` here's the [mapping of what versioning-strategy is uses](https://github.com/googleapis/release-please/blob/3e807972fc8d1a348cd45e32d933ada4d25d4a28/src/factories/versioning-strategy-factory.ts#L40-L47).

And even if it did choose to use `PrereleaseVersioningStrategy` or `DefaultVersioningStrategy` neither of these strategies have the ability to leave a prerelease. Because they always [add the current `prereleaseType` or `prereleaseType` from the config from the existing version](https://github.com/googleapis/release-please/blob/3e807972fc8d1a348cd45e32d933ada4d25d4a28/src/versioning-strategies/prerelease.ts#L116-L135). Neither of these classes even have access to the `options.prerelease` boolean. And at the point in which both have it whats the point in differentiating between them anymore?

This is added as a new versioning-strategy `semver`. To note the property currently documented as `versioning-strategy` in the docs is not working, and is currently `versioning`. [I opened a PR to fix the json schema for the config](https://github.com/googleapis/release-please/pull/2450), but now we know it's a bug i'll leave that discussion open there.

So `"versioning-strategy": "semver"` would be ignored and you'd need `"versioning": "semver"`, again not relevant to *this* PR but another quirk to note.

I'm going to keep this in draft for now, just want to open up for discussion, and next steps. My main questions are 

* Is the `release-please` team open to new "semver" versioning strategy?
* How could we fix the existing strategies? I think they're design overall is broken (unless I'm missing something) but perhaps outside the context of semver / node people rely on that functionality? Is there a world in which we can deprecate `PrereleaseVersioningStrategy` or `DefaultVersioningStrategy` and just use `SemverVersioningStrategy`?

I also have a published fork if anyone wants to try it https://www.npmjs.com/package/@reggi/release-please