### PR TITLE
feat: Manifest.createRelease to return PR numbers

### DIFF
--- a/src/manifest.ts
+++ b/src/manifest.ts
@@ -291,6 +291,7 @@ export interface CreatedRelease extends GitHubRelease {
   major: number;
   minor: number;
   patch: number;
+  prNumber: number;
 }
 
 export class Manifest {
@@ -1251,7 +1252,7 @@ export class Manifest {
       // stop releasing once we hit an error
       if (error) continue;
       try {
-        githubReleases.push(await this.createRelease(release));
+        githubReleases.push(await this.createRelease(release, pullRequest));
       } catch (err) {
         if (err instanceof DuplicateReleaseError) {
           this.logger.warn(`Duplicate release tag: ${release.tag.toString()}`);
@@ -1302,7 +1303,8 @@ export class Manifest {
   }
 
   private async createRelease(
-    release: CandidateRelease
+    release: CandidateRelease,
+    pullRequest: PullRequest
   ): Promise<CreatedRelease> {
     const githubRelease = await this.github.createRelease(release, {
       draft: release.draft,
@@ -1316,6 +1318,7 @@ export class Manifest {
       major: release.tag.version.major,
       minor: release.tag.version.minor,
       patch: release.tag.version.patch,
+      prNumber: pullRequest.number,
     };
   }
 

--- a/test/cli.ts
+++ b/test/cli.ts
@@ -368,6 +368,7 @@ describe('CLI', () => {
             major: 1,
             minor: 2,
             patch: 3,
+            prNumber: 123,
           },
         ]);
     });
@@ -1178,6 +1179,7 @@ describe('CLI', () => {
               major: 1,
               minor: 2,
               patch: 3,
+              prNumber: 123,
             },
           ]);
       });
@@ -1352,6 +1354,7 @@ describe('CLI', () => {
               major: 1,
               minor: 2,
               patch: 3,
+              prNumber: 123,
             },
           ]);
       });

--- a/test/manifest.ts
+++ b/test/manifest.ts
@@ -5904,6 +5904,7 @@ describe('Manifest', () => {
       expect(releases[0]!.sha).to.eql('abc123');
       expect(releases[0]!.notes).to.eql('some release notes');
       expect(releases[0]!.path).to.eql('.');
+      expect(releases[0]!.prNumber).to.eql(1234);
       sinon.assert.calledOnce(commentStub);
       sinon.assert.calledOnceWithExactly(
         addLabelsStub,
@@ -6010,18 +6011,22 @@ describe('Manifest', () => {
       expect(releases[0]!.sha).to.eql('abc123');
       expect(releases[0]!.notes).to.be.string;
       expect(releases[0]!.path).to.eql('packages/bot-config-utils');
+      expect(releases[0]!.prNumber).to.eql(1234);
       expect(releases[1]!.tagName).to.eql('label-utils-v1.1.0');
       expect(releases[1]!.sha).to.eql('abc123');
       expect(releases[1]!.notes).to.be.string;
       expect(releases[1]!.path).to.eql('packages/label-utils');
+      expect(releases[1]!.prNumber).to.eql(1234);
       expect(releases[2]!.tagName).to.eql('object-selector-v1.1.0');
       expect(releases[2]!.sha).to.eql('abc123');
       expect(releases[2]!.notes).to.be.string;
       expect(releases[2]!.path).to.eql('packages/object-selector');
+      expect(releases[2]!.prNumber).to.eql(1234);
       expect(releases[3]!.tagName).to.eql('datastore-lock-v2.1.0');
       expect(releases[3]!.sha).to.eql('abc123');
       expect(releases[3]!.notes).to.be.string;
       expect(releases[3]!.path).to.eql('packages/datastore-lock');
+      expect(releases[3]!.prNumber).to.eql(1234);
       sinon.assert.callCount(commentStub, 1);
       sinon.assert.calledOnceWithExactly(
         addLabelsStub,
@@ -6078,6 +6083,7 @@ describe('Manifest', () => {
       expect(releases[0]!.sha).to.eql('abc123');
       expect(releases[0]!.notes).to.be.string;
       expect(releases[0]!.path).to.eql('.');
+      expect(releases[0]!.prNumber).to.eql(1234);
       sinon.assert.calledOnce(commentStub);
       sinon.assert.calledOnceWithExactly(
         addLabelsStub,


### PR DESCRIPTION
This pull request gives the caller of the Manifest.createRelease with the pull request number. This is for the Release Please bot's new capability to tag a commit with the Release Please pull request numbers. https://github.com/googleapis/repo-automation-bots/blob/main/packages/release-please/src/release-please.ts#L386 will receive the pull request number. The CreatedRelease interface extends GitHubRelease, which has commit SHA for the release.

b/b/394646919