### PR TITLE
fix: workspace - always update manifest versions

### DIFF
--- a/src/plugins/workspace.ts
+++ b/src/plugins/workspace.ts
@@ -262,6 +262,9 @@ export abstract class WorkspacePlugin<T> extends ManifestPlugin {
         const version = existingCandidate.pullRequest.version!;
         this.logger.debug(`version: ${version} from release-please`);
         updatedVersions.set(packageName, version);
+        if (this.isReleaseVersion(version)) {
+          updatedPathVersions.set(this.pathFromPackage(pkg), version);
+        }
       } else {
         const version = this.bumpVersion(pkg);
         this.logger.debug(`version: ${version} forced bump`);

--- a/test/plugins/cargo-workspace.ts
+++ b/test/plugins/cargo-workspace.ts
@@ -36,6 +36,7 @@ import {CargoToml} from '../../src/updaters/rust/cargo-toml';
 import {parseCargoManifest} from '../../src/updaters/rust/common';
 import {ConfigurationError} from '../../src/errors';
 import assert = require('assert');
+import {ReleasePleaseManifest} from '../../src/updaters/release-please-manifest';
 
 const sandbox = sinon.createSandbox();
 const fixturesPath = './test/fixtures/plugins/cargo-workspace';
@@ -136,6 +137,14 @@ describe('CargoWorkspace plugin', () => {
       assertHasUpdate(updates, 'packages/rustA/Cargo.toml');
       assertHasUpdate(updates, 'Cargo.lock');
       snapshot(dateSafe(rustCandidate!.pullRequest.body.toString()));
+      const updater = assertHasUpdate(
+        updates,
+        '.release-please-manifest.json',
+        ReleasePleaseManifest
+      ).updater as ReleasePleaseManifest;
+      expect(updater.versionsMap?.get('packages/rustA')?.toString()).to.eql(
+        '1.1.2'
+      );
     });
     it('combines rust packages', async () => {
       const candidates: CandidateReleasePullRequest[] = [
@@ -196,6 +205,17 @@ describe('CargoWorkspace plugin', () => {
       assertHasUpdate(updates, 'packages/rustA/Cargo.toml');
       assertHasUpdate(updates, 'packages/rustD/Cargo.toml');
       snapshot(dateSafe(rustCandidate!.pullRequest.body.toString()));
+      const updater = assertHasUpdate(
+        updates,
+        '.release-please-manifest.json',
+        ReleasePleaseManifest
+      ).updater as ReleasePleaseManifest;
+      expect(updater.versionsMap?.get('packages/rustA')?.toString()).to.eql(
+        '1.1.2'
+      );
+      expect(updater.versionsMap?.get('packages/rustD')?.toString()).to.eql(
+        '4.4.5'
+      );
     });
     it('handles glob paths', async () => {
       const candidates: CandidateReleasePullRequest[] = [
@@ -311,6 +331,26 @@ describe('CargoWorkspace plugin', () => {
       assertHasUpdate(updates, 'packages/rustD/Cargo.toml', RawContent);
       assertHasUpdate(updates, 'packages/rustE/Cargo.toml', RawContent);
       snapshot(dateSafe(rustCandidate!.pullRequest.body.toString()));
+      const updater = assertHasUpdate(
+        updates,
+        '.release-please-manifest.json',
+        ReleasePleaseManifest
+      ).updater as ReleasePleaseManifest;
+      expect(updater.versionsMap?.get('packages/rustA')?.toString()).to.eql(
+        '1.1.2'
+      );
+      expect(updater.versionsMap?.get('packages/rustB')?.toString()).to.eql(
+        '2.2.3'
+      );
+      expect(updater.versionsMap?.get('packages/rustC')?.toString()).to.eql(
+        '3.3.4'
+      );
+      expect(updater.versionsMap?.get('packages/rustD')?.toString()).to.eql(
+        '4.4.5'
+      );
+      expect(updater.versionsMap?.get('packages/rustE')?.toString()).to.eql(
+        '3.3.4'
+      );
     });
     it('can skip merging rust packages', async () => {
       // This is the same setup as 'walks dependency tree and updates previously untouched packages'

--- a/test/plugins/maven-workspace.ts
+++ b/test/plugins/maven-workspace.ts
@@ -102,6 +102,14 @@ describe('MavenWorkspace plugin', () => {
       expect(newCandidates).length(1);
       safeSnapshot(newCandidates[0].pullRequest.body.toString());
       expect(newCandidates[0].pullRequest.body.releaseData).length(1);
+      const updates = newCandidates[0].pullRequest.updates;
+      const updater = assertHasUpdate(
+        updates,
+        '.release-please-manifest.json',
+        ReleasePleaseManifest
+      ).updater as ReleasePleaseManifest;
+      expect(updater.versionsMap?.size).to.eql(1);
+      expect(updater.versionsMap?.get('maven4')?.toString()).to.eql('4.4.5');
     });
     it('appends to existing candidate', async () => {
       const candidates: CandidateReleasePullRequest[] = [
@@ -145,6 +153,15 @@ describe('MavenWorkspace plugin', () => {
       expect(newCandidates).length(1);
       safeSnapshot(newCandidates[0].pullRequest.body.toString());
       expect(newCandidates[0].pullRequest.body.releaseData).length(2);
+      const updates = newCandidates[0].pullRequest.updates;
+      const updater = assertHasUpdate(
+        updates,
+        '.release-please-manifest.json',
+        ReleasePleaseManifest
+      ).updater as ReleasePleaseManifest;
+      expect(updater.versionsMap?.size).to.eql(2);
+      expect(updater.versionsMap?.get('maven3')?.toString()).to.eql('3.3.4');
+      expect(updater.versionsMap?.get('maven4')?.toString()).to.eql('4.4.5');
     });
     it('appends to existing candidate with special updater', async () => {
       const customUpdater = new RawContent('some content');
@@ -245,6 +262,17 @@ describe('MavenWorkspace plugin', () => {
       expect(newCandidates).length(1);
       safeSnapshot(newCandidates[0].pullRequest.body.toString());
       expect(newCandidates[0].pullRequest.body.releaseData).length(4);
+      const updates = newCandidates[0].pullRequest.updates;
+      const updater = assertHasUpdate(
+        updates,
+        '.release-please-manifest.json',
+        ReleasePleaseManifest
+      ).updater as ReleasePleaseManifest;
+      expect(updater.versionsMap?.size).to.eql(4);
+      expect(updater.versionsMap?.get('maven1')?.toString()).to.eql('1.1.2');
+      expect(updater.versionsMap?.get('maven2')?.toString()).to.eql('2.2.3');
+      expect(updater.versionsMap?.get('maven3')?.toString()).to.eql('3.3.4');
+      expect(updater.versionsMap?.get('maven4')?.toString()).to.eql('4.4.5');
     });
     it('skips pom files not configured for release', async () => {
       plugin = new MavenWorkspace(

--- a/test/plugins/node-workspace.ts
+++ b/test/plugins/node-workspace.ts
@@ -181,6 +181,12 @@ describe('NodeWorkspace plugin', () => {
       const updates = nodeCandidate!.pullRequest.updates;
       assertHasUpdate(updates, 'node1/package.json');
       snapshot(dateSafe(nodeCandidate!.pullRequest.body.toString()));
+      const updater = assertHasUpdate(
+        updates,
+        '.release-please-manifest.json',
+        ReleasePleaseManifest
+      ).updater as ReleasePleaseManifest;
+      expect(updater.versionsMap?.get('node1')?.toString()).to.eql('3.3.4');
     });
     it('respects version prefix', async () => {
       const candidates: CandidateReleasePullRequest[] = [
@@ -263,6 +269,15 @@ describe('NodeWorkspace plugin', () => {
       snapshotUpdate(updates, 'package.json');
       snapshotUpdate(updates, 'node1/package.json');
       snapshotUpdate(updates, 'node4/package.json');
+
+      const updater = assertHasUpdate(
+        updates,
+        '.release-please-manifest.json',
+        ReleasePleaseManifest
+      ).updater as ReleasePleaseManifest;
+      expect(updater.versionsMap?.get('node1')?.toString()).to.eql('3.3.4');
+      expect(updater.versionsMap?.get('node4')?.toString()).to.eql('4.4.5');
+      expect(updater.versionsMap?.get('.')?.toString()).to.eql('5.5.6');
     });
     it('walks dependency tree and updates previously untouched packages', async () => {
       const candidates: CandidateReleasePullRequest[] = [
@@ -310,8 +325,10 @@ describe('NodeWorkspace plugin', () => {
         '.release-please-manifest.json',
         ReleasePleaseManifest
       ).updater as ReleasePleaseManifest;
+      expect(updater.versionsMap?.get('node1')?.toString()).to.eql('3.3.4');
       expect(updater.versionsMap?.get('node2')?.toString()).to.eql('2.2.3');
       expect(updater.versionsMap?.get('node3')?.toString()).to.eql('1.1.2');
+      expect(updater.versionsMap?.get('node4')?.toString()).to.eql('4.4.5');
       expect(updater.versionsMap?.get('node5')?.toString()).to.eql('1.0.1');
       snapshot(dateSafe(nodeCandidate!.pullRequest.body.toString()));
     });


### PR DESCRIPTION
Thank you for opening a Pull Request! Before submitting your PR, there are a few things you can do to make sure it goes smoothly:
- [x ] Make sure to open an issue as a [bug/issue](https://github.com/googleapis/release-please/issues/new/choose) before writing your code!  That way we can discuss the change, evaluate designs, and agree on the general idea
- [ x] Ensure the tests and linter pass
- [ x] Code coverage does not decrease (if any source code was changed)
- [ x] Appropriate docs were updated (if necessary)

Fixes #2172 🦕

For the NodeWorkspace and CargoWorkspace plugin, manifest updates are generated with an empty versionMap.

From what I understand, the [buildUpdatedVersions](https://github.com/googleapis/release-please/blob/main/src/plugins/workspace.ts#L185C22-L185C41) method is only adding candidates in the `updatedPathVersions` return (but is correctly adding everything in the `updatedVersions` return).
This feels like an oversight, as I don't know why the `updatedVersions` and the `updatedPathVersions` could have different versions.

I managed to make tests fail with my first commit, where manifest updates are not generated for cargo and node in the current version. (I also added the assertions for the maven plugin, but it works correctly).

The second commit introduce my proposition to fix this: always adding new versions to both outputs of the buildUpdatedVersions method.

What do you think about this change ?
Could this modification have side effects that I am not aware of ?