### PR TITLE
fix: use version-file if it's set for go projects

### DIFF
--- a/src/strategies/go.ts
+++ b/src/strategies/go.ts
@@ -14,10 +14,18 @@
 
 // Generic
 import {Changelog} from '../updaters/changelog';
-import {BaseStrategy, BuildUpdatesOptions} from './base';
+import {BaseStrategy, BuildUpdatesOptions, BaseStrategyOptions} from './base';
 import {Update} from '../update';
+import {VersionGo} from '../updaters/go/version-go';
 
 export class Go extends BaseStrategy {
+  readonly versionFile: string;
+
+  constructor(options: BaseStrategyOptions) {
+    super(options);
+    this.versionFile = options.versionFile ?? '';
+  }
+
   protected async buildUpdates(
     options: BuildUpdatesOptions
   ): Promise<Update[]> {
@@ -32,6 +40,17 @@ export class Go extends BaseStrategy {
         changelogEntry: options.changelogEntry,
       }),
     });
+
+    // If a version file is specified, update it
+    if (this.versionFile) {
+      updates.push({
+        path: this.addPath(this.versionFile),
+        createIfMissing: false,
+        updater: new VersionGo({
+          version,
+        }),
+      });
+    }
 
     return updates;
   }

--- a/test/fixtures/strategies/go/internal/version/version.go
+++ b/test/fixtures/strategies/go/internal/version/version.go
@@ -1,0 +1,18 @@
+// Copyright 2021 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package version
+
+// Version is the current version of the library
+const Version = "0.1.0"

--- a/test/strategies/go.ts
+++ b/test/strategies/go.ts
@@ -17,11 +17,12 @@ import {expect} from 'chai';
 import {GitHub} from '../../src/github';
 import {Go} from '../../src/strategies/go';
 import * as sinon from 'sinon';
-import {assertHasUpdate} from '../helpers';
+import {assertHasUpdate, assertNoHasUpdate} from '../helpers';
 import {buildMockConventionalCommit} from '../helpers';
 import {TagName} from '../../src/util/tag-name';
 import {Version} from '../../src/version';
 import {Changelog} from '../../src/updaters/changelog';
+import {VersionGo} from '../../src/updaters/go/version-go';
 
 const sandbox = sinon.createSandbox();
 
@@ -95,6 +96,25 @@ describe('Go', () => {
       );
       const updates = release!.updates;
       assertHasUpdate(updates, 'CHANGELOG.md', Changelog);
+      // Version file should not be updated when not specified
+      assertNoHasUpdate(updates, 'internal/version/version.go');
+    });
+
+    it('updates version file when version-file is set', async () => {
+      const strategy = new Go({
+        targetBranch: 'main',
+        github,
+        component: 'google-cloud-automl',
+        versionFile: 'internal/version/version.go',
+      });
+      const latestRelease = undefined;
+      const release = await strategy.buildReleasePullRequest(
+        COMMITS,
+        latestRelease
+      );
+      const updates = release!.updates;
+      assertHasUpdate(updates, 'CHANGELOG.md', Changelog);
+      assertHasUpdate(updates, 'internal/version/version.go', VersionGo);
     });
   });
 });


### PR DESCRIPTION
Make the `Go` strategy use the `versionFile` value if it's defined.

Fixes #2541 