### PR TITLE
fix: skipSnapshot is not working for java-yoshi

### DIFF
--- a/src/strategies/java-yoshi.ts
+++ b/src/strategies/java-yoshi.ts
@@ -52,6 +52,9 @@ export class JavaYoshi extends Java {
   }
 
   protected async needsSnapshot(): Promise<boolean> {
+    if (this.canSkipSnapshot()) {
+      return false;
+    }
     return VersionsManifest.needsSnapshot(
       (await this.getVersionsContent()).parsedContent
     );

--- a/src/strategies/java.ts
+++ b/src/strategies/java.ts
@@ -164,11 +164,15 @@ export class Java extends BaseStrategy {
     return !version.preRelease || version.preRelease.indexOf('SNAPSHOT') < 0;
   }
 
+  protected canSkipSnapshot(): boolean {
+    return this.skipSnapshot;
+  }
+
   protected async needsSnapshot(
     commits: ConventionalCommit[],
     latestRelease?: Release
   ): Promise<boolean> {
-    if (this.skipSnapshot) {
+    if (this.canSkipSnapshot()) {
       return false;
     }
 

--- a/test/strategies/java-yoshi.ts
+++ b/test/strategies/java-yoshi.ts
@@ -133,6 +133,37 @@ describe('JavaYoshi', () => {
       );
       expect(release!.version?.toString()).to.eql(expectedVersion);
     });
+
+    it('returns a major/minor version bump PR if skipSnapShot is true', async () => {
+      const expectedVersion = '0.123.5';
+      const strategy = new JavaYoshi({
+        targetBranch: 'main',
+        github,
+        component: 'google-cloud-automl',
+        skipSnapshot: true,
+      });
+      sandbox.stub(github, 'findFilesByFilenameAndRef').resolves([]);
+      const getFileContentsStub = sandbox.stub(
+        github,
+        'getFileContentsOnBranch'
+      );
+      getFileContentsStub
+        .withArgs('versions.txt', 'main')
+        .resolves(
+          buildGitHubFileContent(fixturesPath, 'versions-released.txt')
+        );
+      const latestRelease = {
+        tag: new TagName(Version.parse('0.123.4'), 'google-cloud-automl'),
+        sha: 'abc123',
+        notes: 'some notes',
+      };
+      const release = await strategy.buildReleasePullRequest(
+        COMMITS,
+        latestRelease
+      );
+      expect(release!.version?.toString()).to.eql(expectedVersion);
+    });
+
     it('handles promotion to 1.0.0', async () => {
       const commits = [
         ...buildMockConventionalCommit(


### PR DESCRIPTION
**Description:**

In Java libraries, we are not publishing any **SNAPSHOT** artifacts on merging **SNAPSHOT** PRs. Creating a **SNAPSHOT** PR is an overhead because all we do in the SNAPSHOT is merge the PR to generate the actual PRs. 

We will providing the options to the library owners to disable creating SNAPSHOT if it's irrelevant to their repositories.
