### PR TITLE
docs: fix typo in manifest-releaser.md

### DIFF
--- a/docs/manifest-releaser.md
+++ b/docs/manifest-releaser.md
@@ -1,7 +1,7 @@
 # Manifest Driven release-please
 
 release-please can be setup to use source-controlled files containing releaser
-specific configuration (the `release-please-config.json`) as well package
+specific configuration (the `release-please-config.json`) as well as package
 version tracking (the `.release-please-manifest.json`).
 
 The motivation of the manifest-based releaser is support for monorepos:


### PR DESCRIPTION
No issue opened — trivial documentation fix.

Small typo fix in docs/manifest-releaser.md:
"as well package version tracking" → "as well as package version tracking".
