### PR TITLE
feat(java): support release candidates in java

### DIFF
--- a/src/strategies/java.ts
+++ b/src/strategies/java.ts
@@ -104,7 +104,7 @@ export class Java extends BaseStrategy {
   ): Promise<ReleasePullRequest> {
     const component = await this.getComponent();
     const newVersion = latestRelease
-      ? await this.snapshotVersioning.bump(latestRelease.tag.version, [])
+      ? this.snapshotVersioning.bump(latestRelease.tag.version, [])
       : this.initialReleaseVersion();
     const versionsMap = await this.buildVersionsMap([]);
     for (const [component, version] of versionsMap.entries()) {

--- a/test/strategies/java.ts
+++ b/test/strategies/java.ts
@@ -133,6 +133,34 @@ describe('Java', () => {
         assertNoHasUpdate(release!.updates, 'CHANGELOG.md');
       });
 
+      it('returns an rc number bump snapshot PR', async () => {
+        const strategy = new Java({
+          targetBranch: 'main',
+          github,
+        });
+
+        const latestRelease = {
+          tag: new TagName(Version.parse('2.3.3-rc1')),
+          sha: 'abc123',
+          notes: 'some notes',
+        };
+        const release = await strategy.buildReleasePullRequest(
+          COMMITS_NO_SNAPSHOT,
+          latestRelease,
+          false,
+          DEFAULT_LABELS
+        );
+
+        expect(release?.version?.toString()).to.eql('2.3.3-rc2-SNAPSHOT');
+        expect(release?.title.toString()).to.eql(
+          'chore(main): release 2.3.3-rc2-SNAPSHOT'
+        );
+        expect(release?.headRefName).to.eql('release-please--branches--main');
+        expect(release?.draft).to.eql(false);
+        expect(release?.labels).to.eql(DEFAULT_SNAPSHOT_LABELS);
+        assertNoHasUpdate(release!.updates, 'CHANGELOG.md');
+      });
+
       it('skips a snapshot bump PR', async () => {
         const strategy = new Java({
           targetBranch: 'main',

--- a/test/versioning-strategies/java.ts
+++ b/test/versioning-strategies/java.ts
@@ -138,22 +138,22 @@ describe('JavaVersioningStrategy', () => {
           new DefaultVersioningStrategy({bumpMinorPreMajor: true})
         );
         const oldVersion = Version.parse('0.1.2-SNAPSHOT');
-        const newVersion = await strategy.bump(oldVersion, breakingCommits);
+        const newVersion = strategy.bump(oldVersion, breakingCommits);
         expect(newVersion.toString()).to.equal('0.2.0');
       });
 
       describe('with release candidate qualifier', () => {
         it('can bump a major', async () => {
           const strategy = new JavaSnapshot(new DefaultVersioningStrategy({}));
-          const oldVersion = Version.parse('1.2.0-rc1-SNAPSHOT');
-          const newVersion = await strategy.bump(oldVersion, breakingCommits);
+          const oldVersion = Version.parse('1.2.0-rc2-SNAPSHOT');
+          const newVersion = strategy.bump(oldVersion, breakingCommits);
           expect(newVersion.toString()).to.equal('2.0.0-rc1');
         });
 
         it('can bump a major on pre major for breaking change', async () => {
           const strategy = new JavaSnapshot(new DefaultVersioningStrategy({}));
-          const oldVersion = Version.parse('0.1.2-rc1-SNAPSHOT');
-          const newVersion = await strategy.bump(oldVersion, breakingCommits);
+          const oldVersion = Version.parse('0.1.2-rc2-SNAPSHOT');
+          const newVersion = strategy.bump(oldVersion, breakingCommits);
           expect(newVersion.toString()).to.equal('1.0.0-rc1');
         });
 
@@ -161,8 +161,8 @@ describe('JavaVersioningStrategy', () => {
           const strategy = new JavaSnapshot(
             new DefaultVersioningStrategy({bumpMinorPreMajor: true})
           );
-          const oldVersion = Version.parse('0.1.2-rc1-SNAPSHOT');
-          const newVersion = await strategy.bump(oldVersion, breakingCommits);
+          const oldVersion = Version.parse('0.1.2-rc2-SNAPSHOT');
+          const newVersion = strategy.bump(oldVersion, breakingCommits);
           expect(newVersion.toString()).to.equal('0.2.0-rc1');
         });
       });
@@ -194,14 +194,14 @@ describe('JavaVersioningStrategy', () => {
       describe('with release candidate qualifier', () => {
         it('can bump a minor', async () => {
           const strategy = new JavaSnapshot(new DefaultVersioningStrategy({}));
-          const oldVersion = Version.parse('1.2.3-rc1-SNAPSHOT');
-          const newVersion = await strategy.bump(oldVersion, featureCommits);
+          const oldVersion = Version.parse('1.2.3-rc2-SNAPSHOT');
+          const newVersion = strategy.bump(oldVersion, featureCommits);
           expect(newVersion.toString()).to.equal('1.3.0-rc1');
         });
         it('can bump a minor pre-major', async () => {
           const strategy = new JavaSnapshot(new DefaultVersioningStrategy({}));
-          const oldVersion = Version.parse('0.1.2-rc1-SNAPSHOT');
-          const newVersion = await strategy.bump(oldVersion, featureCommits);
+          const oldVersion = Version.parse('0.1.2-rc2-SNAPSHOT');
+          const newVersion = strategy.bump(oldVersion, featureCommits);
           expect(newVersion.toString()).to.equal('0.2.0-rc1');
         });
         it('can bump a patch pre-major', async () => {
@@ -210,9 +210,9 @@ describe('JavaVersioningStrategy', () => {
               bumpPatchForMinorPreMajor: true,
             })
           );
-          const oldVersion = Version.parse('0.1.2-rc1-SNAPSHOT');
-          const newVersion = await strategy.bump(oldVersion, featureCommits);
-          expect(newVersion.toString()).to.equal('0.1.2-rc1');
+          const oldVersion = Version.parse('0.1.2-rc2-SNAPSHOT');
+          const newVersion = strategy.bump(oldVersion, featureCommits);
+          expect(newVersion.toString()).to.equal('0.1.2-rc2');
         });
       });
     });
@@ -226,9 +226,9 @@ describe('JavaVersioningStrategy', () => {
       });
       it('can bump a patch with release candidate qualifier', async () => {
         const strategy = new JavaSnapshot(new DefaultVersioningStrategy({}));
-        const oldVersion = Version.parse('1.2.3-rc1-SNAPSHOT');
-        const newVersion = await strategy.bump(oldVersion, fixCommits);
-        expect(newVersion.toString()).to.equal('1.2.3-rc1');
+        const oldVersion = Version.parse('1.2.3-rc2-SNAPSHOT');
+        const newVersion = strategy.bump(oldVersion, fixCommits);
+        expect(newVersion.toString()).to.equal('1.2.3-rc2');
       });
     });
   });
@@ -261,34 +261,6 @@ describe('JavaVersioningStrategy', () => {
         const newVersion = await strategy.bump(oldVersion, breakingCommits);
         expect(newVersion.toString()).to.equal('0.1.2-sp.1');
       });
-      describe('with release candidate qualifier', () => {
-        it('can bump a major', async () => {
-          const strategy = new JavaSnapshot(
-            new ServicePackVersioningStrategy({})
-          );
-          const oldVersion = Version.parse('1.2.3-sp.1-rc1-SNAPSHOT');
-          const newVersion = await strategy.bump(oldVersion, breakingCommits);
-          expect(newVersion.toString()).to.equal('1.2.3-sp.1-rc1');
-        });
-
-        it('can bump a major on pre major for breaking change', async () => {
-          const strategy = new JavaSnapshot(
-            new ServicePackVersioningStrategy({})
-          );
-          const oldVersion = Version.parse('0.1.2-sp.1-rc1-SNAPSHOT');
-          const newVersion = await strategy.bump(oldVersion, breakingCommits);
-          expect(newVersion.toString()).to.equal('0.1.2-sp.1-rc1');
-        });
-
-        it('can bump a minor pre major for breaking change', async () => {
-          const strategy = new JavaSnapshot(
-            new ServicePackVersioningStrategy({bumpMinorPreMajor: true})
-          );
-          const oldVersion = Version.parse('0.1.2-sp.1-rc1-SNAPSHOT');
-          const newVersion = await strategy.bump(oldVersion, breakingCommits);
-          expect(newVersion.toString()).to.equal('0.1.2-sp.1-rc1');
-        });
-      });
     });
 
     describe('with a feature', () => {
@@ -318,34 +290,6 @@ describe('JavaVersioningStrategy', () => {
         const newVersion = await strategy.bump(oldVersion, featureCommits);
         expect(newVersion.toString()).to.equal('0.1.2-sp.1');
       });
-      describe('with release candidate qualifier', () => {
-        it('can bump a minor', async () => {
-          const strategy = new JavaSnapshot(
-            new ServicePackVersioningStrategy({})
-          );
-          const oldVersion = Version.parse('1.2.3-sp.1-rc1-SNAPSHOT');
-          const newVersion = await strategy.bump(oldVersion, featureCommits);
-          expect(newVersion.toString()).to.equal('1.2.3-sp.1-rc1');
-        });
-
-        it('can bump a minor on pre major for breaking change', async () => {
-          const strategy = new JavaSnapshot(
-            new ServicePackVersioningStrategy({})
-          );
-          const oldVersion = Version.parse('0.1.2-sp.1-rc1-SNAPSHOT');
-          const newVersion = await strategy.bump(oldVersion, featureCommits);
-          expect(newVersion.toString()).to.equal('0.1.2-sp.1-rc1');
-        });
-
-        it('can bump a minor pre major for breaking change', async () => {
-          const strategy = new JavaSnapshot(
-            new ServicePackVersioningStrategy({bumpMinorPreMajor: true})
-          );
-          const oldVersion = Version.parse('0.1.2-sp.1-rc1-SNAPSHOT');
-          const newVersion = await strategy.bump(oldVersion, featureCommits);
-          expect(newVersion.toString()).to.equal('0.1.2-sp.1-rc1');
-        });
-      });
     });
 
     describe('with a fix', () => {
@@ -374,34 +318,6 @@ describe('JavaVersioningStrategy', () => {
         const oldVersion = Version.parse('0.1.2-sp.1-SNAPSHOT');
         const newVersion = await strategy.bump(oldVersion, fixCommits);
         expect(newVersion.toString()).to.equal('0.1.2-sp.1');
-      });
-      describe('with release candidate qualifier', () => {
-        it('can bump a patch', async () => {
-          const strategy = new JavaSnapshot(
-            new ServicePackVersioningStrategy({})
-          );
-          const oldVersion = Version.parse('1.2.3-sp.1-rc1-SNAPSHOT');
-          const newVersion = await strategy.bump(oldVersion, fixCommits);
-          expect(newVersion.toString()).to.equal('1.2.3-sp.1-rc1');
-        });
-
-        it('can bump a patch on pre major for breaking change', async () => {
-          const strategy = new JavaSnapshot(
-            new ServicePackVersioningStrategy({})
-          );
-          const oldVersion = Version.parse('0.1.2-sp.1-rc1-SNAPSHOT');
-          const newVersion = await strategy.bump(oldVersion, fixCommits);
-          expect(newVersion.toString()).to.equal('0.1.2-sp.1-rc1');
-        });
-
-        it('can bump a patch pre major for breaking change', async () => {
-          const strategy = new JavaSnapshot(
-            new ServicePackVersioningStrategy({bumpMinorPreMajor: true})
-          );
-          const oldVersion = Version.parse('0.1.2-sp.1-SNAPSHOT');
-          const newVersion = await strategy.bump(oldVersion, fixCommits);
-          expect(newVersion.toString()).to.equal('0.1.2-sp.1');
-        });
       });
     });
   });
@@ -433,25 +349,25 @@ describe('JavaVersioningStrategy', () => {
       describe('with release candidate qualifier', () => {
         it('can bump a major', async () => {
           const strategy = new JavaSnapshot(new AlwaysBumpPatch({}));
-          const oldVersion = Version.parse('1.2.3-rc1-SNAPSHOT');
-          const newVersion = await strategy.bump(oldVersion, breakingCommits);
-          expect(newVersion.toString()).to.equal('1.2.3-rc1');
+          const oldVersion = Version.parse('1.2.3-rc2-SNAPSHOT');
+          const newVersion = strategy.bump(oldVersion, breakingCommits);
+          expect(newVersion.toString()).to.equal('1.2.3-rc2');
         });
 
         it('can bump a major on pre major for breaking change', async () => {
           const strategy = new JavaSnapshot(new AlwaysBumpPatch({}));
-          const oldVersion = Version.parse('0.1.2-rc1-SNAPSHOT');
-          const newVersion = await strategy.bump(oldVersion, breakingCommits);
-          expect(newVersion.toString()).to.equal('0.1.2-rc1');
+          const oldVersion = Version.parse('0.1.2-rc2-SNAPSHOT');
+          const newVersion = strategy.bump(oldVersion, breakingCommits);
+          expect(newVersion.toString()).to.equal('0.1.2-rc2');
         });
 
         it('can bump a minor pre major for breaking change', async () => {
           const strategy = new JavaSnapshot(
             new AlwaysBumpPatch({bumpMinorPreMajor: true})
           );
-          const oldVersion = Version.parse('0.1.2-rc1-SNAPSHOT');
-          const newVersion = await strategy.bump(oldVersion, breakingCommits);
-          expect(newVersion.toString()).to.equal('0.1.2-rc1');
+          const oldVersion = Version.parse('0.1.2-rc2-SNAPSHOT');
+          const newVersion = strategy.bump(oldVersion, breakingCommits);
+          expect(newVersion.toString()).to.equal('0.1.2-rc2');
         });
       });
     });
@@ -482,25 +398,25 @@ describe('JavaVersioningStrategy', () => {
       describe('with release candidate qualifier', () => {
         it('can bump a minor', async () => {
           const strategy = new JavaSnapshot(new AlwaysBumpPatch({}));
-          const oldVersion = Version.parse('1.2.3-rc1-SNAPSHOT');
-          const newVersion = await strategy.bump(oldVersion, featureCommits);
-          expect(newVersion.toString()).to.equal('1.2.3-rc1');
+          const oldVersion = Version.parse('1.2.3-rc2-SNAPSHOT');
+          const newVersion = strategy.bump(oldVersion, featureCommits);
+          expect(newVersion.toString()).to.equal('1.2.3-rc2');
         });
 
         it('can bump a minor on pre major for breaking change', async () => {
           const strategy = new JavaSnapshot(new AlwaysBumpPatch({}));
-          const oldVersion = Version.parse('0.1.2-rc1-SNAPSHOT');
-          const newVersion = await strategy.bump(oldVersion, featureCommits);
-          expect(newVersion.toString()).to.equal('0.1.2-rc1');
+          const oldVersion = Version.parse('0.1.2-rc2-SNAPSHOT');
+          const newVersion = strategy.bump(oldVersion, featureCommits);
+          expect(newVersion.toString()).to.equal('0.1.2-rc2');
         });
 
         it('can bump a minor pre major for breaking change', async () => {
           const strategy = new JavaSnapshot(
             new AlwaysBumpPatch({bumpMinorPreMajor: true})
           );
-          const oldVersion = Version.parse('0.1.2-rc1-SNAPSHOT');
-          const newVersion = await strategy.bump(oldVersion, featureCommits);
-          expect(newVersion.toString()).to.equal('0.1.2-rc1');
+          const oldVersion = Version.parse('0.1.2-rc2-SNAPSHOT');
+          const newVersion = strategy.bump(oldVersion, featureCommits);
+          expect(newVersion.toString()).to.equal('0.1.2-rc2');
         });
       });
     });
@@ -509,7 +425,7 @@ describe('JavaVersioningStrategy', () => {
       it('can bump a patch', async () => {
         const strategy = new JavaSnapshot(new AlwaysBumpPatch({}));
         const oldVersion = Version.parse('1.2.3-SNAPSHOT');
-        const newVersion = await strategy.bump(oldVersion, fixCommits);
+        const newVersion = strategy.bump(oldVersion, fixCommits);
         expect(newVersion.toString()).to.equal('1.2.3');
       });
 
@@ -531,25 +447,25 @@ describe('JavaVersioningStrategy', () => {
       describe('with release candidate qualifier', () => {
         it('can bump a patch', async () => {
           const strategy = new JavaSnapshot(new AlwaysBumpPatch({}));
-          const oldVersion = Version.parse('1.2.3-rc1-SNAPSHOT');
-          const newVersion = await strategy.bump(oldVersion, fixCommits);
-          expect(newVersion.toString()).to.equal('1.2.3-rc1');
+          const oldVersion = Version.parse('1.2.3-rc2-SNAPSHOT');
+          const newVersion = strategy.bump(oldVersion, fixCommits);
+          expect(newVersion.toString()).to.equal('1.2.3-rc2');
         });
 
         it('can bump a patch on pre major for breaking change', async () => {
           const strategy = new JavaSnapshot(new AlwaysBumpPatch({}));
-          const oldVersion = Version.parse('0.1.2-rc1-SNAPSHOT');
-          const newVersion = await strategy.bump(oldVersion, fixCommits);
-          expect(newVersion.toString()).to.equal('0.1.2-rc1');
+          const oldVersion = Version.parse('0.1.2-rc2-SNAPSHOT');
+          const newVersion = strategy.bump(oldVersion, fixCommits);
+          expect(newVersion.toString()).to.equal('0.1.2-rc2');
         });
 
         it('can bump a patch pre major for breaking change', async () => {
           const strategy = new JavaSnapshot(
             new AlwaysBumpPatch({bumpMinorPreMajor: true})
           );
-          const oldVersion = Version.parse('0.1.2-rc1-SNAPSHOT');
-          const newVersion = await strategy.bump(oldVersion, fixCommits);
-          expect(newVersion.toString()).to.equal('0.1.2-rc1');
+          const oldVersion = Version.parse('0.1.2-rc2-SNAPSHOT');
+          const newVersion = strategy.bump(oldVersion, fixCommits);
+          expect(newVersion.toString()).to.equal('0.1.2-rc2');
         });
       });
     });


### PR DESCRIPTION
Active only when we have a prerelease suffix (-rc).
    
By default, after releasing a library versioned as X.Y.Z-rc(n),
a snapshot PR will set it to X.Y.Z-rc(n+1)-SNAPSHOT.

When determining the next release, the version may be
reset from `rc(m)` to `rc1` if:
 - a minor bump is determined for next release
 - a major bump is determined for next release
    
Otherwise, the `-SNAPSHOT` string will simply be removed.

NOTE: This is not compatible with ServicePack versioning.