### PR TITLE
feat: add setting to define extra prefix / conventional-commit type mapping

### DIFF
--- a/schemas/config.json
+++ b/schemas/config.json
@@ -20,6 +20,13 @@
           "description": "Feature changes only bump semver patch if version < 1.0.0",
           "type": "boolean"
         },
+        "extra-prefix-mapping": {
+          "description": "Map custom commit prefixes to conventional commit types. Use empty string (\"\") to map non-conventional commits. Example: {\"change\": \"fix\", \"\": \"chore\"}",
+          "type": "object",
+          "additionalProperties": {
+            "type": "string"
+          }
+        },
         "prerelease-type": {
           "description": "Configuration option for the prerelease versioning strategy. If prerelease strategy used and type set, will set the prerelease part of the version to the provided value in case prerelease part is not present.",
           "type": "string"

--- a/src/manifest.ts
+++ b/src/manifest.ts
@@ -101,6 +101,7 @@ export interface ReleaserConfig {
   bumpMinorPreMajor?: boolean;
   bumpPatchForMinorPreMajor?: boolean;
   prereleaseType?: string;
+  extraPrefixMapping?: Record<string, string>;
 
   // Strategy options
   releaseAs?: string;
@@ -161,6 +162,7 @@ interface ReleaserConfigJson {
   'bump-minor-pre-major'?: boolean;
   'bump-patch-for-minor-pre-major'?: boolean;
   'prerelease-type'?: string;
+  'extra-prefix-mapping'?: Record<string, string>;
   'changelog-sections'?: ChangelogSection[];
   'release-as'?: string;
   'skip-github-release'?: boolean;
@@ -735,7 +737,8 @@ export class Manifest {
       this.logger.debug(`targetBranch: ${this.targetBranch}`);
       let pathCommits = parseConventionalCommits(
         commitsPerPath[path],
-        this.logger
+        this.logger,
+        config.extraPrefixMapping
       );
       // The processCommits hook can be implemented by plugins to
       // post-process commits. This can be used to perform cleanup, e.g,, sentence
@@ -1379,6 +1382,7 @@ function extractReleaserConfig(
     bumpMinorPreMajor: config['bump-minor-pre-major'],
     bumpPatchForMinorPreMajor: config['bump-patch-for-minor-pre-major'],
     prereleaseType: config['prerelease-type'],
+    extraPrefixMapping: config['extra-prefix-mapping'],
     versioning: config['versioning'],
     changelogSections: config['changelog-sections'],
     changelogPath: config['changelog-path'],

--- a/test/util/filter-commits.ts
+++ b/test/util/filter-commits.ts
@@ -89,4 +89,49 @@ describe('filterCommits', () => {
     ]);
     expect(commits.length).to.equal(1);
   });
+  it('includes commits with fix type', () => {
+    const commits = filterCommits([
+      {
+        type: 'fix',
+        notes: [],
+        references: [],
+        bareMessage: 'update readme',
+        message: 'update readme',
+        scope: null,
+        breaking: false,
+        sha: 'abc123',
+      },
+    ]);
+    expect(commits.length).to.equal(1);
+  });
+  it('includes commits with feat type', () => {
+    const commits = filterCommits([
+      {
+        type: 'feat',
+        notes: [],
+        references: [],
+        bareMessage: 'add new feature',
+        message: 'add new feature',
+        scope: null,
+        breaking: false,
+        sha: 'def456',
+      },
+    ]);
+    expect(commits.length).to.equal(1);
+  });
+  it('excludes commits with chore type', () => {
+    const commits = filterCommits([
+      {
+        type: 'chore',
+        notes: [],
+        references: [],
+        bareMessage: 'update dependencies',
+        message: 'update dependencies',
+        scope: null,
+        breaking: false,
+        sha: 'ghi789',
+      },
+    ]);
+    expect(commits.length).to.equal(0);
+  });
 });


### PR DESCRIPTION
Add `extra-prefix-mapping` configuration to map arbitrary commit prefixes to conventional
commit types, enabling flexible handling of various commit message conventions.

This change enables release-please to handle various commit message conventions
by providing a flexible mapping mechanism. Key use cases include:

- **Emoji-based commits**: Map emoji prefixes (e.g., 🐛, ✨, 📝) to conventional types
  when using workflows like [gitmoji](https://github.com/arvinxx/gitmoji-commit-workflow)
- **Custom commit prefixes**: Map organization-specific prefixes (e.g., "change:", "update:") to conventional types
- **Legacy code integration**: Handle non-conventional commits when merging legacy codebases
  by mapping the empty string ("") to a default type

Fully backward compatible - feature disabled by default.

Fixes #2623.
Fixes #2385.