### PR TITLE
feat: add include-v-in-release-name config option

### DIFF
--- a/schemas/config.json
+++ b/schemas/config.json
@@ -86,6 +86,10 @@
           "description": "When tagging a release, include `v` in the tag. Defaults to `false`.",
           "type": "boolean"
         },
+        "include-v-in-release-name": {
+          "description": "Include `v` in the GitHub release name. Defaults to `true`.",
+          "type": "boolean"
+        },
         "changelog-type": {
           "description": "The type of changelog to use. Defaults to `default`.",
           "type": "string",
@@ -471,6 +475,7 @@
     "extra-label": true,
     "include-component-in-tag": true,
     "include-v-in-tag": true,
+    "include-v-in-release-name": true,
     "changelog-type": true,
     "changelog-host": true,
     "changelog-path": true,

--- a/src/manifest.ts
+++ b/src/manifest.ts
@@ -113,6 +113,7 @@ export interface ReleaserConfig {
   packageName?: string;
   includeComponentInTag?: boolean;
   includeVInTag?: boolean;
+  includeVInReleaseName?: boolean;
   pullRequestTitlePattern?: string;
   pullRequestHeader?: string;
   pullRequestFooter?: string;
@@ -172,6 +173,7 @@ interface ReleaserConfigJson {
   'extra-label'?: string;
   'include-component-in-tag'?: boolean;
   'include-v-in-tag'?: boolean;
+  'include-v-in-release-name'?: boolean;
   'changelog-type'?: ChangelogNotesType;
   'changelog-host'?: string;
   'pull-request-title-pattern'?: string;
@@ -1393,6 +1395,7 @@ function extractReleaserConfig(
     extraFiles: config['extra-files'],
     includeComponentInTag: config['include-component-in-tag'],
     includeVInTag: config['include-v-in-tag'],
+    includeVInReleaseName: config['include-v-in-release-name'],
     changelogType: config['changelog-type'],
     pullRequestTitlePattern: config['pull-request-title-pattern'],
     pullRequestHeader: config['pull-request-header'],
@@ -1750,6 +1753,8 @@ function mergeReleaserConfig(
     includeComponentInTag:
       pathConfig.includeComponentInTag ?? defaultConfig.includeComponentInTag,
     includeVInTag: pathConfig.includeVInTag ?? defaultConfig.includeVInTag,
+    includeVInReleaseName:
+      pathConfig.includeVInReleaseName ?? defaultConfig.includeVInReleaseName,
     tagSeparator: pathConfig.tagSeparator ?? defaultConfig.tagSeparator,
     pullRequestTitlePattern:
       pathConfig.pullRequestTitlePattern ??

--- a/src/strategies/base.ts
+++ b/src/strategies/base.ts
@@ -75,6 +75,7 @@ export interface BaseStrategyOptions {
   changelogNotes?: ChangelogNotes;
   includeComponentInTag?: boolean;
   includeVInTag?: boolean;
+  includeVInReleaseName?: boolean;
   pullRequestTitlePattern?: string;
   pullRequestHeader?: string;
   pullRequestFooter?: string;
@@ -110,6 +111,7 @@ export abstract class BaseStrategy implements Strategy {
   private releaseAs?: string;
   protected includeComponentInTag: boolean;
   protected includeVInTag: boolean;
+  protected includeVInReleaseName: boolean;
   protected initialVersion?: string;
   readonly pullRequestTitlePattern?: string;
   readonly pullRequestHeader?: string;
@@ -147,6 +149,7 @@ export abstract class BaseStrategy implements Strategy {
       options.changelogNotes || new DefaultChangelogNotes(options);
     this.includeComponentInTag = options.includeComponentInTag ?? true;
     this.includeVInTag = options.includeVInTag ?? true;
+    this.includeVInReleaseName = options.includeVInReleaseName ?? true;
     this.pullRequestTitlePattern = options.pullRequestTitlePattern;
     this.pullRequestHeader = options.pullRequestHeader;
     this.pullRequestFooter = options.pullRequestFooter;
@@ -698,10 +701,11 @@ export abstract class BaseStrategy implements Strategy {
       this.tagSeparator,
       this.includeVInTag
     );
+    const versionPrefix = this.includeVInReleaseName ? 'v' : '';
     const releaseName =
       component && this.includeComponentInTag
-        ? `${component}: v${version.toString()}`
-        : `v${version.toString()}`;
+        ? `${component}: ${versionPrefix}${version.toString()}`
+        : `${versionPrefix}${version.toString()}`;
     return {
       name: releaseName,
       tag,

--- a/src/updaters/release-please-config.ts
+++ b/src/updaters/release-please-config.ts
@@ -72,6 +72,7 @@ function releaserConfigToJsonConfig(
     'release-label': config.releaseLabels?.join(','),
     'include-component-in-tag': config.includeComponentInTag,
     'include-v-in-tag': config.includeVInTag,
+    'include-v-in-release-name': config.includeVInReleaseName,
     'changelog-type': config.changelogType,
     'changelog-host': config.changelogHost,
     'pull-request-title-pattern': config.pullRequestTitlePattern,

--- a/test/strategies/base.ts
+++ b/test/strategies/base.ts
@@ -452,5 +452,67 @@ describe('Strategy', () => {
       expect(release, 'Release').to.not.be.undefined;
       expect(release!.tag.toString()).to.eql('1.2.3');
     });
+    it('skips v in release name', async () => {
+      const strategy = new TestStrategy({
+        targetBranch: 'main',
+        github,
+        component: 'google-cloud-automl',
+        includeComponentInTag: false,
+        includeVInReleaseName: false,
+      });
+      const release = await strategy.buildRelease({
+        title: 'chore(main): release v1.2.3',
+        headBranchName: 'release-please/branches/main',
+        baseBranchName: 'main',
+        number: 1234,
+        body: new PullRequestBody([]).toString(),
+        labels: [],
+        files: [],
+        sha: 'abc123',
+      });
+      expect(release, 'Release').to.not.be.undefined;
+      expect(release!.name).to.eql('1.2.3');
+    });
+    it('skips v in release name with component', async () => {
+      const strategy = new TestStrategy({
+        targetBranch: 'main',
+        github,
+        component: 'google-cloud-automl',
+        includeComponentInTag: true,
+        includeVInReleaseName: false,
+      });
+      const release = await strategy.buildRelease({
+        title: 'chore(main): release v1.2.3',
+        headBranchName: 'release-please/branches/main',
+        baseBranchName: 'main',
+        number: 1234,
+        body: new PullRequestBody([]).toString(),
+        labels: [],
+        files: [],
+        sha: 'abc123',
+      });
+      expect(release, 'Release').to.not.be.undefined;
+      expect(release!.name).to.eql('google-cloud-automl: 1.2.3');
+    });
+    it('includes v in release name by default', async () => {
+      const strategy = new TestStrategy({
+        targetBranch: 'main',
+        github,
+        component: 'google-cloud-automl',
+        includeComponentInTag: false,
+      });
+      const release = await strategy.buildRelease({
+        title: 'chore(main): release v1.2.3',
+        headBranchName: 'release-please/branches/main',
+        baseBranchName: 'main',
+        number: 1234,
+        body: new PullRequestBody([]).toString(),
+        labels: [],
+        files: [],
+        sha: 'abc123',
+      });
+      expect(release, 'Release').to.not.be.undefined;
+      expect(release!.name).to.eql('v1.2.3');
+    });
   });
 });


### PR DESCRIPTION
## Summary

This PR adds a new configuration option `include-v-in-release-name` that controls whether the `v` prefix is included in GitHub release names.

### Problem

Currently, the GitHub release name is hardcoded to always include the `v` prefix (e.g., `v1.2.3`). Users who prefer releases without the `v` prefix have no way to configure this. While `include-v-in-tag` exists to control the tag name, there's no equivalent for the release name.

### Solution

Added a new `include-v-in-release-name` boolean configuration option that:

- Defaults to `true` (maintains backwards compatibility)
- When set to `false`, creates releases without the `v` prefix (e.g., `1.2.3`)
- Works independently of `include-v-in-tag` to allow different formats for tags vs release names

### Changes

- **schemas/config.json**: Added `include-v-in-release-name` property to the schema
- **src/manifest.ts**: Added `includeVInReleaseName` to `ReleaserConfig` interface and config parsing
- **src/strategies/base.ts**: Modified release name generation to use the new option
- **src/updaters/release-please-config.ts**: Added serialization support
- **test/strategies/base.ts**: Added tests for the new functionality

### Example Config

```json
{
  "include-v-in-tag": false,
  "include-v-in-release-name": false,
  "packages": {
    ".": {
      "release-type": "node"
    }
  }
}
```

With this config:
- Tag: `1.2.3`
- Release name: `1.2.3`

### Use Case

Users who:
1. Want consistent naming between tags and release names without `v`
2. Have downstream tooling that expects release names without the `v` prefix
3. Prefer semantic version numbers without the `v` prefix for releases

This follows the pattern established by the existing `include-v-in-tag` option and provides users with complete control over version prefix formatting.