### PR TITLE
fix: wire --latest-tag-version CLI option to ManifestOptions

### DIFF
--- a/src/bin/release-please.ts
+++ b/src/bin/release-please.ts
@@ -878,7 +878,7 @@ interface HandleError {
 }
 
 function extractManifestOptions(
-  argv: GitHubArgs & (PullRequestArgs | ReleaseArgs)
+  argv: GitHubArgs & (PullRequestArgs | ReleaseArgs) & Partial<VersioningArgs>
 ): ManifestOptions {
   const manifestOptions: ManifestOptions = {};
   if ('fork' in argv && argv.fork !== undefined) {
@@ -906,6 +906,12 @@ function extractManifestOptions(
   }
   if ('draftPullRequest' in argv && argv.draftPullRequest !== undefined) {
     manifestOptions.draftPullRequest = argv.draftPullRequest;
+  }
+  if ('latestTagVersion' in argv && argv.latestTagVersion) {
+    manifestOptions.latestTagVersion = argv.latestTagVersion;
+  }
+  if ('latestTagSha' in argv && argv.latestTagSha) {
+    manifestOptions.lastReleaseSha = argv.latestTagSha;
   }
   return manifestOptions;
 }


### PR DESCRIPTION
The `--latest-tag-version` and `--latest-tag-sha` CLI options are defined but not wired up to `ManifestOptions`, making them non-functional.
This change wires these options to `ManifestOptions`.

This enables scenarios where the latest release version cannot be automatically discovered and thus needs to be passed via CLI options.
