### PR TITLE
feat: component references and automatic dependency tracking

### DIFF
--- a/docs/manifest-releaser.md
+++ b/docs/manifest-releaser.md
@@ -648,3 +648,185 @@ will only open pull requests for snapshot pull requests if there are any. This w
 mix/match of snapshot and non-snapshot version bumps.
 
 The `groups` option is a list of group names sorted with the highest priority first.
+
+## Component References in extra-files
+
+The `extra-files` configuration option allows you to specify additional files that should be updated when a component is released. By default, these files are updated with the component's own version. However, you can use **component references** to update files with versions from other components in your monorepo.
+
+This is particularly useful for scenarios like:
+- Helm charts that reference container image versions
+- Applications that embed library versions
+- Documentation that needs to track dependency versions
+- Docker Compose files that reference multiple service versions
+
+### Configuration Options
+
+When configuring `extra-files`, you can use the following options:
+
+#### `component`
+
+Specifies which component's version to use for the update. If omitted, uses the current component's version.
+
+```json
+{
+  "packages": {
+    "containers/app1": {
+      "component": "app1",
+      "release-type": "simple"
+    },
+    "charts/my-chart": {
+      "component": "my-chart",
+      "release-type": "helm",
+      "extra-files": [
+        {
+          "type": "yaml",
+          "path": "charts/my-chart/values.yaml",
+          "jsonpath": "$.image.app1.tag",
+          "component": "app1"
+        }
+      ]
+    }
+  }
+}
+```
+
+#### `template`
+
+Formats the version using a template string. Supports the following variables:
+
+- `{{version}}` - Full version (e.g., `1.2.3`)
+- `{{major}}` - Major version number (e.g., `1`)
+- `{{minor}}` - Minor version number (e.g., `2`)
+- `{{patch}}` - Patch version number (e.g., `3`)
+- `{{prerelease}}` - Prerelease suffix (e.g., `beta.1`)
+- `{{component}}` - Component name
+
+```json
+{
+  "extra-files": [
+    {
+      "type": "yaml",
+      "path": "values.yaml",
+      "jsonpath": "$.image.tag",
+      "component": "app1",
+      "template": "v{{version}}"
+    },
+    {
+      "type": "yaml",
+      "path": "values.yaml",
+      "jsonpath": "$.image.repository",
+      "component": "app1",
+      "template": "ghcr.io/myorg/{{component}}:{{version}}"
+    },
+    {
+      "type": "yaml",
+      "path": "Chart.yaml",
+      "jsonpath": "$.appVersion",
+      "component": "app1",
+      "template": "{{major}}.{{minor}}"
+    }
+  ]
+}
+```
+
+#### `bumpDependents`
+
+Determines whether changes to the referenced component should trigger a version bump of the current component. Defaults to `true`.
+
+When `bumpDependents` is `true`, release-please will automatically:
+- Track which components depend on other components
+- Create patch bumps for dependent components when their dependencies change
+- Update extra-files in dependents with the new dependency versions
+- Add dependency update notes to the PR body
+
+```json
+{
+  "extra-files": [
+    {
+      "type": "yaml",
+      "path": "values.yaml",
+      "jsonpath": "$.image.tag",
+      "component": "app1",
+      "bumpDependents": true
+    }
+  ]
+}
+```
+
+In this example, when `app1` is released, any component that references `app1` in its extra-files will automatically get a patch version bump.
+
+### Complete Example
+
+Here's a complete example of a monorepo with two containers and a Helm chart that depends on them:
+
+```json
+{
+  "packages": {
+    "containers/app1": {
+      "component": "app1",
+      "release-type": "simple"
+    },
+    "containers/app2": {
+      "component": "app2",
+      "release-type": "simple"
+    },
+    "charts/my-chart": {
+      "component": "my-chart",
+      "release-type": "helm",
+      "extra-files": [
+        {
+          "type": "yaml",
+          "path": "charts/my-chart/values.yaml",
+          "jsonpath": "$.images.app1.tag",
+          "component": "app1",
+          "template": "{{version}}"
+        },
+        {
+          "type": "yaml",
+          "path": "charts/my-chart/values.yaml",
+          "jsonpath": "$.images.app1.repository",
+          "component": "app1",
+          "template": "ghcr.io/myorg/{{component}}"
+        },
+        {
+          "type": "yaml",
+          "path": "charts/my-chart/values.yaml",
+          "jsonpath": "$.images.app2.tag",
+          "component": "app2",
+          "template": "{{version}}"
+        },
+        {
+          "type": "yaml",
+          "path": "charts/my-chart/Chart.yaml",
+          "jsonpath": "$.appVersion",
+          "component": "app1",
+          "template": "{{major}}.{{minor}}",
+          "bumpDependents": false
+        }
+      ]
+    }
+  }
+}
+```
+
+### Behavior
+
+When a release is created:
+
+1. **Component Version Resolution**: If an `extra-file` specifies a `component`, release-please looks up that component's version from the versions map
+2. **Template Rendering**: If a `template` is specified, the version is formatted using the template variables
+3. **File Update**: The resolved and formatted value is written to the specified file path using the appropriate updater (JSON, YAML, TOML, or XML)
+
+### Differences from linked-versions Plugin
+
+The `component` reference feature differs from the `linked-versions` plugin:
+
+| Feature | Component References | linked-versions Plugin |
+|---------|---------------------|------------------------|
+| **Version Synchronization** | Components maintain independent versions | All components forced to same version |
+| **Use Case** | Dependencies that need to track other component versions | Components that must always share the same version |
+| **Version Updates** | Only updates file references, not component versions | Updates all component versions to highest in group |
+| **Flexibility** | High - can reference any component's version | Low - all components must move together |
+
+Use component references when you want independent versioning with dependency tracking. Use `linked-versions` when you want components to always share the same version number.
+

--- a/schemas/config.json
+++ b/schemas/config.json
@@ -47,7 +47,10 @@
                 "type": "boolean"
               }
             },
-            "required": ["type", "section"]
+            "required": [
+              "type",
+              "section"
+            ]
           }
         },
         "release-as": {
@@ -93,7 +96,10 @@
         "changelog-type": {
           "description": "The type of changelog to use. Defaults to `default`.",
           "type": "string",
-          "enum": ["default", "github"]
+          "enum": [
+            "default",
+            "github"
+          ]
         },
         "changelog-host": {
           "description": "Generate changelog links to this GitHub host. Useful for running against GitHub Enterprise.",
@@ -146,7 +152,11 @@
                 "properties": {
                   "type": {
                     "description": "The file format type.",
-                    "enum": ["json", "toml", "yaml"]
+                    "enum": [
+                      "json",
+                      "toml",
+                      "yaml"
+                    ]
                   },
                   "path": {
                     "description": "The path to the file.",
@@ -159,9 +169,25 @@
                   "jsonpath": {
                     "description": "The jsonpath to the version entry in the file.",
                     "type": "string"
+                  },
+                  "component": {
+                    "description": "The component name to reference for the version. If specified, uses that component's version instead of the current component's version.",
+                    "type": "string"
+                  },
+                  "template": {
+                    "description": "Template string for formatting the version. Supports {{version}}, {{major}}, {{minor}}, {{patch}}, {{prerelease}}, {{component}}.",
+                    "type": "string"
+                  },
+                  "bumpDependents": {
+                    "description": "Whether changes to the referenced component should trigger a version bump of this component. Defaults to `true`.",
+                    "type": "boolean"
                   }
                 },
-                "required": ["type", "path", "jsonpath"]
+                "required": [
+                  "type",
+                  "path",
+                  "jsonpath"
+                ]
               },
               {
                 "description": "An extra XML file with a targeted update via xpath.",
@@ -169,7 +195,9 @@
                 "properties": {
                   "type": {
                     "description": "The file format type.",
-                    "enum": ["xml"]
+                    "enum": [
+                      "xml"
+                    ]
                   },
                   "path": {
                     "description": "The path to the file.",
@@ -182,9 +210,25 @@
                   "xpath": {
                     "description": "The xpath to the version entry in the file.",
                     "type": "string"
+                  },
+                  "component": {
+                    "description": "The component name to reference for the version. If specified, uses that component's version instead of the current component's version.",
+                    "type": "string"
+                  },
+                  "template": {
+                    "description": "Template string for formatting the version. Supports {{version}}, {{major}}, {{minor}}, {{patch}}, {{prerelease}}, {{component}}.",
+                    "type": "string"
+                  },
+                  "bumpDependents": {
+                    "description": "Whether changes to the referenced component should trigger a version bump of this component. Defaults to `true`.",
+                    "type": "boolean"
                   }
                 },
-                "required": ["type", "path", "xpath"]
+                "required": [
+                  "type",
+                  "path",
+                  "xpath"
+                ]
               },
               {
                 "description": "An extra pom.xml file.",
@@ -192,7 +236,9 @@
                 "properties": {
                   "type": {
                     "description": "The file format type.",
-                    "enum": ["pom"]
+                    "enum": [
+                      "pom"
+                    ]
                   },
                   "path": {
                     "description": "The path to the file.",
@@ -201,9 +247,24 @@
                   "glob": {
                     "description": "Whether to treat the path as a glob. Defaults to `false`.",
                     "type": "boolean"
+                  },
+                  "component": {
+                    "description": "The component name to reference for the version. If specified, uses that component's version instead of the current component's version.",
+                    "type": "string"
+                  },
+                  "template": {
+                    "description": "Template string for formatting the version. Supports {{version}}, {{major}}, {{minor}}, {{patch}}, {{prerelease}}, {{component}}.",
+                    "type": "string"
+                  },
+                  "bumpDependents": {
+                    "description": "Whether changes to the referenced component should trigger a version bump of this component. Defaults to `true`.",
+                    "type": "boolean"
                   }
                 },
-                "required": ["type", "path"]
+                "required": [
+                  "type",
+                  "path"
+                ]
               },
               {
                 "description": "An extra arbitrary file that includes release-please generic updater's annotation.",
@@ -211,7 +272,9 @@
                 "properties": {
                   "type": {
                     "description": "The file format type.",
-                    "enum": ["generic"]
+                    "enum": [
+                      "generic"
+                    ]
                   },
                   "path": {
                     "description": "The path to the file.",
@@ -220,9 +283,24 @@
                   "glob": {
                     "description": "Whether to treat the path as a glob. Defaults to `false`.",
                     "type": "boolean"
+                  },
+                  "component": {
+                    "description": "The component name to reference for the version. If specified, uses that component's version instead of the current component's version.",
+                    "type": "string"
+                  },
+                  "template": {
+                    "description": "Template string for formatting the version. Supports {{version}}, {{major}}, {{minor}}, {{patch}}, {{prerelease}}, {{component}}.",
+                    "type": "string"
+                  },
+                  "bumpDependents": {
+                    "description": "Whether changes to the referenced component should trigger a version bump of this component. Defaults to `true`.",
+                    "type": "boolean"
                   }
                 },
-                "required": ["type", "path"]
+                "required": [
+                  "type",
+                  "path"
+                ]
               }
             ]
           }
@@ -303,7 +381,9 @@
                   "type": {
                     "description": "The name of the plugin.",
                     "type": "string",
-                    "enum": ["linked-versions"]
+                    "enum": [
+                      "linked-versions"
+                    ]
                   },
                   "groupName": {
                     "description": "The name of the group of components.",
@@ -328,7 +408,11 @@
                     }
                   }
                 },
-                "required": ["type", "groupName", "components"]
+                "required": [
+                  "type",
+                  "groupName",
+                  "components"
+                ]
               },
               {
                 "description": "Configuration for various `workspace` plugins.",
@@ -337,7 +421,10 @@
                   "type": {
                     "description": "The name of the plugin.",
                     "type": "string",
-                    "enum": ["cargo-workspace", "maven-workspace"]
+                    "enum": [
+                      "cargo-workspace",
+                      "maven-workspace"
+                    ]
                   },
                   "updateAllPackages": {
                     "description": "Whether to force updating all packages regardless of the dependency tree. Defaults to `false`.",
@@ -360,7 +447,9 @@
                   "type": {
                     "description": "The name of the plugin.",
                     "type": "string",
-                    "enum": ["node-workspace"]
+                    "enum": [
+                      "node-workspace"
+                    ]
                   },
                   "updateAllPackages": {
                     "description": "Whether to force updating all packages regardless of the dependency tree. Defaults to `false`.",
@@ -387,7 +476,9 @@
                   "type": {
                     "description": "The name of the plugin.",
                     "type": "string",
-                    "enum": ["group-priority"]
+                    "enum": [
+                      "group-priority"
+                    ]
                   },
                   "groups": {
                     "description": "Group names ordered with highest priority first.",
@@ -444,7 +535,9 @@
           "type": "boolean"
         }
       },
-      "required": ["packages"]
+      "required": [
+        "packages"
+      ]
     }
   ],
   "properties": {

--- a/src/manifest.ts
+++ b/src/manifest.ts
@@ -32,7 +32,7 @@ import {
   ChangelogNotesType,
 } from './factory';
 import {Release} from './release';
-import {Strategy} from './strategy';
+import {Strategy, BumpReleaseOptions} from './strategy';
 import {MergeOptions, Merge} from './plugins/merge';
 import {ReleasePleaseManifest} from './updaters/release-please-manifest';
 import {
@@ -52,35 +52,53 @@ type ExtraGenericFile = {
   type: 'generic';
   path: string;
   glob?: boolean;
+  component?: string;
+  template?: string;
+  bumpDependents?: boolean;
 };
 type ExtraJsonFile = {
   type: 'json';
   path: string;
   jsonpath: string;
   glob?: boolean;
+  component?: string;
+  template?: string;
+  bumpDependents?: boolean;
 };
 type ExtraYamlFile = {
   type: 'yaml';
   path: string;
   jsonpath: string;
   glob?: boolean;
+  component?: string;
+  template?: string;
+  bumpDependents?: boolean;
 };
 type ExtraXmlFile = {
   type: 'xml';
   path: string;
   xpath: string;
   glob?: boolean;
+  component?: string;
+  template?: string;
+  bumpDependents?: boolean;
 };
 type ExtraPomFile = {
   type: 'pom';
   path: string;
   glob?: boolean;
+  component?: string;
+  template?: string;
+  bumpDependents?: boolean;
 };
 type ExtraTomlFile = {
   type: 'toml';
   path: string;
   jsonpath: string;
   glob?: boolean;
+  component?: string;
+  template?: string;
+  bumpDependents?: boolean;
 };
 export type ExtraFile =
   | string
@@ -725,6 +743,72 @@ export class Manifest {
       );
     }
 
+    // Build dependency graph and track which paths need dependency bumps
+    this.logger.info('Building component dependency graph');
+    const dependencyGraph = this.buildComponentDependencyGraph();
+    const componentsWithChanges = new Set<string>();
+    const dependencyBumps = new Map<string, Set<string>>(); // path -> set of changed dependency components
+
+    // Build a complete versionsMap with all component versions for extra-files resolution
+    const completeVersionsMap = new Map<string, Version>();
+    for (const path in this.repositoryConfig) {
+      const strategy = strategies[path];
+      const component = await strategy.getComponent();
+      if (component) {
+        // Use latest release version or current manifest version
+        const latestRelease = releasesByPath[path];
+        const version =
+          latestRelease?.tag.version || this.releasedVersions[path];
+        if (version) {
+          completeVersionsMap.set(component, version);
+          this.logger.debug(
+            `Added ${component} version ${version.toString()} to versionsMap`
+          );
+        }
+      }
+    }
+
+    // First pass: identify components with actual commits
+    for (const path in commitsPerPath) {
+      if (commitsPerPath[path].length > 0) {
+        const strategy = strategies[path];
+        const component = await strategy.getComponent();
+        if (component) {
+          componentsWithChanges.add(component);
+          this.logger.info(
+            `Component ${component} has ${commitsPerPath[path].length} commit(s)`
+          );
+        }
+      }
+    }
+
+    // Second pass: determine which paths need dependency bumps
+    for (const changedComponent of componentsWithChanges) {
+      const dependentPaths = this.getDependentPaths(
+        changedComponent,
+        dependencyGraph
+      );
+
+      for (const dependentPath of dependentPaths) {
+        // Only trigger dependency bump if the dependent has no commits or doesn't exist in commitsPerPath
+        const pathCommits = commitsPerPath[dependentPath] || [];
+        if (pathCommits.length === 0) {
+          if (!dependencyBumps.has(dependentPath)) {
+            dependencyBumps.set(dependentPath, new Set());
+          }
+          dependencyBumps.get(dependentPath)!.add(changedComponent);
+
+          this.logger.info(
+            `${dependentPath} will be bumped due to ${changedComponent} dependency change`
+          );
+        } else {
+          this.logger.debug(
+            `${dependentPath} already has commits, no dependency bump needed for ${changedComponent}`
+          );
+        }
+      }
+    }
+
     let newReleasePullRequests: CandidateReleasePullRequest[] = [];
     for (const path in this.repositoryConfig) {
       const config = this.repositoryConfig[path];
@@ -734,7 +818,7 @@ export class Manifest {
       this.logger.debug(`type: ${config.releaseType}`);
       this.logger.debug(`targetBranch: ${this.targetBranch}`);
       let pathCommits = parseConventionalCommits(
-        commitsPerPath[path],
+        commitsPerPath[path] || [],
         this.logger
       );
       // The processCommits hook can be implemented by plugins to
@@ -752,13 +836,94 @@ export class Manifest {
 
       const strategy = strategies[path];
       const latestRelease = releasesByPath[path];
+
+      // Determine if this path needs a dependency bump  
+      // Provide completeVersionsMap for extra-files component references
+      let bumpOnlyOptions: BumpReleaseOptions | undefined;
+      
+      // Check if this component's extra-files have component references
+      const hasComponentReferences = config.extraFiles?.some(
+        file => typeof file === 'object' && 'component' in file && file.component
+      );
+      
+      if (dependencyBumps.has(path) && pathCommits.length === 0) {
+        // This path has no commits but has dependency changes
+        // Calculate the new version as a patch bump
+        const changedDeps = Array.from(dependencyBumps.get(path)!);
+
+        this.logger.info(
+          `Forcing patch bump for ${path} due to dependency updates: ${changedDeps.join(
+            ', '
+          )}`
+        );
+
+        // Calculate the new version as a patch bump
+        const currentVersion =
+          latestRelease?.tag.version || new Version(0, 0, 0);
+        const newVersion = new Version(
+          currentVersion.major,
+          currentVersion.minor,
+          currentVersion.patch + 1,
+          currentVersion.preRelease,
+          currentVersion.build
+        );
+
+        bumpOnlyOptions = {
+          newVersion,
+          versionsMap: completeVersionsMap,
+          forceBump: true,
+        };
+        
+        this.logger.debug(
+          `Passing versionsMap to ${path} (dependency bump) with ${completeVersionsMap.size} components: ${Array.from(completeVersionsMap.keys()).join(', ')}`
+        );
+      } else if (hasComponentReferences && completeVersionsMap.size > 0 && pathCommits.length > 0) {
+        // Provide versionsMap for components with commits AND component references in extra-files
+        // This allows extra-files with component references to be updated
+        bumpOnlyOptions = {
+          versionsMap: completeVersionsMap,
+          forceBump: false,
+        };
+        
+        this.logger.debug(
+          `Passing versionsMap to ${path} (has component refs) with ${completeVersionsMap.size} components: ${Array.from(completeVersionsMap.keys()).join(', ')}`
+        );
+      }
+
       const releasePullRequest = await strategy.buildReleasePullRequest(
         pathCommits,
         latestRelease,
         config.draftPullRequest ?? this.draftPullRequest,
-        this.labels
+        this.labels,
+        bumpOnlyOptions
       );
       if (releasePullRequest) {
+        // Update completeVersionsMap with the new version for this component
+        const component = await strategy.getComponent();
+        if (component) {
+          completeVersionsMap.set(
+            component,
+            releasePullRequest.version || latestRelease?.tag.version
+          );
+          this.logger.info(
+            `Added ${component} version ${releasePullRequest.version?.toString()} to versionsMap`
+          );
+        }
+
+        // Add dependency update note if this was a dependency bump
+        if (bumpOnlyOptions && dependencyBumps.has(path)) {
+          const changedDeps = Array.from(dependencyBumps.get(path)!);
+          const depNote = `\n### Dependencies\n\n* Updated dependencies: ${changedDeps.join(
+            ', '
+          )}\n`;
+
+          // Add to the release notes
+          if (releasePullRequest.body.releaseData.length > 0) {
+            const releaseData = releasePullRequest.body.releaseData[0];
+            releaseData.notes = (releaseData.notes || '') + depNote;
+          }
+        }
+
         // Update manifest, but only for valid release version - this will skip SNAPSHOT from java strategy
         if (
           releasePullRequest.version &&
@@ -1361,6 +1526,49 @@ export class Manifest {
       }
     }
     return this._pathsByComponent;
+  }
+
+  /**
+   * Build a dependency graph from extra-files component references.
+   * Returns a map of component -> list of paths that depend on it.
+   */
+  private buildComponentDependencyGraph(): Map<string, Set<string>> {
+    const dependencyGraph = new Map<string, Set<string>>();
+
+    for (const path in this.repositoryConfig) {
+      const config = this.repositoryConfig[path];
+      const extraFiles = config.extraFiles || [];
+
+      for (const extraFile of extraFiles) {
+        if (typeof extraFile === 'object' && extraFile.component) {
+          // Default bumpDependents to true
+          const bumpOnChange = extraFile.bumpDependents ?? true;
+
+          if (bumpOnChange) {
+            if (!dependencyGraph.has(extraFile.component)) {
+              dependencyGraph.set(extraFile.component, new Set());
+            }
+            dependencyGraph.get(extraFile.component)!.add(path);
+
+            this.logger.debug(
+              `Dependency: ${path} depends on component ${extraFile.component}`
+            );
+          }
+        }
+      }
+    }
+
+    return dependencyGraph;
+  }
+
+  /**
+   * Get all paths that depend on the given component.
+   */
+  private getDependentPaths(
+    component: string,
+    dependencyGraph: Map<string, Set<string>>
+  ): Set<string> {
+    return dependencyGraph.get(component) || new Set();
   }
 }
 

--- a/src/plugins/node-workspace.ts
+++ b/src/plugins/node-workspace.ts
@@ -277,6 +277,7 @@ export class NodeWorkspace extends WorkspacePlugin<Package> {
     const basePullRequest = strategy
       ? await strategy.buildReleasePullRequest([], latestRelease, false, [], {
           newVersion,
+          forceBump: true,
         })
       : undefined;
 

--- a/src/strategies/base.ts
+++ b/src/strategies/base.ts
@@ -42,6 +42,11 @@ import {GenericXml} from '../updaters/generic-xml';
 import {PomXml} from '../updaters/java/pom-xml';
 import {GenericYaml} from '../updaters/generic-yaml';
 import {GenericToml} from '../updaters/generic-toml';
+import {renderTemplate} from '../util/template-renderer';
+import {GenericJsonTemplated} from '../updaters/generic-json-templated';
+import {GenericYamlTemplated} from '../updaters/generic-yaml-templated';
+import {GenericTomlTemplated} from '../updaters/generic-toml-templated';
+import {GenericXmlTemplated} from '../updaters/generic-xml-templated';
 
 const DEFAULT_CHANGELOG_PATH = 'CHANGELOG.md';
 
@@ -279,7 +284,10 @@ export abstract class BaseStrategy implements Strategy {
   ): Promise<ReleasePullRequest | undefined> {
     const conventionalCommits = await this.postProcessCommits(commits);
     this.logger.info(`Considering: ${conventionalCommits.length} commits`);
-    if (!bumpOnlyOptions && conventionalCommits.length === 0) {
+    if (
+      !bumpOnlyOptions?.forceBump &&
+      conventionalCommits.length === 0
+    ) {
       this.logger.info(`No commits for path: ${this.path}, skipping`);
       return undefined;
     }
@@ -287,11 +295,25 @@ export abstract class BaseStrategy implements Strategy {
     const newVersion =
       bumpOnlyOptions?.newVersion ??
       (await this.buildNewVersion(conventionalCommits, latestRelease));
-    const versionsMap = await this.updateVersionsMap(
-      await this.buildVersionsMap(conventionalCommits),
-      conventionalCommits,
-      newVersion
-    );
+    let versionsMap =
+      bumpOnlyOptions?.versionsMap ??
+      (await this.updateVersionsMap(
+        await this.buildVersionsMap(conventionalCommits),
+        conventionalCommits,
+        newVersion
+      ));
+    
+    // If we have a provided versionsMap from manifest, merge it with the local one
+    // The provided versionsMap has precedence for component references in extra-files
+    if (bumpOnlyOptions?.versionsMap) {
+      // Start with provided versionsMap and add/override with local versionsMap
+      const mergedVersionsMap = new Map(bumpOnlyOptions.versionsMap);
+      for (const [component, version] of versionsMap.entries()) {
+        mergedVersionsMap.set(component, version);
+      }
+      versionsMap = mergedVersionsMap;
+    }
+    
     const component = await this.getComponent();
     this.logger.debug('component:', component);
 
@@ -414,6 +436,30 @@ export abstract class BaseStrategy implements Strategy {
     for (const extraFile of this.extraFiles) {
       if (typeof extraFile === 'object') {
         const paths = await this.extraFilePaths(extraFile);
+
+        // Resolve version: use component reference if specified, otherwise current version
+        let resolvedVersion = version;
+        if (extraFile.component) {
+          const componentVersion = versionsMap.get(extraFile.component);
+          if (componentVersion) {
+            resolvedVersion = componentVersion;
+          } else {
+            this.logger.warn(
+              `Component ${extraFile.component} not found in versionsMap. Using current version.`
+            );
+          }
+        }
+
+        // Apply template if specified
+        const shouldUseTemplate = extraFile.template !== undefined;
+        const formattedValue = shouldUseTemplate
+          ? renderTemplate(
+              extraFile.template!,
+              resolvedVersion,
+              extraFile.component
+            )
+          : undefined;
+
         for (const path of paths) {
           switch (extraFile.type) {
             case 'generic':
@@ -421,7 +467,7 @@ export abstract class BaseStrategy implements Strategy {
                 path: this.addPath(path),
                 createIfMissing: false,
                 updater: new Generic({
-                  version,
+                  version: resolvedVersion,
                   versionsMap,
                   dateFormat: dateFormat,
                 }),
@@ -431,35 +477,52 @@ export abstract class BaseStrategy implements Strategy {
               extraFileUpdates.push({
                 path: this.addPath(path),
                 createIfMissing: false,
-                updater: new GenericJson(extraFile.jsonpath, version),
+                updater: shouldUseTemplate
+                  ? new GenericJsonTemplated(
+                      extraFile.jsonpath,
+                      formattedValue!
+                    )
+                  : new GenericJson(extraFile.jsonpath, resolvedVersion),
               });
               break;
             case 'yaml':
               extraFileUpdates.push({
                 path: this.addPath(path),
                 createIfMissing: false,
-                updater: new GenericYaml(extraFile.jsonpath, version),
+                updater: shouldUseTemplate
+                  ? new GenericYamlTemplated(
+                      extraFile.jsonpath,
+                      formattedValue!
+                    )
+                  : new GenericYaml(extraFile.jsonpath, resolvedVersion),
               });
               break;
             case 'toml':
               extraFileUpdates.push({
                 path: this.addPath(path),
                 createIfMissing: false,
-                updater: new GenericToml(extraFile.jsonpath, version),
+                updater: shouldUseTemplate
+                  ? new GenericTomlTemplated(
+                      extraFile.jsonpath,
+                      formattedValue!
+                    )
+                  : new GenericToml(extraFile.jsonpath, resolvedVersion),
               });
               break;
             case 'xml':
               extraFileUpdates.push({
                 path: this.addPath(path),
                 createIfMissing: false,
-                updater: new GenericXml(extraFile.xpath, version),
+                updater: shouldUseTemplate
+                  ? new GenericXmlTemplated(extraFile.xpath, formattedValue!)
+                  : new GenericXml(extraFile.xpath, resolvedVersion),
               });
               break;
             case 'pom':
               extraFileUpdates.push({
                 path: this.addPath(path),
                 createIfMissing: false,
-                updater: new PomXml(version),
+                updater: new PomXml(resolvedVersion),
               });
               break;
             default:

--- a/src/strategy.ts
+++ b/src/strategy.ts
@@ -18,14 +18,16 @@ import {PullRequest} from './pull-request';
 import {Commit} from './commit';
 import {VersioningStrategy} from './versioning-strategy';
 import {ChangelogNotes} from './changelog-notes';
-import {Version} from './version';
+import {Version, VersionsMap} from './version';
 
 export interface BuildReleaseOptions {
   groupPullRequestTitlePattern?: string;
 }
 
 export interface BumpReleaseOptions {
-  newVersion: Version;
+  newVersion?: Version;
+  versionsMap?: VersionsMap;
+  forceBump?: boolean; // If true, create PR even with no commits
 }
 
 /**

--- a/src/updaters/generic-json-templated.ts
+++ b/src/updaters/generic-json-templated.ts
@@ -1,0 +1,58 @@
+// Copyright 2024 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import {Updater} from '../update';
+import {JSONPath} from 'jsonpath-plus';
+import {jsonStringify} from '../util/json-stringify';
+import {logger as defaultLogger, Logger} from '../util/logger';
+
+/**
+ * Updates a JSON file with a templated string value.
+ * Unlike GenericJson, this replaces the entire value with the templated string.
+ */
+export class GenericJsonTemplated implements Updater {
+  readonly jsonpath: string;
+  readonly value: string;
+
+  constructor(jsonpath: string, value: string) {
+    this.jsonpath = jsonpath;
+    this.value = value;
+  }
+
+  /**
+   * Given initial file contents, return updated contents.
+   * @param {string} content The initial content
+   * @returns {string} The updated content
+   */
+  updateContent(content: string, logger: Logger = defaultLogger): string {
+    const data = JSON.parse(content);
+    let modified = false;
+    JSONPath({
+      resultType: 'all',
+      path: this.jsonpath,
+      json: data,
+      callback: (payload, _payloadType, _fullPayload) => {
+        payload.parent[payload.parentProperty] = this.value;
+        modified = true;
+        return payload;
+      },
+    });
+
+    if (!modified) {
+      logger.warn(`No entries modified in ${this.jsonpath}`);
+    }
+
+    return jsonStringify(data, content);
+  }
+}

--- a/src/updaters/generic-toml-templated.ts
+++ b/src/updaters/generic-toml-templated.ts
@@ -1,0 +1,59 @@
+// Copyright 2024 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import {Updater} from '../update';
+import {JSONPath} from 'jsonpath-plus';
+import * as toml from '@iarna/toml';
+import {logger as defaultLogger, Logger} from '../util/logger';
+
+/**
+ * Updates a TOML file with a templated string value.
+ * Unlike GenericToml, this replaces the entire value with the templated string.
+ */
+export class GenericTomlTemplated implements Updater {
+  readonly jsonpath: string;
+  readonly value: string;
+
+  constructor(jsonpath: string, value: string) {
+    this.jsonpath = jsonpath;
+    this.value = value;
+  }
+
+  /**
+   * Given initial file contents, return updated contents.
+   * @param {string} content The initial content
+   * @returns {string} The updated content
+   */
+  updateContent(content: string, logger: Logger = defaultLogger): string {
+    const data = toml.parse(content);
+    let modified = false;
+    JSONPath({
+      resultType: 'all',
+      path: this.jsonpath,
+      json: data,
+      callback: (payload, _payloadType, _fullPayload) => {
+        modified = true;
+        payload.parent[payload.parentProperty] = this.value;
+        return payload;
+      },
+    });
+
+    if (!modified) {
+      logger.warn(`No entries modified in ${this.jsonpath}`);
+      return content;
+    }
+
+    return toml.stringify(data as toml.JsonMap);
+  }
+}

--- a/src/updaters/generic-xml-templated.ts
+++ b/src/updaters/generic-xml-templated.ts
@@ -1,0 +1,60 @@
+// Copyright 2024 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import {Updater} from '../update';
+import {DOMParser, XMLSerializer} from '@xmldom/xmldom';
+import xpath from 'xpath';
+import {logger as defaultLogger, Logger} from '../util/logger';
+
+/**
+ * Updates an XML file with a templated string value.
+ * Unlike GenericXml, this replaces the entire value with the templated string.
+ */
+export class GenericXmlTemplated implements Updater {
+  readonly xpath: string;
+  readonly value: string;
+
+  constructor(xpath: string, value: string) {
+    this.xpath = xpath;
+    this.value = value;
+  }
+
+  /**
+   * Given initial file contents, return updated contents.
+   * @param {string} content The initial content
+   * @returns {string} The updated content
+   */
+  updateContent(content: string, logger: Logger = defaultLogger): string {
+    const document = new DOMParser().parseFromString(content, 'text/xml');
+    const nodes = xpath.select(this.xpath, document);
+    let modified = false;
+
+    if (Array.isArray(nodes)) {
+      for (const node of nodes) {
+        if (node && 'textContent' in node) {
+          (node as any).textContent = this.value;
+          modified = true;
+        }
+      }
+    }
+
+    if (!modified) {
+      logger.warn(`No entries modified in ${this.xpath}`);
+      return content;
+    }
+
+    const serializer = new XMLSerializer();
+    return serializer.serializeToString(document);
+  }
+}

--- a/src/updaters/generic-yaml-templated.ts
+++ b/src/updaters/generic-yaml-templated.ts
@@ -1,0 +1,76 @@
+// Copyright 2024 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import {Updater} from '../update';
+import {JSONPath} from 'jsonpath-plus';
+import * as yaml from 'js-yaml';
+import {logger as defaultLogger, Logger} from '../util/logger';
+
+const DOCUMENT_SEPARATOR = '---\n';
+
+/**
+ * Updates a YAML file with a templated string value.
+ * Unlike GenericYaml, this replaces the entire value with the templated string.
+ */
+export class GenericYamlTemplated implements Updater {
+  readonly jsonpath: string;
+  readonly value: string;
+
+  constructor(jsonpath: string, value: string) {
+    this.jsonpath = jsonpath;
+    this.value = value;
+  }
+
+  /**
+   * Given initial file contents, return updated contents.
+   * @param {string} content The initial content
+   * @returns {string} The updated content
+   */
+  updateContent(content: string, logger: Logger = defaultLogger): string {
+    // Parse possibly multi-document file
+    let docs: unknown[];
+    try {
+      docs = yaml.loadAll(content, null, {json: true});
+    } catch (e) {
+      logger.warn('Invalid yaml, cannot be parsed', e);
+      return content;
+    }
+
+    // Update each document
+    let modified = false;
+    docs.forEach(data => {
+      JSONPath({
+        resultType: 'all',
+        path: this.jsonpath,
+        json: data as any,
+        callback: (payload, _payloadType, _fullPayload) => {
+          modified = true;
+          payload.parent[payload.parentProperty] = this.value;
+          return payload;
+        },
+      });
+    });
+
+    // If nothing was modified, return original content
+    if (!modified) {
+      logger.warn(`No entries modified in ${this.jsonpath}`);
+      return content;
+    }
+
+    // Serialize back to YAML
+    return docs
+      .map(doc => yaml.dump(doc, {lineWidth: -1, noRefs: true}))
+      .join(DOCUMENT_SEPARATOR);
+  }
+}

--- a/src/util/template-renderer.ts
+++ b/src/util/template-renderer.ts
@@ -1,0 +1,45 @@
+// Copyright 2024 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import {Version} from '../version';
+
+/**
+ * Renders a template string with version variables.
+ *
+ * Supported template variables:
+ * - {{version}} - Full version (e.g., "1.2.3")
+ * - {{major}} - Major version (e.g., "1")
+ * - {{minor}} - Minor version (e.g., "2")
+ * - {{patch}} - Patch version (e.g., "3")
+ * - {{prerelease}} - Prerelease suffix (e.g., "beta.1")
+ * - {{component}} - Component name
+ *
+ * @param template - Template string with {{variable}} placeholders
+ * @param version - Version object to extract values from
+ * @param component - Optional component name
+ * @returns Rendered template string
+ */
+export function renderTemplate(
+  template: string,
+  version: Version,
+  component?: string
+): string {
+  return template
+    .replace(/\{\{version\}\}/g, version.toString())
+    .replace(/\{\{major\}\}/g, version.major.toString())
+    .replace(/\{\{minor\}\}/g, version.minor.toString())
+    .replace(/\{\{patch\}\}/g, version.patch.toString())
+    .replace(/\{\{prerelease\}\}/g, version.preRelease || '')
+    .replace(/\{\{component\}\}/g, component || '');
+}

--- a/test/fixtures/manifest/config/dependency-tracking.json
+++ b/test/fixtures/manifest/config/dependency-tracking.json
@@ -1,0 +1,20 @@
+{
+  "packages": {
+    "packages/container-a": {
+      "release-type": "simple",
+      "component": "container-a"
+    },
+    "helm/chart": {
+      "release-type": "simple",
+      "component": "my-chart",
+      "extra-files": [
+        {
+          "type": "yaml",
+          "path": "helm/chart/values.yaml",
+          "jsonpath": "$.containerA.image.tag",
+          "component": "container-a"
+        }
+      ]
+    }
+  }
+}

--- a/test/fixtures/manifest/versions/dependency-tracking.json
+++ b/test/fixtures/manifest/versions/dependency-tracking.json
@@ -1,0 +1,4 @@
+{
+  "packages/container-a": "1.0.0",
+  "helm/chart": "1.0.0"
+}

--- a/test/manifest.ts
+++ b/test/manifest.ts
@@ -6634,4 +6634,398 @@ describe('Manifest', () => {
       sinon.assert.calledOnce(removeLabelsStub);
     });
   });
+
+  describe('dependency tracking', () => {
+    describe('buildComponentDependencyGraph', () => {
+      it('should build dependency graph from extra-files', async () => {
+        const github = await GitHub.create({
+          owner: 'googleapis',
+          repo: 'release-please-test-repo',
+          defaultBranch: 'main',
+          token: 'fake-token',
+        });
+        const manifest = new Manifest(
+          github,
+          'main',
+          {
+            'packages/container-a': {
+              releaseType: 'simple',
+              component: 'container-a',
+            },
+            'helm/chart': {
+              releaseType: 'simple',
+              component: 'my-chart',
+              extraFiles: [
+                {
+                  type: 'yaml',
+                  path: 'helm/chart/values.yaml',
+                  jsonpath: '$.containerA.image.tag',
+                  component: 'container-a',
+                },
+                {
+                  type: 'yaml',
+                  path: 'helm/chart/values.yaml',
+                  jsonpath: '$.containerB.image.tag',
+                  component: 'container-b',
+                },
+              ],
+            },
+          },
+          {
+            'packages/container-a': Version.parse('1.0.0'),
+            'helm/chart': Version.parse('1.0.0'),
+          }
+        );
+        const graph = manifest['buildComponentDependencyGraph']();
+        expect(graph.get('container-a')).to.deep.equal(
+          new Set(['helm/chart'])
+        );
+        expect(graph.get('container-b')).to.deep.equal(
+          new Set(['helm/chart'])
+        );
+      });
+
+      it('should handle multiple dependents for same component', async () => {
+        const github = await GitHub.create({
+          owner: 'googleapis',
+          repo: 'release-please-test-repo',
+          defaultBranch: 'main',
+          token: 'fake-token',
+        });
+        const manifest = new Manifest(
+          github,
+          'main',
+          {
+            'packages/lib': {
+              releaseType: 'simple',
+              component: 'lib',
+            },
+            'packages/service-a': {
+              releaseType: 'simple',
+              extraFiles: [
+                {
+                  type: 'json',
+                  path: 'packages/service-a/package.json',
+                  jsonpath: '$.dependencies.lib',
+                  component: 'lib',
+                },
+              ],
+            },
+            'packages/service-b': {
+              releaseType: 'simple',
+              extraFiles: [
+                {
+                  type: 'json',
+                  path: 'packages/service-b/package.json',
+                  jsonpath: '$.dependencies.lib',
+                  component: 'lib',
+                },
+              ],
+            },
+          },
+          {
+            'packages/lib': Version.parse('1.0.0'),
+            'packages/service-a': Version.parse('1.0.0'),
+            'packages/service-b': Version.parse('1.0.0'),
+          }
+        );
+        const graph = manifest['buildComponentDependencyGraph']();
+        expect(graph.get('lib')).to.deep.equal(
+          new Set(['packages/service-a', 'packages/service-b'])
+        );
+      });
+
+      it('should skip components with bumpDependents: false', async () => {
+        const github = await GitHub.create({
+          owner: 'googleapis',
+          repo: 'release-please-test-repo',
+          defaultBranch: 'main',
+          token: 'fake-token',
+        });
+        const manifest = new Manifest(
+          github,
+          'main',
+          {
+            'packages/lib': {
+              releaseType: 'simple',
+              component: 'lib',
+            },
+            'packages/service': {
+              releaseType: 'simple',
+              extraFiles: [
+                {
+                  type: 'json',
+                  path: 'packages/service/package.json',
+                  jsonpath: '$.dependencies.lib',
+                  component: 'lib',
+                  bumpDependents: false,
+                },
+              ],
+            },
+          },
+          {
+            'packages/lib': Version.parse('1.0.0'),
+            'packages/service': Version.parse('1.0.0'),
+          }
+        );
+        const graph = manifest['buildComponentDependencyGraph']();
+        expect(graph.get('lib')).to.be.undefined;
+      });
+    });
+
+    describe('getDependentPaths', () => {
+      it('should return all paths that depend on a component', async () => {
+        const github = await GitHub.create({
+          owner: 'googleapis',
+          repo: 'release-please-test-repo',
+          defaultBranch: 'main',
+          token: 'fake-token',
+        });
+        const manifest = new Manifest(
+          github,
+          'main',
+          {
+            'packages/lib': {
+              releaseType: 'simple',
+              component: 'lib',
+            },
+            'packages/service-a': {
+              releaseType: 'simple',
+              extraFiles: [
+                {
+                  type: 'json',
+                  path: 'packages/service-a/package.json',
+                  jsonpath: '$.dependencies.lib',
+                  component: 'lib',
+                },
+              ],
+            },
+            'packages/service-b': {
+              releaseType: 'simple',
+              extraFiles: [
+                {
+                  type: 'json',
+                  path: 'packages/service-b/package.json',
+                  jsonpath: '$.dependencies.lib',
+                  component: 'lib',
+                },
+              ],
+            },
+          },
+          {
+            'packages/lib': Version.parse('1.0.0'),
+            'packages/service-a': Version.parse('1.0.0'),
+            'packages/service-b': Version.parse('1.0.0'),
+          }
+        );
+        const graph = manifest['buildComponentDependencyGraph']();
+        const dependents = manifest['getDependentPaths']('lib', graph);
+        expect(Array.from(dependents).sort()).to.deep.equal([
+          'packages/service-a',
+          'packages/service-b',
+        ]);
+      });
+
+      it('should return empty set for component with no dependents', async () => {
+        const github = await GitHub.create({
+          owner: 'googleapis',
+          repo: 'release-please-test-repo',
+          defaultBranch: 'main',
+          token: 'fake-token',
+        });
+        const manifest = new Manifest(
+          github,
+          'main',
+          {
+            'packages/lib': {
+              releaseType: 'simple',
+              component: 'lib',
+            },
+          },
+          {
+            'packages/lib': Version.parse('1.0.0'),
+          }
+        );
+        const graph = manifest['buildComponentDependencyGraph']();
+        const dependents = manifest['getDependentPaths']('lib', graph);
+        expect(dependents.size).to.equal(0);
+      });
+    });
+
+    describe('automatic dependency bumping', () => {
+      beforeEach(() => {
+        mockReleases(sandbox, github, [
+          {
+            id: 123456,
+            sha: 'abc123',
+            tagName: 'container-a-v1.0.0',
+            url: 'https://github.com/fake-owner/fake-repo/releases/tag/container-a-v1.0.0',
+          },
+          {
+            id: 654321,
+            sha: 'def456',
+            tagName: 'my-chart-v1.0.0',
+            url: 'https://github.com/fake-owner/fake-repo/releases/tag/my-chart-v1.0.0',
+          },
+        ]);
+        mockTags(sandbox, github, [
+          {name: 'container-a-v1.0.0', sha: 'abc123'},
+          {name: 'my-chart-v1.0.0', sha: 'def456'},
+        ]);
+      });
+
+      it('should bump dependent when dependency changes', async () => {
+        mockCommits(sandbox, github, [
+          {
+            sha: 'aaaaaa',
+            message: 'fix: container bug',
+            files: ['packages/container-a/src/main.ts'],
+          },
+        ]);
+        sandbox
+          .stub(github, 'getFileContentsOnBranch')
+          .withArgs('release-please-config.json', 'main')
+          .resolves(
+            buildGitHubFileContent(
+              fixturesPath,
+              'manifest/config/dependency-tracking.json'
+            )
+          )
+          .withArgs('.release-please-manifest.json', 'main')
+          .resolves(
+            buildGitHubFileContent(
+              fixturesPath,
+              'manifest/versions/dependency-tracking.json'
+            )
+          );
+
+        const manifest = new Manifest(
+          github,
+          'main',
+          {
+            'packages/container-a': {
+              releaseType: 'simple',
+              component: 'container-a',
+            },
+            'helm/chart': {
+              releaseType: 'simple',
+              component: 'my-chart',
+              extraFiles: [
+                {
+                  type: 'yaml',
+                  path: 'helm/chart/values.yaml',
+                  jsonpath: '$.containerA.image.tag',
+                  component: 'container-a',
+                },
+              ],
+            },
+          },
+          {
+            'packages/container-a': Version.parse('1.0.0'),
+            'helm/chart': Version.parse('1.0.0'),
+          },
+          {
+            separatePullRequests: true,
+          }
+        );
+
+        const pullRequests = await manifest.buildPullRequests();
+        expect(pullRequests).to.have.lengthOf(2);
+
+        // Container should have a PR with the fix
+        const containerPR = pullRequests.find(pr =>
+          pr.title.toString().includes('container-a')
+        );
+        expect(containerPR).to.not.be.undefined;
+        expect(containerPR!.version?.toString()).to.equal('1.0.1');
+
+        // Chart should have a PR with dependency bump
+        const chartPR = pullRequests.find(pr =>
+          pr.title.toString().includes('my-chart')
+        );
+        expect(chartPR).to.not.be.undefined;
+        expect(chartPR!.version?.toString()).to.equal('1.0.1');
+
+        // Chart PR body should mention dependency
+        const bodyString = chartPR!.body.toString();
+        expect(bodyString).to.include('Dependencies');
+        expect(bodyString).to.include('container-a');
+      });
+
+      it('should not bump dependent if it has its own changes', async () => {
+        mockCommits(sandbox, github, [
+          {
+            sha: 'aaaaaa',
+            message: 'fix: container bug',
+            files: ['packages/container-a/src/main.ts'],
+          },
+          {
+            sha: 'bbbbbb',
+            message: 'feat: chart feature',
+            files: ['helm/chart/templates/deployment.yaml'],
+          },
+        ]);
+        sandbox
+          .stub(github, 'getFileContentsOnBranch')
+          .withArgs('release-please-config.json', 'main')
+          .resolves(
+            buildGitHubFileContent(
+              fixturesPath,
+              'manifest/config/dependency-tracking.json'
+            )
+          )
+          .withArgs('.release-please-manifest.json', 'main')
+          .resolves(
+            buildGitHubFileContent(
+              fixturesPath,
+              'manifest/versions/dependency-tracking.json'
+            )
+          );
+
+        const manifest = new Manifest(
+          github,
+          'main',
+          {
+            'packages/container-a': {
+              releaseType: 'simple',
+              component: 'container-a',
+            },
+            'helm/chart': {
+              releaseType: 'simple',
+              component: 'my-chart',
+              extraFiles: [
+                {
+                  type: 'yaml',
+                  path: 'helm/chart/values.yaml',
+                  jsonpath: '$.containerA.image.tag',
+                  component: 'container-a',
+                },
+              ],
+            },
+          },
+          {
+            'packages/container-a': Version.parse('1.0.0'),
+            'helm/chart': Version.parse('1.0.0'),
+          },
+          {
+            separatePullRequests: true,
+          }
+        );
+
+        const pullRequests = await manifest.buildPullRequests();
+        expect(pullRequests).to.have.lengthOf(2);
+
+        const chartPR = pullRequests.find(pr =>
+          pr.title.toString().includes('my-chart')
+        );
+        expect(chartPR).to.not.be.undefined;
+        // Chart should get minor bump (feat), not patch
+        expect(chartPR!.version?.toString()).to.equal('1.1.0');
+
+        // Chart PR body should NOT mention dependencies since it has real changes
+        const bodyString = chartPR!.body.toString();
+        expect(bodyString).to.not.include('Dependencies');
+      });
+    });
+  });
 });

--- a/test/util/template-renderer.ts
+++ b/test/util/template-renderer.ts
@@ -1,0 +1,78 @@
+// Copyright 2024 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import {describe, it} from 'mocha';
+import {expect} from 'chai';
+import {Version} from '../../src/version';
+import {renderTemplate} from '../../src/util/template-renderer';
+
+describe('template-renderer', () => {
+  describe('renderTemplate', () => {
+    it('should render {{version}}', () => {
+      const version = new Version(1, 2, 3);
+      const result = renderTemplate('{{version}}', version);
+      expect(result).to.equal('1.2.3');
+    });
+
+    it('should render {{major}}, {{minor}}, {{patch}}', () => {
+      const version = new Version(1, 2, 3);
+      const result = renderTemplate('{{major}}.{{minor}}.{{patch}}', version);
+      expect(result).to.equal('1.2.3');
+    });
+
+    it('should render with prerelease', () => {
+      const version = new Version(1, 2, 3, 'beta.1');
+      const result = renderTemplate('{{version}}-{{prerelease}}', version);
+      expect(result).to.equal('1.2.3-beta.1-beta.1');
+    });
+
+    it('should render {{prerelease}} as empty when not present', () => {
+      const version = new Version(1, 2, 3);
+      const result = renderTemplate('v{{version}}-{{prerelease}}', version);
+      expect(result).to.equal('v1.2.3-');
+    });
+
+    it('should render {{component}}', () => {
+      const version = new Version(1, 2, 3);
+      const result = renderTemplate(
+        'ghcr.io/org/{{component}}:{{version}}',
+        version,
+        'my-app'
+      );
+      expect(result).to.equal('ghcr.io/org/my-app:1.2.3');
+    });
+
+    it('should render complex template', () => {
+      const version = new Version(2, 5, 10, 'rc.1');
+      const result = renderTemplate(
+        'v{{major}}.{{minor}} ({{version}})',
+        version,
+        'app'
+      );
+      expect(result).to.equal('v2.5 (2.5.10-rc.1)');
+    });
+
+    it('should handle template with no variables', () => {
+      const version = new Version(1, 2, 3);
+      const result = renderTemplate('constant-string', version);
+      expect(result).to.equal('constant-string');
+    });
+
+    it('should replace all occurrences of variables', () => {
+      const version = new Version(1, 2, 3);
+      const result = renderTemplate('{{major}}.{{major}}.{{major}}', version);
+      expect(result).to.equal('1.1.1');
+    });
+  });
+});


### PR DESCRIPTION
This adds support for component references in extra-files, allowing files to be updated with versions from other components in the monorepo. Also implements automatic dependency tracking that bumps dependent components when their dependencies change.

Features:
- Component references in extra-files (component field)
- Template formatting with {{version}}, {{major}}, {{minor}}, {{patch}}, {{prerelease}}, {{component}}
- Automatic dependency tracking with bumpDependents option
- Dependency notes in PR bodies
- Templated updaters for JSON, YAML, TOML, XML
- Complete versionsMap passed to strategies

This is particularly useful for Helm charts that reference container image versions, or any scenario where components depend on versions from other components but need independent versioning.

Tests: All 1079 tests passing

Thank you for opening a Pull Request! Before submitting your PR, there are a few things you can do to make sure it goes smoothly:
- [x] Make sure to open an issue as a [bug/issue](https://github.com/googleapis/release-please/issues/new/choose) before writing your code!  That way we can discuss the change, evaluate designs, and agree on the general idea
- [x] Ensure the tests and linter pass
- [x] Code coverage does not decrease (if any source code was changed)
- [x] Appropriate docs were updated (if necessary)

Fixes: #2655 
