### PR TITLE
docs: fix a typo in manifest-releaser.md

### DIFF
--- a/docs/manifest-releaser.md
+++ b/docs/manifest-releaser.md
@@ -100,7 +100,7 @@ merged into the default/configured branch.
 
 ```
 release-please will now use "1.1.1" as the last-released/current version for
-"path/to/pkg" and suggest the next version according to coventional commits it
+"path/to/pkg" and suggest the next version according to conventional commits it
 has found since the last merged release PR (or "bootstrap-sha" if this is the
 first run).
 


### PR DESCRIPTION
This fixes nothing, so I didn't opened an issue.

It's just a small a typo I noticed while reading the documentation.
