### PR TITLE
chore: replace old nodejs teams with cloud-sdk-nodejs-team

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -6,7 +6,7 @@
 
 
 # The yoshi-nodejs team is the default owner for nodejs repositories.
-*     @googleapis/yoshi-nodejs @googleapis/github-automation
+*     @googleapis/cloud-sdk-nodejs-team @googleapis/cloud-sdk-platform-team
 
 # The github automation team is the default owner for the auto-approve file.
-.github/auto-approve.yml @googleapis/github-automation
+.github/auto-approve.yml @googleapis/cloud-sdk-platform-team

--- a/.repo-metadata.json
+++ b/.repo-metadata.json
@@ -5,7 +5,7 @@
   "language": "nodejs",
   "repo": "googleapis/release-please",
   "distribution_name": "release-please",
-  "codeowner_team": "@googleapis/github-automation",
+  "codeowner_team": "@googleapis/cloud-sdk-platform-team",
   "client_documentation": "https://cloud.google.com/nodejs/docs/reference/release-please/latest",
   "library_type": "OTHER"
 }


### PR DESCRIPTION
b/479541676