### PR TITLE
feat: add bun.lock support

### DIFF
--- a/__snapshots__/bun-lock.js
+++ b/__snapshots__/bun-lock.js
@@ -1,0 +1,24 @@
+exports['BunLock updateContent monorepo updates workspace versions 1'] = `
+{
+  "lockfileVersion": 1,
+  "configVersion": 1,
+  "workspaces": {
+    "": {
+      "name": "release-please",
+      "version": "14.0.0",
+    },
+    "packages/foo": {
+      "name": "release-please-foo",
+      "version": "2.0.0",
+      "dependencies": {
+        "release-please-bar": "workspace:*",
+      },
+    },
+    "packages/bar": {
+      "name": "release-please-bar",
+      "version": "3.0.0",
+    },
+  },
+}
+
+`

--- a/package-lock.json
+++ b/package-lock.json
@@ -29,6 +29,7 @@
         "http-proxy-agent": "^7.0.0",
         "https-proxy-agent": "^7.0.0",
         "js-yaml": "^4.0.0",
+        "jsonc-parser": "^3.3.1",
         "jsonpath-plus": "^10.0.0",
         "node-html-parser": "^6.0.0",
         "parse-github-repo-url": "^1.4.1",
@@ -3517,12 +3518,19 @@
       "resolved": "https://registry.npmjs.org/json5/-/json5-2.2.3.tgz",
       "integrity": "sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg==",
       "dev": true,
+      "license": "MIT",
       "bin": {
         "json5": "lib/cli.js"
       },
       "engines": {
         "node": ">=6"
       }
+    },
+    "node_modules/jsonc-parser": {
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/jsonc-parser/-/jsonc-parser-3.3.1.tgz",
+      "integrity": "sha512-HUgH65KyejrUFPvHFPbqOY0rsFip3Bo5wb4ngvdi1EpCYWUQDC5V+Y7mZws+DLkr4M//zQJoanu1SP+87Dv1oQ==",
+      "license": "MIT"
     },
     "node_modules/jsonpath-plus": {
       "version": "10.3.0",

--- a/package.json
+++ b/package.json
@@ -86,6 +86,7 @@
     "http-proxy-agent": "^7.0.0",
     "https-proxy-agent": "^7.0.0",
     "js-yaml": "^4.0.0",
+    "jsonc-parser": "^3.3.1",
     "jsonpath-plus": "^10.0.0",
     "node-html-parser": "^6.0.0",
     "parse-github-repo-url": "^1.4.1",

--- a/src/strategies/node.ts
+++ b/src/strategies/node.ts
@@ -16,6 +16,7 @@ import {BaseStrategy, BuildUpdatesOptions} from './base';
 import {Update} from '../update';
 import {ChangelogJson} from '../updaters/changelog-json';
 import {PackageLockJson} from '../updaters/node/package-lock-json';
+import {BunLock} from '../updaters/node/bun-lock';
 import {SamplesPackageJson} from '../updaters/node/samples-package-json';
 import {Changelog} from '../updaters/changelog';
 import {PackageJson} from '../updaters/node/package-json';
@@ -43,6 +44,14 @@ export class Node extends BaseStrategy {
           versionsMap,
         }),
       });
+    });
+
+    updates.push({
+      path: this.addPath('bun.lock'),
+      createIfMissing: false,
+      updater: new BunLock({
+        versionsMap,
+      }),
     });
 
     updates.push({

--- a/src/updaters/node/bun-lock.ts
+++ b/src/updaters/node/bun-lock.ts
@@ -1,0 +1,66 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import {Updater} from '../../update';
+import {VersionsMap} from '../../version';
+import {logger as defaultLogger, Logger} from '../../util/logger';
+import {UpdateOptions} from '../default';
+import {modify, applyEdits, parse} from 'jsonc-parser';
+
+interface BunWorkspace {
+  name: string;
+  version?: string;
+}
+
+interface BunLockData {
+  workspaces: Record<string, BunWorkspace>;
+}
+
+export class BunLock implements Updater {
+  versionsMap?: VersionsMap;
+
+  constructor(options: Partial<UpdateOptions>) {
+    this.versionsMap = options.versionsMap;
+  }
+
+  updateContent(content: string, logger: Logger = defaultLogger): string {
+    if (!this.versionsMap) {
+      return content;
+    }
+
+    const parsed = parse(content, [], {
+      allowTrailingComma: true,
+    }) as BunLockData;
+
+    const edits = [];
+    for (const [path, workspace] of Object.entries(parsed.workspaces)) {
+      if (!workspace.name) continue;
+
+      const version = this.versionsMap.get(workspace.name);
+      if (version) {
+        logger.info(`updating from ${workspace.version} to ${version}`);
+        edits.push(
+          ...modify(
+            content,
+            ['workspaces', path, 'version'],
+            version.toString(),
+            {formattingOptions: {insertSpaces: true, tabSize: 2}}
+          )
+        );
+      }
+    }
+
+    return applyEdits(content, edits);
+  }
+}

--- a/test/updaters/bun-lock.ts
+++ b/test/updaters/bun-lock.ts
@@ -1,0 +1,43 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import {readFileSync} from 'fs';
+import {resolve} from 'path';
+import * as snapshot from 'snap-shot-it';
+import {describe, it} from 'mocha';
+import {BunLock} from '../../src/updaters/node/bun-lock';
+import {Version} from '../../src/version';
+
+const fixturesPath = './test/updaters/fixtures';
+
+describe('BunLock', () => {
+  describe('updateContent monorepo', () => {
+    it('updates workspace versions', async () => {
+      const oldContent = readFileSync(
+        resolve(fixturesPath, './bun.lock'),
+        'utf8'
+      );
+      const versionsMap = new Map();
+      versionsMap.set('release-please', new Version(14, 0, 0));
+      versionsMap.set('release-please-foo', new Version(2, 0, 0));
+      versionsMap.set('release-please-bar', new Version(3, 0, 0));
+      const bunLock = new BunLock({
+        version: Version.parse('14.0.0'),
+        versionsMap,
+      });
+      const newContent = bunLock.updateContent(oldContent);
+      snapshot(newContent.replace(/\r\n/g, '\n'));
+    });
+  });
+});

--- a/test/updaters/fixtures/bun.lock
+++ b/test/updaters/fixtures/bun.lock
@@ -1,0 +1,20 @@
+{
+  "lockfileVersion": 1,
+  "configVersion": 1,
+  "workspaces": {
+    "": {
+      "name": "release-please",
+    },
+    "packages/foo": {
+      "name": "release-please-foo",
+      "version": "1.0.0",
+      "dependencies": {
+        "release-please-bar": "workspace:*",
+      },
+    },
+    "packages/bar": {
+      "name": "release-please-bar",
+      "version": "1.0.0",
+    },
+  },
+}


### PR DESCRIPTION
`bun.lock` is not updated when creating a release in a monorepo because it is written in JSONC format, which is not supported by standard JavaScript JSON parsers.

Thank you for opening a Pull Request! Before submitting your PR, there are a few things you can do to make sure it goes smoothly:
- [x] Make sure to open an issue as a [bug/issue](https://github.com/googleapis/release-please/issues/new/choose) before writing your code!  That way we can discuss the change, evaluate designs, and agree on the general idea
- [x] Ensure the tests and linter pass
- [x] Code coverage does not decrease (if any source code was changed)
- [x] Appropriate docs were updated (if necessary)

Fixes #2689 🦕
