### PR TITLE
fix: pass header and footer through in Java snapshot PRs

### DIFF
--- a/src/strategies/java.ts
+++ b/src/strategies/java.ts
@@ -123,14 +123,19 @@ export class Java extends BaseStrategy {
       : BranchName.ofTargetBranch(this.targetBranch);
     const notes =
       '### Updating meta-information for bleeding-edge SNAPSHOT release.';
-    // TODO use pullrequest header here?
-    const pullRequestBody = new PullRequestBody([
+    const pullRequestBody = new PullRequestBody(
+      [
+        {
+          component,
+          version: newVersion,
+          notes,
+        },
+      ],
       {
-        component,
-        version: newVersion,
-        notes,
-      },
-    ]);
+        header: this.pullRequestHeader,
+        footer: this.pullRequestFooter,
+      }
+    );
     const updates = await this.buildUpdates({
       newVersion,
       versionsMap,

--- a/test/strategies/java.ts
+++ b/test/strategies/java.ts
@@ -230,6 +230,31 @@ describe('Java', () => {
         expect(release?.labels).to.eql(['bot', 'custom:snapshot']);
       });
 
+      it('includes header and footer in snapshot PR', async () => {
+        const strategy = new Java({
+          targetBranch: 'main',
+          github,
+          pullRequestHeader: 'My custom header',
+          pullRequestFooter: 'My custom footer',
+        });
+
+        const latestRelease = {
+          tag: new TagName(Version.parse('2.3.3')),
+          sha: 'abc123',
+          notes: 'some notes',
+        };
+        const release = await strategy.buildReleasePullRequest(
+          COMMITS_NO_SNAPSHOT,
+          latestRelease,
+          false,
+          DEFAULT_LABELS
+        );
+
+        const body = release?.body.toString();
+        expect(body).to.include('My custom header');
+        expect(body).to.include('My custom footer');
+      });
+
       it('creates draft snapshot PR', async () => {
         const strategy = new Java({
           targetBranch: 'main',


### PR DESCRIPTION
## Summary
The `buildSnapshotPullRequest()` method in the Java strategy constructs
a `PullRequestBody` without passing the configured `pullRequestHeader`
and `pullRequestFooter`, causing these options to be silently ignored
for Java snapshot PRs.

This is especially visible for single-package repos where
`separatePullRequests` defaults to `true` and the Merge plugin
(which would otherwise apply the footer) does not run.

## Changes
- Pass `this.pullRequestHeader` and `this.pullRequestFooter` to
  `PullRequestBody` in `java.ts:buildSnapshotPullRequest()`
- Remove the existing TODO comment that was asking about this
- Add a test verifying header and footer appear in snapshot PRs

## Context
Discovered while configuring `pull-request-footer` on
[prometheus/client_java](https://github.com/prometheus/client_java)
— a single-package Java repo where the footer was silently ignored
on the SNAPSHOT PR.