### PR TITLE
fix: preserve version in merge plugin when no root candidate exists

### DIFF
--- a/src/plugins/merge.ts
+++ b/src/plugins/merge.ts
@@ -104,11 +104,15 @@ export class Merge extends ManifestPlugin {
     }
     const updates = mergeUpdates(rawUpdates);
 
+    // Fall back to the first in-scope candidate when there is no root-path
+    // candidate (common in monorepos where all packages live in subdirectories)
+    const primaryRelease = rootRelease ?? inScopeCandidates[0] ?? null;
+
     const pullRequest = {
       title: PullRequestTitle.ofComponentTargetBranchVersion(
-        rootRelease?.pullRequest.title.component,
+        primaryRelease?.pullRequest.title.component,
         this.targetBranch,
-        rootRelease?.pullRequest.title.version,
+        primaryRelease?.pullRequest.title.version,
         this.pullRequestTitlePattern,
         this.componentNoSpace
       ),
@@ -122,6 +126,7 @@ export class Merge extends ManifestPlugin {
       headRefName:
         this.headBranchName ??
         BranchName.ofTargetBranch(this.targetBranch).toString(),
+      version: primaryRelease?.pullRequest.version,
       draft: !candidates.some(candidate => !candidate.pullRequest.draft),
     };
 

--- a/test/plugins/merge.ts
+++ b/test/plugins/merge.ts
@@ -25,6 +25,7 @@ import {
 import snapshot = require('snap-shot-it');
 import {RawContent} from '../../src/updaters/raw-content';
 import {CompositeUpdater} from '../../src/updaters/composite';
+import {Version} from '../../src/version';
 
 const sandbox = sinon.createSandbox();
 
@@ -184,6 +185,51 @@ describe('Merge plugin', () => {
         'label-c',
       ]);
       snapshot(dateSafe(candidate.pullRequest.body.toString()));
+    });
+    it('preserves version when all candidates are in subdirectories', async () => {
+      const candidates: CandidateReleasePullRequest[] = [
+        buildMockCandidatePullRequest('packages/pkgA', 'node', '2.0.0', {
+          component: '@scope/pkgA',
+        }),
+      ];
+      const plugin = new Merge(github, 'main', {});
+      const newCandidates = await plugin.run(candidates);
+      expect(newCandidates).lengthOf(1);
+      const candidate = newCandidates[0];
+      expect(candidate.path).to.eql('.');
+      expect(candidate.pullRequest.version).to.eql(Version.parse('2.0.0'));
+    });
+
+    it('preserves version from root candidate when present', async () => {
+      const candidates: CandidateReleasePullRequest[] = [
+        buildMockCandidatePullRequest('.', 'node', '5.0.0', {
+          component: 'root-pkg',
+        }),
+        buildMockCandidatePullRequest('packages/pkgA', 'node', '2.0.0', {
+          component: '@scope/pkgA',
+        }),
+      ];
+      const plugin = new Merge(github, 'main', {});
+      const newCandidates = await plugin.run(candidates);
+      expect(newCandidates).lengthOf(1);
+      const candidate = newCandidates[0];
+      expect(candidate.pullRequest.version).to.eql(Version.parse('5.0.0'));
+    });
+
+    it('preserves version when merging multiple subdirectory candidates', async () => {
+      const candidates: CandidateReleasePullRequest[] = [
+        buildMockCandidatePullRequest('packages/pkgA', 'node', '2.0.0', {
+          component: '@scope/pkgA',
+        }),
+        buildMockCandidatePullRequest('packages/pkgB', 'node', '3.1.0', {
+          component: '@scope/pkgB',
+        }),
+      ];
+      const plugin = new Merge(github, 'main', {});
+      const newCandidates = await plugin.run(candidates);
+      expect(newCandidates).lengthOf(1);
+      const candidate = newCandidates[0];
+      expect(candidate.pullRequest.version).to.eql(Version.parse('2.0.0'));
     });
   });
 });


### PR DESCRIPTION
When all packages live in subdirectories (no package at path '.'), the Merge plugin failed to set the version field on the merged pull request. This caused downstream workspace plugins to drop the merged candidate because they filter out candidates without a version.

This is a problem in polyglot monorepos that use multiple workspace plugins (e.g. node-workspace + cargo-workspace): the second plugin's run() method drops the first plugin's merged result due to missing version.

Fix: fall back to the first in-scope candidate when there is no root-path candidate, and always propagate the version field to the merged pull request.

Thank you for opening a Pull Request! Before submitting your PR, there are a few things you can do to make sure it goes smoothly:
- [x] Make sure to open an issue as a [bug/issue](https://github.com/googleapis/release-please/issues/new/choose) before writing your code!  That way we can discuss the change, evaluate designs, and agree on the general idea
- [x] Ensure the tests and linter pass
- [x] Code coverage does not decrease (if any source code was changed)
- [x] Appropriate docs were updated (if necessary)

Fixes #2686 🦕
