### PR TITLE
fix: exclude peer dependencies from changelog when updatePeerDependencies is false

### DIFF
--- a/__snapshots__/node-workspace.js
+++ b/__snapshots__/node-workspace.js
@@ -238,6 +238,29 @@ Release notes for path: node1, releaseType: node
 This PR was generated with [Release Please](https://github.com/googleapis/release-please). See [documentation](https://github.com/googleapis/release-please#release-please).
 `
 
+exports['NodeWorkspace plugin run should not include peer dependency notes in changelog when package has both dev and peer deps 1'] = `
+:robot: I have created a release *beep* *boop*
+---
+
+
+<details><summary>@here/pkgA: 3.3.4</summary>
+
+Release notes for path: node1, releaseType: node
+</details>
+
+<details><summary>@here/plugin2: 4.4.5</summary>
+
+### Dependencies
+
+* The following workspace dependencies were updated
+  * devDependencies
+    * @here/pkgA bumped from ^3.3.3 to ^3.3.4
+</details>
+
+---
+This PR was generated with [Release Please](https://github.com/googleapis/release-please). See [documentation](https://github.com/googleapis/release-please#release-please).
+`
+
 exports['NodeWorkspace plugin run walks dependency tree and updates previously untouched packages (prerelease) 1'] = `
 :robot: I have created a release *beep* *boop*
 ---
@@ -347,6 +370,31 @@ exports['NodeWorkspace plugin with updatePeerDependencies: true respects version
     "@here/pkgA": "^2.2.2"
   }
 }
+`
+
+exports['NodeWorkspace plugin with updatePeerDependencies: true should include peer dependency notes in changelog when package has both dev and peer deps 1'] = `
+:robot: I have created a release *beep* *boop*
+---
+
+
+<details><summary>@here/pkgA: 3.3.4</summary>
+
+Release notes for path: node1, releaseType: node
+</details>
+
+<details><summary>@here/plugin2: 4.4.5</summary>
+
+### Dependencies
+
+* The following workspace dependencies were updated
+  * devDependencies
+    * @here/pkgA bumped from ^3.3.3 to ^3.3.4
+  * peerDependencies
+    * @here/pkgA bumped from ^3.3.3 to ^3.3.4
+</details>
+
+---
+This PR was generated with [Release Please](https://github.com/googleapis/release-please). See [documentation](https://github.com/googleapis/release-please#release-please).
 `
 
 exports['NodeWorkspace plugin with updatePeerDependencies: true should not ignore peer dependencies 1'] = `

--- a/src/plugins/node-workspace.ts
+++ b/src/plugins/node-workspace.ts
@@ -200,7 +200,8 @@ export class NodeWorkspace extends WorkspacePlugin<Package> {
       pkg,
       updatedPackage,
       updatedVersions,
-      this.logger
+      this.logger,
+      this.updatePeerDependencies
     );
 
     existingCandidate.pullRequest.updates =
@@ -268,7 +269,8 @@ export class NodeWorkspace extends WorkspacePlugin<Package> {
       pkg,
       updatedPackage,
       updatedVersions,
-      this.logger
+      this.logger,
+      this.updatePeerDependencies
     );
 
     const strategy = this.strategiesByPath[updatedPackage.path];
@@ -454,7 +456,8 @@ function getChangelogDepsNotes(
   original: Package,
   updated: Package,
   updateVersions: VersionsMap,
-  logger: Logger
+  logger: Logger,
+  updatePeerDependencies = true
 ): string {
   let depUpdateNotes = '';
   type DT =
@@ -465,7 +468,7 @@ function getChangelogDepsNotes(
   const depTypes: DT[] = [
     'dependencies',
     'devDependencies',
-    'peerDependencies',
+    ...(updatePeerDependencies ? (['peerDependencies'] as const) : []),
     'optionalDependencies',
   ];
   const updates: Map<DT, string[]> = new Map();

--- a/test/fixtures/plugins/node-workspace/plugin2/package.json
+++ b/test/fixtures/plugins/node-workspace/plugin2/package.json
@@ -1,0 +1,10 @@
+{
+  "name": "@here/plugin2",
+  "version": "4.4.4",
+  "peerDependencies": {
+    "@here/pkgA": "^3.3.3"
+  },
+  "devDependencies": {
+    "@here/pkgA": "^3.3.3"
+  }
+}

--- a/test/plugins/node-workspace.ts
+++ b/test/plugins/node-workspace.ts
@@ -696,6 +696,45 @@ describe('NodeWorkspace plugin', () => {
       assertNoHasUpdate(updates, 'plugin1/package.json');
       snapshot(dateSafe(nodeCandidate!.pullRequest.body.toString()));
     });
+    it('should not include peer dependency notes in changelog when package has both dev and peer deps', async () => {
+      const candidates: CandidateReleasePullRequest[] = [
+        buildMockCandidatePullRequest('node1', 'node', '3.3.4', {
+          component: '@here/pkgA',
+          updates: [
+            buildMockPackageUpdate('node1/package.json', 'node1/package.json'),
+          ],
+        }),
+      ];
+      stubFilesFromFixtures({
+        sandbox,
+        github,
+        fixturePath: fixturesPath,
+        files: ['node1/package.json', 'plugin2/package.json'],
+        flatten: false,
+        targetBranch: 'main',
+      });
+      plugin = new NodeWorkspace(github, 'main', {
+        node1: {
+          releaseType: 'node',
+        },
+        plugin2: {
+          releaseType: 'node',
+        },
+      });
+      const newCandidates = await plugin.run(candidates);
+      expect(newCandidates).lengthOf(1);
+      const nodeCandidate = newCandidates.find(
+        candidate => candidate.config.releaseType === 'node'
+      );
+      expect(nodeCandidate).to.not.be.undefined;
+      const updates = nodeCandidate!.pullRequest.updates;
+      assertHasUpdate(updates, 'node1/package.json');
+      assertHasUpdate(updates, 'plugin2/package.json');
+      const body = nodeCandidate!.pullRequest.body.toString();
+      expect(body).to.include('devDependencies');
+      expect(body).to.not.include('peerDependencies');
+      snapshot(dateSafe(body));
+    });
   });
   describe('with updatePeerDependencies: true', () => {
     const options = {updatePeerDependencies: true};
@@ -739,6 +778,51 @@ describe('NodeWorkspace plugin', () => {
       assertHasUpdate(updates, 'node1/package.json');
       assertHasUpdate(updates, 'plugin1/package.json');
       snapshot(dateSafe(nodeCandidate!.pullRequest.body.toString()));
+    });
+
+    it('should include peer dependency notes in changelog when package has both dev and peer deps', async () => {
+      const candidates: CandidateReleasePullRequest[] = [
+        buildMockCandidatePullRequest('node1', 'node', '3.3.4', {
+          component: '@here/pkgA',
+          updates: [
+            buildMockPackageUpdate('node1/package.json', 'node1/package.json'),
+          ],
+        }),
+      ];
+      stubFilesFromFixtures({
+        sandbox,
+        github,
+        fixturePath: fixturesPath,
+        files: ['node1/package.json', 'plugin2/package.json'],
+        flatten: false,
+        targetBranch: 'main',
+      });
+      plugin = new NodeWorkspace(
+        github,
+        'main',
+        {
+          node1: {
+            releaseType: 'node',
+          },
+          plugin2: {
+            releaseType: 'node',
+          },
+        },
+        options
+      );
+      const newCandidates = await plugin.run(candidates);
+      expect(newCandidates).lengthOf(1);
+      const nodeCandidate = newCandidates.find(
+        candidate => candidate.config.releaseType === 'node'
+      );
+      expect(nodeCandidate).to.not.be.undefined;
+      const updates = nodeCandidate!.pullRequest.updates;
+      assertHasUpdate(updates, 'node1/package.json');
+      assertHasUpdate(updates, 'plugin2/package.json');
+      const body = nodeCandidate!.pullRequest.body.toString();
+      expect(body).to.include('devDependencies');
+      expect(body).to.include('peerDependencies');
+      snapshot(dateSafe(body));
     });
 
     it('respects version prefix and updates peer dependencies', async () => {


### PR DESCRIPTION
The `getChangelogDepsNotes` function always iterated over all dependency types including `peerDependencies` when generating changelog entries, regardless of the `updatePeerDependencies` setting. This meant packages with both dev and peer dependencies on a workspace package would show peer dependency updates in the changelog even though the peer deps in package.json were not actually updated.

Thank you for opening a Pull Request! Before submitting your PR, there are a few things you can do to make sure it goes smoothly:
- [x] Make sure to open an issue as a [bug/issue](https://github.com/googleapis/release-please/issues/new/choose) before writing your code!  That way we can discuss the change, evaluate designs, and agree on the general idea
- [x] Ensure the tests and linter pass
- [x] Code coverage does not decrease (if any source code was changed)
- [x] Appropriate docs were updated (if necessary)

Fixes #2610 🦕
