### PR TITLE
docs: modify releasable unit prefixes in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -144,11 +144,11 @@ recommend using squash-merge instead](#linear-git-commit-history-use-squash-merg
 Release Please creates a release pull request after it notices the default branch
 contains "releasable units" since the last release.
 A releasable unit is a commit to the branch with one of the following
-prefixes: "feat", "fix", and "deps".
+prefixes: "feat", "fix", "perf", and "revert".
 (A "chore" or "build" commit is not a releasable unit.)
 
 Some languages have their specific releasable unit configuration. For example,
-"docs" is a prefix for releasable units in Java and Python.
+"deps" and "docs" is a prefix for releasable units in Java and Python.
 
 ### Step 2: Ensure no `autorelease: pending` or `autorelease: triggered` label in an old PR
 


### PR DESCRIPTION
Updated the prefixes for releasable units to include 'perf' and 'revert', per the defaults in src/strategies/base.ts.

Thank you for opening a Pull Request! Before submitting your PR, there are a few things you can do to make sure it goes smoothly:
- [x] Make sure to open an issue as a [bug/issue](https://github.com/googleapis/release-please/issues/new/choose) before writing your code!  That way we can discuss the change, evaluate designs, and agree on the general idea
- [ ] Ensure the tests and linter pass
- [x] Code coverage does not decrease (if any source code was changed)
- [x] Appropriate docs were updated (if necessary)

Fixes #2694 🦕

Related #2289  
