### PR TITLE
fix: limit git fetch to cloneDepth config

### DIFF
--- a/src/local-github.ts
+++ b/src/local-github.ts
@@ -120,7 +120,7 @@ export class LocalGitHub implements Scm {
         fetchArgs.push('--depth', options.cloneDepth.toString());
       }
       logger.debug(`Executing: git ${fetchArgs.join(' ')}`);
-      await execFile('git', fetchArgs, { cwd: repoDir });
+      await execFile('git', fetchArgs, {cwd: repoDir});
 
       logger.debug(`Executing: git checkout ${branch}`);
       await execFile('git', ['checkout', branch], {cwd: repoDir});

--- a/src/local-github.ts
+++ b/src/local-github.ts
@@ -115,8 +115,12 @@ export class LocalGitHub implements Scm {
       }
 
       const branch = gitHubApi.repository.defaultBranch;
-      logger.debug('Executing: git fetch origin');
-      await execFile('git', ['fetch', 'origin'], {cwd: repoDir});
+      const fetchArgs = ['fetch', 'origin'];
+      if (options.cloneDepth) {
+        fetchArgs.push('--depth', options.cloneDepth.toString());
+      }
+      logger.debug(`Executing: git ${fetchArgs.join(' ')}`);
+      await execFile('git', fetchArgs, { cwd: repoDir });
 
       logger.debug(`Executing: git checkout ${branch}`);
       await execFile('git', ['checkout', branch], {cwd: repoDir});


### PR DESCRIPTION
If we have a configured cloneDepth, we should not use `git fetch origin` to fetch the entire repository. Instead, use the depth as the `--depth` option for `git fetch`