### PR TITLE
fix: avoid incorrectly unchanged cargo workspace crates

### DIFF
--- a/src/plugins/cargo-workspace.ts
+++ b/src/plugins/cargo-workspace.ts
@@ -84,6 +84,7 @@ interface CrateInfo {
 export class CargoWorkspace extends WorkspacePlugin<CrateInfo> {
   private strategiesByPath: Record<string, Strategy> = {};
   private releasesByPath: Record<string, Release> = {};
+  private workspaceManifestPaths = new Set<string>();
 
   protected async buildAllPackages(
     candidates: CandidateReleasePullRequest[]
@@ -164,6 +165,7 @@ export class CargoWorkspace extends WorkspacePlugin<CrateInfo> {
         manifestContent: manifestContent.parsedContent,
         manifestPath,
       });
+      this.workspaceManifestPaths.add(manifestPath);
     }
     return {
       allPackages: allCrates,
@@ -198,22 +200,37 @@ export class CargoWorkspace extends WorkspacePlugin<CrateInfo> {
     );
 
     existingCandidate.pullRequest.updates =
-      existingCandidate.pullRequest.updates.map(update => {
-        if (update.path === addPath(existingCandidate.path, 'Cargo.toml')) {
-          update.updater = new RawContent(updatedContent);
-        } else if (update.updater instanceof Changelog && dependencyNotes) {
-          update.updater.changelogEntry = appendDependenciesSectionToChangelog(
-            update.updater.changelogEntry,
-            dependencyNotes,
-            this.logger
+      existingCandidate.pullRequest.updates
+        .filter(update => {
+          if (existingCandidate.path !== ROOT_PROJECT_PATH) {
+            return true;
+          }
+          const rootManifestPath = addPath(
+            existingCandidate.path,
+            'Cargo.toml'
           );
-        } else if (
-          update.path === addPath(existingCandidate.path, 'Cargo.lock')
-        ) {
-          update.updater = new CargoLock(updatedVersions);
-        }
-        return update;
-      });
+          return (
+            !this.workspaceManifestPaths.has(update.path) ||
+            update.path === rootManifestPath
+          );
+        })
+        .map(update => {
+          if (update.path === addPath(existingCandidate.path, 'Cargo.toml')) {
+            update.updater = new RawContent(updatedContent);
+          } else if (update.updater instanceof Changelog && dependencyNotes) {
+            update.updater.changelogEntry =
+              appendDependenciesSectionToChangelog(
+                update.updater.changelogEntry,
+                dependencyNotes,
+                this.logger
+              );
+          } else if (
+            update.path === addPath(existingCandidate.path, 'Cargo.lock')
+          ) {
+            update.updater = new CargoLock(updatedVersions);
+          }
+          return update;
+        });
 
     // append dependency notes
     if (dependencyNotes) {

--- a/test/plugins/cargo-workspace.ts
+++ b/test/plugins/cargo-workspace.ts
@@ -608,5 +608,86 @@ describe('CargoWorkspace plugin', () => {
         }
       );
     });
+
+    it('removes root rust strategy member updates outside workspace decisions', async () => {
+      const candidates: CandidateReleasePullRequest[] = [
+        buildMockCandidatePullRequest('.', 'rust', '2.33.1', {
+          component: 'root',
+          updates: [
+            buildMockPackageUpdate('Cargo.toml', 'packages/rustA/Cargo.toml'),
+            buildMockPackageUpdate(
+              'packages/rustA/Cargo.toml',
+              'packages/rustA/Cargo.toml'
+            ),
+            buildMockPackageUpdate(
+              'packages/rustB/Cargo.toml',
+              'packages/rustB/Cargo.toml'
+            ),
+          ],
+        }),
+      ];
+      stubFilesFromFixtures({
+        sandbox,
+        github,
+        fixturePath: fixturesPath,
+        files: [
+          'Cargo.toml',
+          'packages/rustA/Cargo.toml',
+          'packages/rustB/Cargo.toml',
+          'packages/rustC/Cargo.toml',
+          'packages/rustD/Cargo.toml',
+          'packages/rustE/Cargo.toml',
+        ],
+        flatten: false,
+        targetBranch: 'main',
+      });
+      sandbox
+        .stub(github, 'findFilesByGlobAndRef')
+        .withArgs('packages/rustA', 'main')
+        .resolves(['packages/rustA'])
+        .withArgs('packages/rustB', 'main')
+        .resolves(['packages/rustB'])
+        .withArgs('packages/rustC', 'main')
+        .resolves(['packages/rustC'])
+        .withArgs('packages/rustD', 'main')
+        .resolves(['packages/rustD'])
+        .withArgs('packages/rustE', 'main')
+        .resolves(['packages/rustE']);
+      plugin = new CargoWorkspace(
+        github,
+        'main',
+        {
+          '.': {
+            releaseType: 'rust',
+          },
+          'packages/rustA': {
+            releaseType: 'rust',
+          },
+          'packages/rustB': {
+            releaseType: 'rust',
+          },
+          'packages/rustC': {
+            releaseType: 'rust',
+          },
+          'packages/rustD': {
+            releaseType: 'rust',
+          },
+          'packages/rustE': {
+            releaseType: 'rust',
+          },
+        },
+        {merge: false}
+      );
+      const newCandidates = await plugin.run(candidates);
+      const rustCandidate = newCandidates.find(
+        candidate => candidate.path === '.'
+      );
+      expect(rustCandidate).to.not.be.undefined;
+      const updates = rustCandidate!.pullRequest.updates;
+      assertHasUpdate(updates, 'Cargo.toml', RawContent);
+      assertHasUpdate(updates, 'Cargo.lock');
+      assertNoHasUpdate(updates, 'packages/rustA/Cargo.toml');
+      assertNoHasUpdate(updates, 'packages/rustB/Cargo.toml');
+    });
   });
 });


### PR DESCRIPTION
- [x] Make sure to open an issue as a [bug/issue](https://github.com/googleapis/release-please/issues/new/choose) before writing your code!  That way we can discuss the change, evaluate designs, and agree on the general idea
- [x] Ensure the tests and linter pass
- [x] Code coverage does not decrease (if any source code was changed)
- [ ] Appropriate docs were updated (if necessary)

Fixes #2748

##  Summary

  This PR fixes a manifest-mode bug where a root Rust release candidate (path:
  ".") could retain workspace member Cargo.toml updates generated by the Rust
  strategy, causing member versions to be rewritten to the root version and
  diverging from per-path manifest decisions.

## What changed

   - Updated CargoWorkspace plugin to drop pre-existing root-candidate updates
   targeting workspace member manifests, while keeping the root Cargo.toml
  update.
   - Kept normal workspace/plugin-driven version propagation and Cargo.lock
  handling intact.

 ## Tests

  Added regression test:

   - test/plugins/cargo-workspace.ts
   - removes root rust strategy member updates outside workspace decisions

  This test verifies root candidates no longer include unintended member
  Cargo.toml bumps.

