### PR TITLE
fix(plugins/workspace): correct 'occured' -> 'occurred' in JSDoc

### DIFF
--- a/src/plugins/workspace.ts
+++ b/src/plugins/workspace.ts
@@ -364,12 +364,12 @@ export abstract class WorkspacePlugin<T> extends ManifestPlugin {
   protected abstract pathFromPackage(pkg: T): string;
 
   /**
-   * Amend any or all in-scope candidates once all other processing has occured.
+   * Amend any or all in-scope candidates once all other processing has occurred.
    *
    * This gives the workspace plugin once last chance to tweak the pull-requests
    * once all the underlying information has been collated.
    * @param {CandidateReleasePullRequest[]} candidates - The list of candidates
-   *   once all other workspace processing has occured.
+   *   once all other workspace processing has occurred.
    * @param {VersionMap} updatedVersions - Map containing any component versions
    *   that have changed.
    * @returns {CandidateReleasePullRequest[]} potentially amended list of


### PR DESCRIPTION
Two JSDoc lines on the workspace plugin's preconfigure hook in `src/plugins/workspace.ts` (lines 367 and 372) used `has occured`. Doc-only TypeScript change inside `/** */` blocks.