### PR TITLE
fix: respect empty pull request header/footer overrides

### DIFF
--- a/src/util/pull-request-body.ts
+++ b/src/util/pull-request-body.ts
@@ -35,8 +35,8 @@ export class PullRequestBody {
   releaseData: ReleaseData[];
   useComponents: boolean;
   constructor(releaseData: ReleaseData[], options?: PullRequestBodyOptions) {
-    this.header = options?.header || DEFAULT_HEADER;
-    this.footer = options?.footer || DEFAULT_FOOTER;
+    this.header = options?.header ?? DEFAULT_HEADER;
+    this.footer = options?.footer ?? DEFAULT_FOOTER;
     this.extra = options?.extra;
     this.releaseData = releaseData;
     this.useComponents = options?.useComponents ?? this.releaseData.length > 1;

--- a/test/util/pull-request-body.ts
+++ b/test/util/pull-request-body.ts
@@ -198,6 +198,23 @@ describe('PullRequestBody', () => {
       snapshot(pullRequestBody.toString());
     });
 
+    it('respects empty header and footer overrides', () => {
+      const data = [
+        {
+          component: 'pkg1',
+          version: Version.parse('1.2.3'),
+          notes: 'some special notes go here',
+        },
+      ];
+      const pullRequestBody = new PullRequestBody(data, {
+        header: '',
+        footer: '',
+      });
+      expect(pullRequestBody.toString()).to.equal(
+        '\n---\n\n\nsome special notes go here\n\n---\n'
+      );
+    });
+
     it('can parse the generated output', () => {
       const data = [
         {


### PR DESCRIPTION
Fixes #2696

### Description:
Respect empty string overrides for `pull-request-header` and `pull-request-footer`.

`PullRequestBody` was using `||`, so `""` fell back to the default text. Switching those assignments to `??` preserves explicit empty overrides while still using the defaults when the options are unset.

Added regression coverage for the empty-string override case.

### Checklist:
* [x] Tests passing (`npm test -- --grep 'PullRequestBody'`)?
* [x] Lint passing (`npm run lint`)?
