### PR TITLE
fix(schema): add missing config properties accepted by code

### DIFF
--- a/schemas/config.json
+++ b/schemas/config.json
@@ -247,7 +247,7 @@
           "type": "string"
         },
         "skip-snapshot": {
-          "description": "If set, do not propose snapshot pull requests. Used by `java` strategies.",
+          "description": "If set, do not propose snapshot pull requests. Used by `java` strategies. Defaults to `false`.",
           "type": "boolean"
         },
         "initial-version": {
@@ -257,6 +257,18 @@
         "component-no-space": {
           "description": "release-please automatically adds ` ` (space) in front of parsed ${component}. This option indicates whether that behaviour should be disabled. Defaults to `false`",
           "type": "boolean"
+        },
+        "include-commit-authors": {
+          "description": "Include commit authors in changelog entries (e.g. `(@username)`). Defaults to `false`.",
+          "type": "boolean"
+        },
+        "component": {
+          "description": "Name of the component for this package. Used in the release pull request title and tag.",
+          "type": "string"
+        },
+        "package-name": {
+          "description": "The name of the package to use when determining the version to release. For Python, this is the distribution name (e.g. from pyproject.toml).",
+          "type": "string"
         }
       }
     }
@@ -501,6 +513,10 @@
     "snapshot-label": true,
     "initial-version": true,
     "exclude-paths": true,
-    "component-no-space": false
+    "component-no-space": false,
+    "include-commit-authors": true,
+    "component": true,
+    "package-name": true,
+    "skip-snapshot": true
   }
 }


### PR DESCRIPTION
Thank you for opening a Pull Request! Before submitting your PR, there are a few things you can do to make sure it goes smoothly:
- [x] Make sure to open an issue as a [bug/issue](https://github.com/googleapis/release-please/issues/new/choose) before writing your code!  That way we can discuss the change, evaluate designs, and agree on the general idea
- [x] Ensure the tests and linter pass
- [x] Code coverage does not decrease (if any source code was changed)
- [x] Appropriate docs were updated (if necessary)

Fixes #2518 🦕

---

The config JSON schema (`schemas/config.json`) is missing several
properties that the TypeScript types in `src/manifest.ts` accept at
runtime. This causes false-positive validation errors for users who
validate their config against the published schema.

### Added properties

| Property | Type | TypeScript source |
|---|---|---|
| `include-commit-authors` | `boolean` | `ReleaserConfigJson` L183 |
| `component` | `string` | `ReleaserPackageConfig` L227 |
| `package-name` | `string` | `ReleaserPackageConfig` L226 |
| `skip-snapshot` | `boolean` | `ReleaserConfigJson` L193 |

All four are added to the `ReleaserConfigOptions` definition and to
the top-level `properties` allowlist. Purely additive — no existing
properties are modified, narrowed, or removed.

### Repro (before this fix)

```bash
cat > /tmp/rp-test.json <<'JSON'
{
  "release-type": "python",
  "include-commit-authors": true,
  "packages": { ".": { "package-name": "my-pkg" } }
}
JSON

npx check-jsonschema \
  --schemafile https://raw.githubusercontent.com/googleapis/release-please/main/schemas/config.json \
  /tmp/rp-test.json
# => Additional properties are not allowed ('include-commit-authors' was unexpected)
```