### PR TITLE
fix: push release PR updates via Git Data API instead of code-suggester

### DIFF
--- a/src/github-api.ts
+++ b/src/github-api.ts
@@ -21,6 +21,7 @@ import {PullRequest} from './pull-request';
 import {Repository} from './repository';
 import {Release} from './release';
 import {
+  ScmChangeSet,
   ScmRelease,
   ScmReleaseIteratorOptions,
   ScmReleaseOptions,
@@ -648,6 +649,112 @@ export class GitHubApi {
           .map((label: any) => label.name)
           .filter((name: any) => !!name) as string[],
       };
+    }
+  );
+
+  /**
+   * Apply file changes as a single commit on top of an existing branch via
+   * the Git Database API. The branch ref is force-updated.
+   *
+   * Empty change sets are a no-op.
+   *
+   * @param branchName The branch to push to (must already exist).
+   * @param message Commit message.
+   * @param changes File-level changes to apply.
+   * @returns The new commit SHA, or undefined if there were no changes.
+   * @throws {ConfigurationError} if the branch does not exist.
+   * @throws {GitHubAPIError} on any other API error.
+   */
+  commitAndPushChanges = wrapAsync(
+    async (
+      branchName: string,
+      message: string,
+      changes: ScmChangeSet
+    ): Promise<string | undefined> => {
+      if (changes.size === 0) {
+        this.logger.debug(
+          `No file changes to push to branch ${branchName}; skipping commit`
+        );
+        return undefined;
+      }
+      const owner = this.repository.owner;
+      const repo = this.repository.repo;
+      const branchSha = await this.getBranchSha(branchName);
+      if (!branchSha) {
+        throw new ConfigurationError(
+          `Branch ${branchName} does not exist`,
+          'core',
+          `${owner}/${repo}`
+        );
+      }
+      const {
+        data: {
+          tree: {sha: baseTreeSha},
+        },
+      } = await this.octokit.git.getCommit({
+        owner,
+        repo,
+        commit_sha: branchSha,
+      });
+      const treeEntries: {
+        path: string;
+        mode: '100644' | '100755' | '040000' | '160000' | '120000';
+        type: 'blob';
+        sha: string | null;
+      }[] = [];
+      for (const [filePath, diff] of changes) {
+        if (diff.content === null) {
+          treeEntries.push({
+            path: filePath,
+            mode: diff.mode,
+            type: 'blob',
+            sha: null,
+          });
+        } else {
+          const {
+            data: {sha: blobSha},
+          } = await this.octokit.git.createBlob({
+            owner,
+            repo,
+            content: Buffer.from(diff.content).toString('base64'),
+            encoding: 'base64',
+          });
+          treeEntries.push({
+            path: filePath,
+            mode: diff.mode,
+            type: 'blob',
+            sha: blobSha,
+          });
+        }
+      }
+      const {
+        data: {sha: newTreeSha},
+      } = await this.octokit.git.createTree({
+        owner,
+        repo,
+        base_tree: baseTreeSha,
+        tree: treeEntries,
+      });
+      const {
+        data: {sha: newCommitSha},
+      } = await this.octokit.git.createCommit({
+        owner,
+        repo,
+        message,
+        tree: newTreeSha,
+        parents: [branchSha],
+      });
+      await this.octokit.git.updateRef({
+        owner,
+        repo,
+        ref: `heads/${branchName}`,
+        sha: newCommitSha,
+        force: true,
+      });
+      this.logger.debug(
+        `Pushed commit ${newCommitSha} (${treeEntries.length} file change(s)) to ${branchName}`
+      );
+      return newCommitSha;
     }
   );
 

--- a/src/github.ts
+++ b/src/github.ts
@@ -792,12 +792,7 @@ export class GitHub implements Scm {
     )
       .toString()
       .slice(0, MAX_ISSUE_BODY_SIZE);
-    // Push file changes directly to the existing PR's branch. We deliberately
-    // bypass code-suggester here: it always tries to create-or-find a PR after
-    // pushing, and its existing-PR detection can miss our PR (e.g. on a
-    // case-sensitive comparison of `head.label`), causing it to attempt a
-    // duplicate create that 422s. We already know the PR number, so all we
-    // need is: push branch, then PATCH title/body.
+    // Force-push the new tree onto the PR's head branch, then PATCH the PR's title/body.
     await this.gitHubApi.commitAndPushChanges(
       releasePullRequest.headRefName,
       message,

--- a/src/github.ts
+++ b/src/github.ts
@@ -792,24 +792,17 @@ export class GitHub implements Scm {
     )
       .toString()
       .slice(0, MAX_ISSUE_BODY_SIZE);
-    const prNumber = await suggesterCreatePullRequest(this.octokit, changes, {
-      upstreamOwner: this.repository.owner,
-      upstreamRepo: this.repository.repo,
-      title,
-      branch: releasePullRequest.headRefName,
-      description: body,
-      primary: targetBranch,
-      force: true,
-      fork: options?.fork === false ? false : true,
+    // Push file changes directly to the existing PR's branch. We deliberately
+    // bypass code-suggester here: it always tries to create-or-find a PR after
+    // pushing, and its existing-PR detection can miss our PR (e.g. on a
+    // case-sensitive comparison of `head.label`), causing it to attempt a
+    // duplicate create that 422s. We already know the PR number, so all we
+    // need is: push branch, then PATCH title/body.
+    await this.gitHubApi.commitAndPushChanges(
+      releasePullRequest.headRefName,
       message,
-      logger: this.logger,
-      draft: releasePullRequest.draft,
-    });
-    if (prNumber !== number) {
-      this.logger.warn(
-        `updated code for ${prNumber}, but update requested for ${number}`
-      );
-    }
+      changes
+    );
     return this.gitHubApi.updatePullRequest(number, title, body);
   }
 

--- a/src/local-github.ts
+++ b/src/local-github.ts
@@ -804,12 +804,7 @@ export class LocalGitHub implements Scm {
       .toString()
       .slice(0, MAX_ISSUE_BODY_SIZE);
 
-    // Push file changes directly to the existing PR's branch. We deliberately
-    // bypass code-suggester here: it always tries to create-or-find a PR after
-    // pushing, and its existing-PR detection can miss our PR (e.g. on a
-    // case-sensitive comparison of `head.label`), causing it to attempt a
-    // duplicate create that 422s. We already know the PR number, so all we
-    // need is: push branch, then PATCH title/body.
+    // Force-push the new tree onto the PR's head branch, then PATCH the PR's title/body.
     await this.gitHubApi.commitAndPushChanges(
       pullRequest.headRefName,
       message,

--- a/src/local-github.ts
+++ b/src/local-github.ts
@@ -804,28 +804,17 @@ export class LocalGitHub implements Scm {
       .toString()
       .slice(0, MAX_ISSUE_BODY_SIZE);
 
-    const prNumber = await suggesterCreatePullRequest(
-      this.gitHubApi.octokit,
-      changes,
-      {
-        upstreamOwner: this.repository.owner,
-        upstreamRepo: this.repository.repo,
-        title,
-        branch: pullRequest.headRefName,
-        description: body,
-        primary: targetBranch,
-        force: true,
-        fork: options?.fork === false ? false : true,
-        message,
-        logger: this.logger,
-        draft: pullRequest.draft,
-      }
+    // Push file changes directly to the existing PR's branch. We deliberately
+    // bypass code-suggester here: it always tries to create-or-find a PR after
+    // pushing, and its existing-PR detection can miss our PR (e.g. on a
+    // case-sensitive comparison of `head.label`), causing it to attempt a
+    // duplicate create that 422s. We already know the PR number, so all we
+    // need is: push branch, then PATCH title/body.
+    await this.gitHubApi.commitAndPushChanges(
+      pullRequest.headRefName,
+      message,
+      changes
     );
-    if (prNumber !== number) {
-      this.logger.warn(
-        `updated code for ${prNumber}, but update requested for ${number}`
-      );
-    }
     return this.gitHubApi.updatePullRequest(number, title, body);
   }
 

--- a/test/github.ts
+++ b/test/github.ts
@@ -1214,5 +1214,113 @@ describe('GitHub', () => {
       sinon.assert.calledOnce(handleOverflowStub);
       req.done();
     });
+
+    it('pushes file changes via the Git Data API and PATCHes the PR (no code-suggester)', async () => {
+      // Stub buildChangeSet so we don't have to nock all of file fetches.
+      const branch = 'release-please--branches--main--components--xdeployment';
+      const changes = new Map();
+      changes.set('CHANGELOG.md', {
+        mode: '100644',
+        content: '# new changelog\n',
+        originalContent: '# old changelog\n',
+      });
+      sandbox.stub(github, 'buildChangeSet').resolves(changes);
+
+      // If code-suggester is reached we'd see /pulls?head=... or POST /pulls;
+      // the absence of a matching nock would error the test if it happened.
+      const createPullRequestSpy = sandbox.spy(
+        codeSuggester,
+        'createPullRequest'
+      );
+
+      // Git Data API call sequence: getRef -> getCommit -> createBlob ->
+      // createTree -> createCommit -> updateRef.
+      req = req
+        .get(`/repos/fake/fake/git/ref/heads%2F${encodeURIComponent(branch)}`)
+        .reply(200, {object: {sha: 'parent-sha'}})
+        .get('/repos/fake/fake/git/commits/parent-sha')
+        .reply(200, {tree: {sha: 'base-tree-sha'}})
+        .post('/repos/fake/fake/git/blobs')
+        .reply(201, {sha: 'blob-sha'})
+        .post('/repos/fake/fake/git/trees', body => {
+          expect(body.base_tree).to.eql('base-tree-sha');
+          expect(body.tree).to.have.lengthOf(1);
+          expect(body.tree[0]).to.deep.include({
+            path: 'CHANGELOG.md',
+            mode: '100644',
+            type: 'blob',
+            sha: 'blob-sha',
+          });
+          return true;
+        })
+        .reply(201, {sha: 'new-tree-sha'})
+        .post('/repos/fake/fake/git/commits', body => {
+          expect(body.tree).to.eql('new-tree-sha');
+          expect(body.parents).to.eql(['parent-sha']);
+          return true;
+        })
+        .reply(201, {sha: 'new-commit-sha'})
+        .patch(
+          `/repos/fake/fake/git/refs/heads%2F${encodeURIComponent(branch)}`,
+          body => {
+            expect(body.sha).to.eql('new-commit-sha');
+            expect(body.force).to.eql(true);
+            return true;
+          }
+        )
+        .reply(200, {object: {sha: 'new-commit-sha'}})
+        .patch('/repos/fake/fake/pulls/123')
+        .reply(200, {
+          number: 123,
+          title: 'updated-title',
+          body: 'updated body',
+          labels: [],
+          head: {ref: branch},
+          base: {ref: 'main'},
+        });
+
+      const pullRequest = {
+        title: PullRequestTitle.ofTargetBranch('main'),
+        body: new PullRequestBody(mockReleaseData(1)),
+        labels: [],
+        headRefName: branch,
+        draft: false,
+        updates: [],
+      };
+      const result = await github.updatePullRequest(123, pullRequest, 'main');
+      expect(result.number).to.eql(123);
+      sinon.assert.notCalled(createPullRequestSpy);
+      req.done();
+    });
+
+    it('skips the commit step when there are no file changes', async () => {
+      sandbox.stub(github, 'buildChangeSet').resolves(new Map());
+      const createPullRequestSpy = sandbox.spy(
+        codeSuggester,
+        'createPullRequest'
+      );
+
+      req = req.patch('/repos/fake/fake/pulls/123').reply(200, {
+        number: 123,
+        title: 'updated-title',
+        body: 'updated body',
+        labels: [],
+        head: {ref: 'release-please--branches--main'},
+        base: {ref: 'main'},
+      });
+
+      const pullRequest = {
+        title: PullRequestTitle.ofTargetBranch('main'),
+        body: new PullRequestBody(mockReleaseData(1)),
+        labels: [],
+        headRefName: 'release-please--branches--main',
+        draft: false,
+        updates: [],
+      };
+      const result = await github.updatePullRequest(123, pullRequest, 'main');
+      expect(result.number).to.eql(123);
+      sinon.assert.notCalled(createPullRequestSpy);
+      req.done();
+    });
   });
 });


### PR DESCRIPTION
Fixes #2773

When `separate-pull-requests: true` is set, updating an existing release PR consistently fails with:

```
Validation Failed: {"resource":"PullRequest","code":"custom", "message":"A pull request already exists for ..."}
```

The branch is updated successfully (`Updating reference heads/release-please--branches--main--components--<comp>`), but the action exits non-zero.

Reproduces on `release-please-action@v4` and `@v5`, against library 17.3.0 and 17.6.0, with a GitHub App token.

## Root cause

`GitHub.updatePullRequest` (and `LocalGitHub.updatePullRequest`) was reusing `code-suggester.createPullRequest` to do *both* the branch push and the PR refresh. `code-suggester` always:

1. pushes the branch,
2. looks up an existing PR for that branch via `octokit.pulls.list({head})` plus a strict `pr.head.label === head` find,
3. if not found, calls `octokit.pulls.create`.

The lookup in step (2) is best-effort. It can miss the PR for several reasons, case-sensitivity differences between `repository.owner` (sometimes lowercased through env-var paths like `GITHUB_REPOSITORY`) and the org login as GitHub returns it in `pr.head.label`, the un-paginated single-page response, brief eventual consistency on `pulls.list`. When the lookup misses, step (3) runs and GitHub returns 422 because there's obviously already a PR for that branch.

`release-please` already knows the PR number it's updating, [`manifest.ts:1040`](https://github.com/googleapis/release-please/blob/v17.6.0/src/manifest.ts#L1040) matched the existing PR before calling `updatePullRequest`. So the detect-or-create step is unnecessary work that can fail. Only the *create* path actually needs find-or-create semantics; the update path was misusing `code-suggester`.

The bug surfaces especially under `separate-pull-requests: true` because each component's body diverges independently after a new commit, and every divergent body hits the update path.

## Fix

- Add a new low-level primitive `commitAndPushChanges(branch, message, changes)` to `GitHubApi`. It uses the Git Data API directly: `getRef → getCommit → createBlob (per file) → createTree → createCommit → updateRef --force`. No PR detection. No PR create. Empty change sets are a no-op.
- `GitHub.updatePullRequest` and `LocalGitHub.updatePullRequest` now call `commitAndPushChanges` followed by the existing `gitHubApi.updatePullRequest(number, title, body)` PATCH.
- `code-suggester` is no longer touched in the update path, so `octokit.pulls.create` cannot be called and the 422 cannot occur, regardless of how the upstream lookup would have behaved.
- The *create* path (`GitHub.createPullRequest`) is unchanged. "Find-or-create" is the correct semantic there; only the *reuse* in the update path was wrong.

## Test plan

- [x] `npm run compile`, passes
- [x] `npm run lint`,  clean (only pre-existing warnings in unrelated files)
- [x] `npm test`,  full suite (1101 tests) passes

You can test the fix by using my `release-please-action` fork.

```yaml
#...
steps:
  - uses: Kerwood/release-please-action@main
    with:
      # this assumes that you have created a personal access token
      # (PAT) and configured it as a GitHub action secret named
      # `MY_RELEASE_PLEASE_TOKEN` (this secret name is not important).
      token: ${{ secrets.MY_RELEASE_PLEASE_TOKEN }}
      # optional. customize path to release-please-config.json
      config-file: release-please-config.json
      # optional. customize path to .release-please-manifest.json
      manifest-file: .release-please-manifest.json
```