### PR TITLE
feat: update librarian.yaml for Node

### DIFF
--- a/__snapshots__/cli.js
+++ b/__snapshots__/cli.js
@@ -51,9 +51,9 @@ Options:
                                 for?
   [choices: "bazel", "dart", "dotnet-yoshi", "elixir", "expo", "go", "go-yoshi",
           "helm", "java", "java-backport", "java-bom", "java-lts", "java-yoshi",
-       "java-yoshi-mono-repo", "krm-blueprint", "maven", "node", "ocaml", "php",
-         "php-yoshi", "python", "r", "ruby", "ruby-yoshi", "rust", "salesforce",
-                                           "sfdx", "simple", "terraform-module"]
+     "java-yoshi-mono-repo", "krm-blueprint", "maven", "node", "node-librarian",
+       "ocaml", "php", "php-yoshi", "python", "r", "ruby", "ruby-yoshi", "rust",
+                             "salesforce", "sfdx", "simple", "terraform-module"]
   --config-file                 where can the config file be found in the
                                 project? [default: "release-please-config.json"]
   --manifest-file               where can the manifest file be found in the
@@ -278,9 +278,9 @@ Options:
                                     for?
   [choices: "bazel", "dart", "dotnet-yoshi", "elixir", "expo", "go", "go-yoshi",
           "helm", "java", "java-backport", "java-bom", "java-lts", "java-yoshi",
-       "java-yoshi-mono-repo", "krm-blueprint", "maven", "node", "ocaml", "php",
-         "php-yoshi", "python", "r", "ruby", "ruby-yoshi", "rust", "salesforce",
-                                           "sfdx", "simple", "terraform-module"]
+     "java-yoshi-mono-repo", "krm-blueprint", "maven", "node", "node-librarian",
+       "ocaml", "php", "php-yoshi", "python", "r", "ruby", "ruby-yoshi", "rust",
+                             "salesforce", "sfdx", "simple", "terraform-module"]
   --config-file                     where can the config file be found in the
                                     project?
                                          [default: "release-please-config.json"]

--- a/__snapshots__/node-librarian.js
+++ b/__snapshots__/node-librarian.js
@@ -1,0 +1,37 @@
+exports['NodeLibrarian buildReleasePullRequest updates changelog.json if present 1'] = `
+{
+  "entries": [
+    {
+      "changes": [
+        {
+          "type": "fix",
+          "sha": "845db1381b3d5d20151cad2588f85feb",
+          "message": "update dependency com.google.cloud:google-cloud-storage to v1.120.0",
+          "issues": [],
+          "scope": "deps"
+        },
+        {
+          "type": "chore",
+          "sha": "b3f8966b023b8f21ce127142aa91841c",
+          "message": "update a very important dep",
+          "issues": [],
+          "breakingChangeNote": "update a very important dep"
+        },
+        {
+          "type": "fix",
+          "sha": "08ca01180a91c0a1ba8992b491db9212",
+          "message": "update dependency com.google.cloud:google-cloud-spanner to v1.50.0",
+          "issues": [],
+          "scope": "deps"
+        }
+      ],
+      "version": "1.0.0",
+      "language": "JAVASCRIPT",
+      "artifactName": "node-test-repo",
+      "id": "abc-123-efd-qwerty",
+      "createTime": "2023-01-05T16:42:33.446Z"
+    }
+  ],
+  "updateTime": "2023-01-05T16:42:33.446Z"
+}
+`

--- a/src/factory.ts
+++ b/src/factory.ts
@@ -32,6 +32,7 @@ import {JavaYoshiMonoRepo} from './strategies/java-yoshi-mono-repo';
 import {KRMBlueprint} from './strategies/krm-blueprint';
 import {Maven} from './strategies/maven';
 import {Node} from './strategies/node';
+import {NodeLibrarian} from './strategies/node-librarian';
 import {OCaml} from './strategies/ocaml';
 import {PHP} from './strategies/php';
 import {PHPYoshi} from './strategies/php-yoshi';
@@ -94,6 +95,7 @@ const releasers: Record<string, ReleaseBuilder> = {
     }),
   'krm-blueprint': options => new KRMBlueprint(options),
   node: options => new Node(options),
+  'node-librarian': options => new NodeLibrarian(options),
   expo: options => new Expo(options),
   ocaml: options => new OCaml(options),
   php: options => new PHP(options),

--- a/src/strategies/node-librarian.ts
+++ b/src/strategies/node-librarian.ts
@@ -35,11 +35,6 @@ export class NodeLibrarian extends BaseStrategy {
     const versionsMap = options.versionsMap;
     const packageName = (await this.getPackageName()) ?? '';
     const lockFiles = ['package-lock.json', 'npm-shrinkwrap.json'];
-    const librarianFilesSearch = this.github.findFilesByFilenameAndRef(
-      'librarian.yaml',
-      this.targetBranch,
-      this.path
-    );
     lockFiles.forEach(lockFile => {
       updates.push({
         path: this.addPath(lockFile),
@@ -94,19 +89,15 @@ export class NodeLibrarian extends BaseStrategy {
       });
     }
 
-    // Update librarian.yaml for every matching library.
-    const librarianFiles = await librarianFilesSearch;
-    librarianFiles.forEach(path => {
-      updates.push({
-        path: this.addPath(path),
-        createIfMissing: false,
-        updater: new LibrarianYamlUpdater({
-          version,
-          versionsMap,
-        }),
-      });
+    // Update librarian.yaml if this package exists within it.
+    updates.push({
+      path: 'librarian.yaml',
+      createIfMissing: false,
+      updater: new LibrarianYamlUpdater({
+        version,
+        packagePath: this.path,
+      }),
     });
-
     return updates;
   }
 

--- a/src/strategies/node-librarian.ts
+++ b/src/strategies/node-librarian.ts
@@ -1,0 +1,146 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import {BaseStrategy, BuildUpdatesOptions} from './base';
+import {Update} from '../update';
+import {ChangelogJson} from '../updaters/changelog-json';
+import {PackageLockJson} from '../updaters/node/package-lock-json';
+import {SamplesPackageJson} from '../updaters/node/samples-package-json';
+import {Changelog} from '../updaters/changelog';
+import {PackageJson} from '../updaters/node/package-json';
+import {LibrarianYamlUpdater} from '../updaters/node/librarian-yaml';
+import {GitHubFileContents} from '@google-automations/git-file-utils';
+import {FileNotFoundError, MissingRequiredFileError} from '../errors';
+import {filterCommits} from '../util/filter-commits';
+
+export class NodeLibrarian extends BaseStrategy {
+  private pkgJsonContents?: GitHubFileContents;
+
+  protected async buildUpdates(
+    options: BuildUpdatesOptions
+  ): Promise<Update[]> {
+    const updates: Update[] = [];
+    const version = options.newVersion;
+    const versionsMap = options.versionsMap;
+    const packageName = (await this.getPackageName()) ?? '';
+    const lockFiles = ['package-lock.json', 'npm-shrinkwrap.json'];
+    const librarianFilesSearch = this.github.findFilesByFilenameAndRef(
+      'librarian.yaml',
+      this.targetBranch,
+      this.path
+    );
+    lockFiles.forEach(lockFile => {
+      updates.push({
+        path: this.addPath(lockFile),
+        createIfMissing: false,
+        updater: new PackageLockJson({
+          version,
+          versionsMap,
+        }),
+      });
+    });
+
+    updates.push({
+      path: this.addPath('samples/package.json'),
+      createIfMissing: false,
+      updater: new SamplesPackageJson({
+        version,
+        packageName,
+      }),
+    });
+
+    !this.skipChangelog &&
+      updates.push({
+        path: this.addPath(this.changelogPath),
+        createIfMissing: true,
+        updater: new Changelog({
+          version,
+          changelogEntry: options.changelogEntry,
+        }),
+      });
+
+    updates.push({
+      path: this.addPath('package.json'),
+      createIfMissing: false,
+      cachedFileContents: this.pkgJsonContents,
+      updater: new PackageJson({
+        version,
+      }),
+    });
+
+    // If a machine readable changelog.json exists update it:
+    if (options.commits && packageName && !this.skipChangelog) {
+      const commits = filterCommits(options.commits, this.changelogSections);
+      updates.push({
+        path: 'changelog.json',
+        createIfMissing: false,
+        updater: new ChangelogJson({
+          artifactName: packageName,
+          version,
+          commits,
+          language: 'JAVASCRIPT',
+        }),
+      });
+    }
+
+    // Update librarian.yaml for every matching library.
+    const librarianFiles = await librarianFilesSearch;
+    librarianFiles.forEach(path => {
+      updates.push({
+        path: this.addPath(path),
+        createIfMissing: false,
+        updater: new LibrarianYamlUpdater({
+          version,
+          versionsMap,
+        }),
+      });
+    });
+
+    return updates;
+  }
+
+  async getDefaultPackageName(): Promise<string | undefined> {
+    const pkgJsonContents = await this.getPkgJsonContents();
+    const pkg = JSON.parse(pkgJsonContents.parsedContent);
+    return pkg.name;
+  }
+
+  protected normalizeComponent(component: string | undefined): string {
+    if (!component) {
+      return '';
+    }
+    return component.match(/^@[\w-]+\//) ? component.split('/')[1] : component;
+  }
+
+  protected async getPkgJsonContents(): Promise<GitHubFileContents> {
+    if (!this.pkgJsonContents) {
+      try {
+        this.pkgJsonContents = await this.github.getFileContentsOnBranch(
+          this.addPath('package.json'),
+          this.targetBranch
+        );
+      } catch (e) {
+        if (e instanceof FileNotFoundError) {
+          throw new MissingRequiredFileError(
+            this.addPath('package.json'),
+            'node',
+            `${this.repository.owner}/${this.repository.repo}`
+          );
+        }
+        throw e;
+      }
+    }
+    return this.pkgJsonContents;
+  }
+}

--- a/src/updaters/node/librarian-yaml.ts
+++ b/src/updaters/node/librarian-yaml.ts
@@ -42,7 +42,7 @@ export class LibrarianYamlUpdater extends DefaultUpdater {
     super(options);
     this.packagePath = options.packagePath;
   }
-  
+
   /**
    * Given initial file contents, return updated contents.
    * @param {string} content The initial content
@@ -71,8 +71,8 @@ export class LibrarianYamlUpdater extends DefaultUpdater {
       const outputDirectory = this.deriveOutputDirectory(
         library.toJSON() as LibrarianLibrary
       );
-      if (outputDirectory == this.packagePath) {
-        let newVersion = this.version.toString()
+      if (outputDirectory === this.packagePath) {
+        const newVersion = this.version.toString();
         if (library.get('version') !== newVersion) {
           library.set('version', newVersion);
           modified = true;

--- a/src/updaters/node/librarian-yaml.ts
+++ b/src/updaters/node/librarian-yaml.ts
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import {DefaultUpdater} from '../default';
+import {DefaultUpdater, UpdateOptions} from '../default';
 import * as yaml from 'yaml';
 import {logger as defaultLogger, Logger} from '../../util/logger';
 
@@ -28,21 +28,27 @@ export interface LibrarianYamlSchema {
   [key: string]: any;
 }
 
+export interface LibrarianUpdateOptions extends UpdateOptions {
+  packagePath: string;
+}
+
 /**
  * Updates a librarian.yaml file.
  */
 export class LibrarianYamlUpdater extends DefaultUpdater {
+  private readonly packagePath: string;
+
+  constructor(options: LibrarianUpdateOptions) {
+    super(options);
+    this.packagePath = options.packagePath;
+  }
+  
   /**
    * Given initial file contents, return updated contents.
    * @param {string} content The initial content
    * @returns {string} The updated content
    */
   updateContent(content: string, logger: Logger = defaultLogger): string {
-    if (!this.versionsMap) {
-      logger.warn('missing versions map');
-      return content;
-    }
-
     // Use yaml package to make sure librarian.yaml is not reformatted because
     // we use different tool to format librarian.yaml.
     const doc = yaml.parseDocument(content);
@@ -65,10 +71,10 @@ export class LibrarianYamlUpdater extends DefaultUpdater {
       const outputDirectory = this.deriveOutputDirectory(
         library.toJSON() as LibrarianLibrary
       );
-      if (this.versionsMap.has(outputDirectory)) {
-        const newVersion = this.versionsMap.get(outputDirectory);
-        if (newVersion && library.get('version') !== newVersion.toString()) {
-          library.set('version', newVersion.toString());
+      if (outputDirectory == this.packagePath) {
+        let newVersion = this.version.toString()
+        if (library.get('version') !== newVersion) {
+          library.set('version', newVersion);
           modified = true;
         }
       }

--- a/src/updaters/node/librarian-yaml.ts
+++ b/src/updaters/node/librarian-yaml.ts
@@ -1,0 +1,89 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import {DefaultUpdater} from '../default';
+import * as yaml from 'yaml';
+import {logger as defaultLogger, Logger} from '../../util/logger';
+
+export interface LibrarianLibrary {
+  name: string;
+  output: string;
+  version: string;
+  [key: string]: any;
+}
+
+export interface LibrarianYamlSchema {
+  libraries: LibrarianLibrary[];
+  [key: string]: any;
+}
+
+/**
+ * Updates a librarian.yaml file.
+ */
+export class LibrarianYamlUpdater extends DefaultUpdater {
+  /**
+   * Given initial file contents, return updated contents.
+   * @param {string} content The initial content
+   * @returns {string} The updated content
+   */
+  updateContent(content: string, logger: Logger = defaultLogger): string {
+    if (!this.versionsMap) {
+      logger.warn('missing versions map');
+      return content;
+    }
+
+    // Use yaml package to make sure librarian.yaml is not reformatted because
+    // we use different tool to format librarian.yaml.
+    const doc = yaml.parseDocument(content);
+    if (!doc || doc.errors.length > 0) {
+      logger.warn('Invalid yaml, cannot be parsed');
+      return content;
+    }
+
+    const libraries = doc.get('libraries');
+    if (!libraries || !yaml.isSeq(libraries)) {
+      return content;
+    }
+
+    let modified = false;
+    for (const library of libraries.items) {
+      if (!yaml.isMap(library)) continue;
+
+      // The release-please version map key is the output directory (explicit or
+      // derived) in librarian.yaml.
+      const outputDirectory = this.deriveOutputDirectory(
+        library.toJSON() as LibrarianLibrary
+      );
+      if (this.versionsMap.has(outputDirectory)) {
+        const newVersion = this.versionsMap.get(outputDirectory);
+        if (newVersion && library.get('version') !== newVersion.toString()) {
+          library.set('version', newVersion.toString());
+          modified = true;
+        }
+      }
+    }
+
+    if (modified) {
+      return doc.toString({lineWidth: 0});
+    }
+    return content;
+  }
+
+  deriveOutputDirectory(library: LibrarianLibrary): string {
+    if (library.output) {
+      return library.output;
+    }
+    return `packages/${library.name}`;
+  }
+}

--- a/test/strategies/node-librarian.ts
+++ b/test/strategies/node-librarian.ts
@@ -232,11 +232,7 @@ describe('NodeLibrarian', () => {
         component: 'google-cloud-automl',
         packageName: 'google-cloud-automl-pkg',
       });
-      const findFilesStub = sandbox.stub(github, 'findFilesByFilenameAndRef');
-      findFilesStub
-        .withArgs('librarian.yaml', 'main', '.')
-        .resolves(['path1/librarian.yaml']);
-      findFilesStub.resolves([]);
+      sandbox.stub(github, 'findFilesByFilenameAndRef').resolves([]);
 
       const latestRelease = undefined;
       const release = await strategy.buildReleasePullRequest(
@@ -255,7 +251,7 @@ describe('NodeLibrarian', () => {
       const updater = update.updater as SamplesPackageJson;
       expect(updater.packageName).to.equal('google-cloud-automl-pkg');
       assertHasUpdate(updates, 'package.json', PackageJson);
-      assertHasUpdate(updates, 'path1/librarian.yaml', LibrarianYamlUpdater);
+      assertHasUpdate(updates, 'librarian.yaml', LibrarianYamlUpdater);
     });
 
     it('omits changelog if skipChangelog=true', async () => {

--- a/test/strategies/node-librarian.ts
+++ b/test/strategies/node-librarian.ts
@@ -1,0 +1,289 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import {describe, it, afterEach, beforeEach} from 'mocha';
+import {NodeLibrarian} from '../../src/strategies/node-librarian';
+import {
+  buildMockConventionalCommit,
+  buildGitHubFileContent,
+  assertHasUpdate,
+  assertNoHasUpdate,
+} from '../helpers';
+import * as nock from 'nock';
+import * as sinon from 'sinon';
+import {GitHub} from '../../src/github';
+import {Version} from '../../src/version';
+import {TagName} from '../../src/util/tag-name';
+import {expect} from 'chai';
+import {PackageLockJson} from '../../src/updaters/node/package-lock-json';
+import {SamplesPackageJson} from '../../src/updaters/node/samples-package-json';
+import {Changelog} from '../../src/updaters/changelog';
+import {PackageJson} from '../../src/updaters/node/package-json';
+import {LibrarianYamlUpdater} from '../../src/updaters/node/librarian-yaml';
+import {ChangelogJson} from '../../src/updaters/changelog-json';
+import * as assert from 'assert';
+import {MissingRequiredFileError, FileNotFoundError} from '../../src/errors';
+import * as snapshot from 'snap-shot-it';
+
+nock.disableNetConnect();
+const sandbox = sinon.createSandbox();
+const fixturesPath = './test/fixtures/strategies/node';
+
+const UUID_REGEX =
+  /[a-f0-9]{8}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{12}/g;
+const ISO_DATE_REGEX =
+  /[0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9]{2}:[0-9]{2}:[0-9]{2}\.[0-9]+Z/g; // 2023-01-05T16:42:33.446Z
+
+describe('NodeLibrarian', () => {
+  let github: GitHub;
+  const commits = [
+    ...buildMockConventionalCommit(
+      'fix(deps): update dependency com.google.cloud:google-cloud-storage to v1.120.0'
+    ),
+  ];
+  beforeEach(async () => {
+    github = await GitHub.create({
+      owner: 'googleapis',
+      repo: 'node-test-repo',
+      defaultBranch: 'main',
+    });
+  });
+  afterEach(() => {
+    sandbox.restore();
+  });
+  describe('buildReleasePullRequest', () => {
+    it('returns release PR changes with defaultInitialVersion', async () => {
+      const expectedVersion = '1.0.0';
+      const strategy = new NodeLibrarian({
+        targetBranch: 'main',
+        github,
+        component: 'google-cloud-automl',
+        packageName: 'google-cloud-automl',
+      });
+      const latestRelease = undefined;
+      sandbox.stub(github, 'findFilesByFilenameAndRef').resolves([]);
+      const release = await strategy.buildReleasePullRequest(
+        commits,
+        latestRelease
+      );
+      expect(release!.version?.toString()).to.eql(expectedVersion);
+    });
+    it('builds a release pull request', async () => {
+      const expectedVersion = '0.123.5';
+      const strategy = new NodeLibrarian({
+        targetBranch: 'main',
+        github,
+        component: 'some-node-package',
+        packageName: 'some-node-package',
+      });
+      const latestRelease = {
+        tag: new TagName(Version.parse('0.123.4'), 'some-node-package'),
+        sha: 'abc123',
+        notes: 'some notes',
+      };
+      sandbox.stub(github, 'findFilesByFilenameAndRef').resolves([]);
+      const pullRequest = await strategy.buildReleasePullRequest(
+        commits,
+        latestRelease
+      );
+      expect(pullRequest!.version?.toString()).to.eql(expectedVersion);
+    });
+    it('detects a default component', async () => {
+      const expectedVersion = '0.123.5';
+      const strategy = new NodeLibrarian({
+        targetBranch: 'main',
+        github,
+      });
+      const commits = [
+        ...buildMockConventionalCommit(
+          'fix(deps): update dependency com.google.cloud:google-cloud-storage to v1.120.0'
+        ),
+      ];
+      const latestRelease = {
+        tag: new TagName(Version.parse('0.123.4'), 'node-test-repo'),
+        sha: 'abc123',
+        notes: 'some notes',
+      };
+      const getFileContentsStub = sandbox.stub(
+        github,
+        'getFileContentsOnBranch'
+      );
+      getFileContentsStub
+        .withArgs('package.json', 'main')
+        .resolves(buildGitHubFileContent(fixturesPath, 'package.json'));
+      sandbox.stub(github, 'findFilesByFilenameAndRef').resolves([]);
+      const pullRequest = await strategy.buildReleasePullRequest(
+        commits,
+        latestRelease
+      );
+      expect(pullRequest!.version?.toString()).to.eql(expectedVersion);
+    });
+    it('detects a default packageName', async () => {
+      const expectedVersion = '0.123.5';
+      const strategy = new NodeLibrarian({
+        targetBranch: 'main',
+        github,
+        component: 'abc-123',
+      });
+      const commits = [
+        ...buildMockConventionalCommit(
+          'fix(deps): update dependency com.google.cloud:google-cloud-storage to v1.120.0'
+        ),
+      ];
+      const latestRelease = {
+        tag: new TagName(Version.parse('0.123.4'), 'node-test-repo'),
+        sha: 'abc123',
+        notes: 'some notes',
+      };
+      const getFileContentsStub = sandbox.stub(
+        github,
+        'getFileContentsOnBranch'
+      );
+      getFileContentsStub
+        .withArgs('package.json', 'main')
+        .resolves(buildGitHubFileContent(fixturesPath, 'package.json'));
+      sandbox.stub(github, 'findFilesByFilenameAndRef').resolves([]);
+      const pullRequest = await strategy.buildReleasePullRequest(
+        commits,
+        latestRelease
+      );
+      expect(pullRequest!.version?.toString()).to.eql(expectedVersion);
+    });
+    it('handles missing package.json', async () => {
+      sandbox
+        .stub(github, 'getFileContentsOnBranch')
+        .rejects(new FileNotFoundError('stub/path'));
+      const strategy = new NodeLibrarian({
+        targetBranch: 'main',
+        github,
+      });
+      const latestRelease = {
+        tag: new TagName(Version.parse('0.123.4'), 'some-node-package'),
+        sha: 'abc123',
+        notes: 'some notes',
+      };
+      assert.rejects(async () => {
+        await strategy.buildReleasePullRequest(commits, latestRelease);
+      }, MissingRequiredFileError);
+    });
+    it('updates changelog.json if present', async () => {
+      const COMMITS = [
+        ...buildMockConventionalCommit(
+          'fix(deps): update dependency com.google.cloud:google-cloud-storage to v1.120.0'
+        ),
+        ...buildMockConventionalCommit('chore: update deps'),
+        ...buildMockConventionalCommit('chore!: update a very important dep'),
+        ...buildMockConventionalCommit(
+          'fix(deps): update dependency com.google.cloud:google-cloud-spanner to v1.50.0'
+        ),
+        ...buildMockConventionalCommit('chore: update common templates'),
+      ];
+      const strategy = new NodeLibrarian({
+        targetBranch: 'main',
+        github,
+        component: 'google-cloud-node',
+      });
+      const getFileContentsStub = sandbox.stub(
+        github,
+        'getFileContentsOnBranch'
+      );
+      getFileContentsStub
+        .withArgs('changelog.json', 'main')
+        .resolves(buildGitHubFileContent(fixturesPath, 'changelog.json'));
+      getFileContentsStub
+        .withArgs('package.json', 'main')
+        .resolves(buildGitHubFileContent(fixturesPath, 'package.json'));
+      sandbox.stub(github, 'findFilesByFilenameAndRef').resolves([]);
+      const latestRelease = undefined;
+      const release = await strategy.buildReleasePullRequest(
+        COMMITS,
+        latestRelease
+      );
+      const updates = release!.updates;
+      assertHasUpdate(updates, 'CHANGELOG.md', Changelog);
+      const update = assertHasUpdate(updates, 'changelog.json', ChangelogJson);
+      const newContent = update.updater.updateContent(
+        JSON.stringify({entries: []})
+      );
+      snapshot(
+        newContent
+          .replace(/\r\n/g, '\n') // make newline consistent regardless of OS.
+          .replace(UUID_REGEX, 'abc-123-efd-qwerty')
+          .replace(ISO_DATE_REGEX, '2023-01-05T16:42:33.446Z')
+      );
+    });
+  });
+  describe('buildUpdates', () => {
+    it('builds common files', async () => {
+      const strategy = new NodeLibrarian({
+        targetBranch: 'main',
+        github,
+        component: 'google-cloud-automl',
+        packageName: 'google-cloud-automl-pkg',
+      });
+      const findFilesStub = sandbox.stub(github, 'findFilesByFilenameAndRef');
+      findFilesStub
+        .withArgs('librarian.yaml', 'main', '.')
+        .resolves(['path1/librarian.yaml']);
+      findFilesStub.resolves([]);
+
+      const latestRelease = undefined;
+      const release = await strategy.buildReleasePullRequest(
+        commits,
+        latestRelease
+      );
+      const updates = release!.updates;
+      assertHasUpdate(updates, 'CHANGELOG.md', Changelog);
+      assertHasUpdate(updates, 'package-lock.json', PackageLockJson);
+      assertHasUpdate(updates, 'npm-shrinkwrap.json', PackageLockJson);
+      const update = assertHasUpdate(
+        updates,
+        'samples/package.json',
+        SamplesPackageJson
+      );
+      const updater = update.updater as SamplesPackageJson;
+      expect(updater.packageName).to.equal('google-cloud-automl-pkg');
+      assertHasUpdate(updates, 'package.json', PackageJson);
+      assertHasUpdate(updates, 'path1/librarian.yaml', LibrarianYamlUpdater);
+    });
+
+    it('omits changelog if skipChangelog=true', async () => {
+      const strategy = new NodeLibrarian({
+        targetBranch: 'main',
+        github,
+        component: 'google-cloud-automl',
+        packageName: 'google-cloud-automl-pkg',
+        skipChangelog: true,
+      });
+      sandbox.stub(github, 'findFilesByFilenameAndRef').resolves([]);
+      const latestRelease = undefined;
+      const release = await strategy.buildReleasePullRequest(
+        commits,
+        latestRelease
+      );
+      const updates = release!.updates;
+      assertNoHasUpdate(updates, 'CHANGELOG.md');
+      assertHasUpdate(updates, 'package-lock.json', PackageLockJson);
+      assertHasUpdate(updates, 'npm-shrinkwrap.json', PackageLockJson);
+      const update = assertHasUpdate(
+        updates,
+        'samples/package.json',
+        SamplesPackageJson
+      );
+      const updater = update.updater as SamplesPackageJson;
+      expect(updater.packageName).to.equal('google-cloud-automl-pkg');
+      assertHasUpdate(updates, 'package.json', PackageJson);
+    });
+  });
+});

--- a/test/updaters/java-librarian-yaml.ts
+++ b/test/updaters/java-librarian-yaml.ts
@@ -81,7 +81,7 @@ libraries:
       api_description_override: allows you to encrypt, store, manage, and audit infrastructure and application-level secrets.
 `;
 
-describe('LibrarianYamlUpdater', () => {
+describe('JavaLibrarianYamlUpdater', () => {
   it('updates librarian.yaml version based on versionsMap', () => {
     const versionsMap = new Map<string, Version>();
     versionsMap.set('google-shopping-css', Version.parse('0.59.0'));

--- a/test/updaters/node-librarian-yaml.ts
+++ b/test/updaters/node-librarian-yaml.ts
@@ -1,0 +1,105 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import {describe, it} from 'mocha';
+import {expect} from 'chai';
+import {LibrarianYamlUpdater} from '../../src/updaters/node/librarian-yaml';
+import {Version} from '../../src/version';
+
+const oldContent = `language: nodejs
+sources:
+  googleapis:
+    commit: cd090841ab172574e740c214c99df00aef9c0dee
+    sha256: 08e4b7744dc23b6e3320a3f1d05db9f40853aaf1089d06bfb8d79044b7a66f21
+default:
+  output: packages
+libraries:
+  - name: google-shopping-css
+    version: 0.11.1
+    apis:
+      - path: google/shopping/css/v1
+    copyright_year: "2026"
+  - name: google-cloud-secretmanager
+    version: 6.1.2
+    apis:
+      - path: google/cloud/secretmanager/v1
+      - path: google/cloud/secretmanager/v1beta2
+    copyright_year: "2026"
+    keep:
+      - .gitignore
+  - name: firestore
+    output: handwritten/firestore
+    version: 8.6.0
+`;
+
+const updatedContent = `language: nodejs
+sources:
+  googleapis:
+    commit: cd090841ab172574e740c214c99df00aef9c0dee
+    sha256: 08e4b7744dc23b6e3320a3f1d05db9f40853aaf1089d06bfb8d79044b7a66f21
+default:
+  output: packages
+libraries:
+  - name: google-shopping-css
+    version: 0.12.0
+    apis:
+      - path: google/shopping/css/v1
+    copyright_year: "2026"
+  - name: google-cloud-secretmanager
+    version: 6.1.2
+    apis:
+      - path: google/cloud/secretmanager/v1
+      - path: google/cloud/secretmanager/v1beta2
+    copyright_year: "2026"
+    keep:
+      - .gitignore
+  - name: firestore
+    output: handwritten/firestore
+    version: 8.7.0
+`;
+
+describe('NodeLibrarianYamlUpdater', () => {
+  it('updates librarian.yaml version based on versionsMap', () => {
+    const versionsMap = new Map<string, Version>();
+    versionsMap.set('packages/google-shopping-css', Version.parse('0.12.0'));
+    versionsMap.set('handwritten/firestore', Version.parse('8.7.0'));
+
+    const updater = new LibrarianYamlUpdater({
+      version: Version.parse('1.0.0'), // Unused
+      versionsMap,
+    });
+    const newContent = updater.updateContent(oldContent);
+    // Compare the content to verify librarian.yaml is not reformatted.
+    expect(newContent).to.eq(updatedContent);
+  });
+
+  it('returns original content if versionsMap is missing', () => {
+    const updater = new LibrarianYamlUpdater({
+      version: Version.parse('1.0.0'),
+    });
+    const newContent = updater.updateContent(oldContent);
+    expect(newContent).to.equal(oldContent);
+  });
+
+  it('returns original content if no libraries match versionsMap', () => {
+    const versionsMap = new Map<string, Version>();
+    versionsMap.set('non-existent', Version.parse('1.0.0'));
+    const updater = new LibrarianYamlUpdater({
+      version: Version.parse('1.0.0'),
+      versionsMap,
+    });
+    const newContent = updater.updateContent(oldContent);
+    expect(newContent).to.equal(oldContent);
+  });
+});

--- a/test/updaters/node-librarian-yaml.ts
+++ b/test/updaters/node-librarian-yaml.ts
@@ -43,7 +43,7 @@ libraries:
     version: 8.6.0
 `;
 
-const updatedContent = `language: nodejs
+const updatedShoppingContent = `language: nodejs
 sources:
   googleapis:
     commit: cd090841ab172574e740c214c99df00aef9c0dee
@@ -66,38 +66,60 @@ libraries:
       - .gitignore
   - name: firestore
     output: handwritten/firestore
+    version: 8.6.0
+`;
+
+const updatedFirestoreContent = `language: nodejs
+sources:
+  googleapis:
+    commit: cd090841ab172574e740c214c99df00aef9c0dee
+    sha256: 08e4b7744dc23b6e3320a3f1d05db9f40853aaf1089d06bfb8d79044b7a66f21
+default:
+  output: packages
+libraries:
+  - name: google-shopping-css
+    version: 0.11.1
+    apis:
+      - path: google/shopping/css/v1
+    copyright_year: "2026"
+  - name: google-cloud-secretmanager
+    version: 6.1.2
+    apis:
+      - path: google/cloud/secretmanager/v1
+      - path: google/cloud/secretmanager/v1beta2
+    copyright_year: "2026"
+    keep:
+      - .gitignore
+  - name: firestore
+    output: handwritten/firestore
     version: 8.7.0
 `;
 
 describe('NodeLibrarianYamlUpdater', () => {
-  it('updates librarian.yaml version based on versionsMap', () => {
-    const versionsMap = new Map<string, Version>();
-    versionsMap.set('packages/google-shopping-css', Version.parse('0.12.0'));
-    versionsMap.set('handwritten/firestore', Version.parse('8.7.0'));
-
+  it('updates librarian.yaml with implicit output directory', () => {
     const updater = new LibrarianYamlUpdater({
-      version: Version.parse('1.0.0'), // Unused
-      versionsMap,
+      version: Version.parse('0.12.0'),
+      packagePath: 'packages/google-shopping-css',
     });
     const newContent = updater.updateContent(oldContent);
     // Compare the content to verify librarian.yaml is not reformatted.
-    expect(newContent).to.eq(updatedContent);
+    expect(newContent).to.eq(updatedShoppingContent);
   });
 
-  it('returns original content if versionsMap is missing', () => {
+  it('updates librarian.yaml with explicit output directory', () => {
     const updater = new LibrarianYamlUpdater({
-      version: Version.parse('1.0.0'),
+      version: Version.parse('8.7.0'),
+      packagePath: 'handwritten/firestore',
     });
     const newContent = updater.updateContent(oldContent);
-    expect(newContent).to.equal(oldContent);
+    // Compare the content to verify librarian.yaml is not reformatted.
+    expect(newContent).to.eq(updatedFirestoreContent);
   });
 
-  it('returns original content if no libraries match versionsMap', () => {
-    const versionsMap = new Map<string, Version>();
-    versionsMap.set('non-existent', Version.parse('1.0.0'));
+  it('returns original content if no libraries match the path', () => {
     const updater = new LibrarianYamlUpdater({
       version: Version.parse('1.0.0'),
-      versionsMap,
+      packagePath: 'packages/non-existent',
     });
     const newContent = updater.updateContent(oldContent);
     expect(newContent).to.equal(oldContent);


### PR DESCRIPTION
This introduces a new Node strategy specifically for https://github.com/googleapis/google-cloud-node, with an updater which is aware of the expected Librarian format for Node.

Once Librarian has moved off release-please, the strategy and updater can be removed.

Towards https://github.com/googleapis/librarian/issues/5461