### PR TITLE
fix(manifest): apply per-package snapshot-label from config

### DIFF
--- a/src/manifest.ts
+++ b/src/manifest.ts
@@ -1422,6 +1422,7 @@ function extractReleaserConfig(
     labels: config['label']?.split(','),
     releaseLabels: config['release-label']?.split(','),
     extraLabels: config['extra-label']?.split(','),
+    snapshotLabels: config['snapshot-label']?.split(','),
     skipSnapshot: config['skip-snapshot'],
     initialVersion: config['initial-version'],
     excludePaths: config['exclude-paths'],
@@ -1790,6 +1791,7 @@ function mergeReleaserConfig(
     skipSnapshot: pathConfig.skipSnapshot ?? defaultConfig.skipSnapshot,
     initialVersion: pathConfig.initialVersion ?? defaultConfig.initialVersion,
     extraLabels: pathConfig.extraLabels ?? defaultConfig.extraLabels,
+    snapshotLabels: pathConfig.snapshotLabels ?? defaultConfig.snapshotLabels,
     excludePaths: pathConfig.excludePaths ?? defaultConfig.excludePaths,
     dateFormat: pathConfig.dateFormat ?? defaultConfig.dateFormat,
   };

--- a/test/fixtures/manifest/config/snapshot-labels.json
+++ b/test/fixtures/manifest/config/snapshot-labels.json
@@ -1,0 +1,13 @@
+{
+  "release-type": "java",
+  "snapshot-label": "global-snapshot",
+  "packages": {
+    ".": {
+      "component": "root"
+    },
+    "node-lib": {
+      "component": "node-lib",
+      "snapshot-label": "per-package-snapshot"
+    }
+  }
+}

--- a/test/manifest.ts
+++ b/test/manifest.ts
@@ -506,6 +506,38 @@ describe('Manifest', () => {
         'lang: nodejs',
       ]);
     });
+    it('should read snapshot labels from manifest', async () => {
+      const getFileContentsStub = sandbox.stub(
+        github,
+        'getFileContentsOnBranch'
+      );
+      getFileContentsStub
+        .withArgs('release-please-config.json', 'main')
+        .resolves(
+          buildGitHubFileContent(
+            fixturesPath,
+            'manifest/config/snapshot-labels.json'
+          )
+        )
+        .withArgs('.release-please-manifest.json', 'main')
+        .resolves(
+          buildGitHubFileContent(
+            fixturesPath,
+            'manifest/versions/versions.json'
+          )
+        );
+      const manifest = await Manifest.fromManifest(
+        github,
+        github.repository.defaultBranch
+      );
+      expect(manifest['snapshotLabels']).to.deep.equal(['global-snapshot']);
+      expect(manifest.repositoryConfig['.'].snapshotLabels).to.deep.equal([
+        'global-snapshot',
+      ]);
+      expect(
+        manifest.repositoryConfig['node-lib'].snapshotLabels
+      ).to.deep.equal(['per-package-snapshot']);
+    });
     it('should read exclude paths from manifest', async () => {
       const getFileContentsStub = sandbox.stub(
         github,


### PR DESCRIPTION
## Summary

`extractReleaserConfig` did not map per-package `snapshot-label`, and
`mergeReleaserConfig` did not propagate it from the root default into
per-package configs. As a result, Java/Maven snapshot PRs fell back to
`DEFAULT_SNAPSHOT_LABELS` (`['autorelease: snapshot']`) regardless of
configuration.

This PR adds the missing mappings and a regression test.

Fixes #2779.

## Reproduction (before this PR)

```json
{
  "release-type": "maven",
  "snapshot-label": "team-a",
  "packages": {
    ".": { "snapshot-label": "team-a,team-b" }
  }
}
```

Expected: snapshot PRs carry the configured labels.
Observed: snapshot PRs carry only `autorelease: snapshot`.

## Root cause

Two missing wirings in `src/manifest.ts`:

1. `extractReleaserConfig` maps `label`, `release-label`, `extra-label`
   but omitted `snapshot-label`.
2. `mergeReleaserConfig` propagated `extraLabels` from the default into
   per-package configs but not `snapshotLabels`, so root-level values
   never reached per-package strategies.

The schema (`schemas/config.json`) and the TypeScript interface already
accepted `snapshot-label` — only the runtime wiring was missing.

## Why moving config to root does not fix it on its own

Root-level `snapshot-label` flows through `parseConfig` into
`manifestOptions.snapshotLabels` and is assigned to
`Manifest.snapshotLabels`, but that field is only used (in
`manifest.ts`) as a matcher when scanning existing open PRs. It does
not flow back to the strategy that labels new snapshot PRs. Both fixes
are required.

## Changes

- `src/manifest.ts` — map `snapshot-label` in `extractReleaserConfig`;
  propagate `snapshotLabels` in `mergeReleaserConfig`.
- `test/fixtures/manifest/config/snapshot-labels.json` — new fixture
  mirroring `extra-labels.json`.
- `test/manifest.ts` — new test covering both the root-level matcher
  and the per-package merge/override.

## Compatibility

- No API or schema change. The TS type was already in place.
- Configs that did not declare `snapshot-label` are unaffected.
- Configs that declared it expecting the (buggy) no-op behavior now
  get the documented behavior.