### PR TITLE
fix: restrict BEGIN_COMMIT_OVERRIDE to PR authors with write access

### DIFF
--- a/src/commit.ts
+++ b/src/commit.ts
@@ -453,9 +453,25 @@ export function parseConventionalCommits(
   return conventionalCommits;
 }
 
+// Author associations whose BEGIN_COMMIT_OVERRIDE body section is honored.
+// Only roles that already have write access to the repository are trusted:
+// the PR body of a merged PR remains editable by its author indefinitely,
+// so honoring overrides from contributor/first-time-contributor/none would
+// let an external contributor rewrite their merged commit message (and the
+// resulting CHANGELOG / release notes) after review has completed.
+const TRUSTED_OVERRIDE_ASSOCIATIONS = new Set<string>([
+  'OWNER',
+  'MEMBER',
+  'COLLABORATOR',
+]);
+
 function preprocessCommitMessage(commit: Commit): string {
   // look for 'BEGIN_COMMIT_OVERRIDE' section of pull request body
   if (commit.pullRequest) {
+    const association = commit.pullRequest.authorAssociation;
+    if (!association || !TRUSTED_OVERRIDE_ASSOCIATIONS.has(association)) {
+      return commit.message;
+    }
     const overrideMessage = (
       commit.pullRequest.body.split('BEGIN_COMMIT_OVERRIDE')[1] || ''
     )

--- a/src/github.ts
+++ b/src/github.ts
@@ -112,6 +112,7 @@ interface GraphQLPullRequest {
       hasNextPage: boolean;
     };
   };
+  authorAssociation?: string;
 }
 
 interface CommitHistory {
@@ -265,6 +266,7 @@ export class GitHub implements Scm {
                         }
                       }
                       body
+                      authorAssociation
                       mergeCommit {
                         oid
                       }
@@ -382,6 +384,8 @@ export class GitHub implements Scm {
           body: pullRequest.body,
           labels: pullRequest.labels.nodes.map(node => node.name),
           files: (pullRequest.files?.nodes || []).map(node => node.path),
+          authorAssociation:
+            pullRequest.authorAssociation as PullRequest['authorAssociation'],
         };
       }
       if (mergePullRequest) {

--- a/src/pull-request.ts
+++ b/src/pull-request.ts
@@ -12,6 +12,16 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+export type PullRequestAuthorAssociation =
+  | 'OWNER'
+  | 'MEMBER'
+  | 'COLLABORATOR'
+  | 'CONTRIBUTOR'
+  | 'FIRST_TIME_CONTRIBUTOR'
+  | 'FIRST_TIMER'
+  | 'MANNEQUIN'
+  | 'NONE';
+
 export interface PullRequest {
   readonly headBranchName: string;
   readonly baseBranchName: string;
@@ -22,4 +32,5 @@ export interface PullRequest {
   readonly labels: string[];
   readonly files: string[];
   readonly sha?: string;
+  readonly authorAssociation?: PullRequestAuthorAssociation;
 }

--- a/test/commits.ts
+++ b/test/commits.ts
@@ -207,6 +207,7 @@ describe('parseConventionalCommits', () => {
       labels: [],
       files: [],
       body,
+      authorAssociation: 'MEMBER',
     };
 
     const conventionalCommits = parseConventionalCommits([commit]);
@@ -227,6 +228,7 @@ describe('parseConventionalCommits', () => {
       labels: [],
       files: [],
       body,
+      authorAssociation: 'OWNER',
     };
 
     const conventionalCommits = parseConventionalCommits([commit]);
@@ -235,6 +237,48 @@ describe('parseConventionalCommits', () => {
     expect(conventionalCommits[0].bareMessage).to.eql('some fix');
     expect(conventionalCommits[1].type).to.eql('feat');
     expect(conventionalCommits[1].bareMessage).to.eql('another feature');
+  });
+
+  it('ignores BEGIN_COMMIT_OVERRIDE from an untrusted PR author', async () => {
+    const commit = buildMockCommit('chore: some commit');
+    const body =
+      'BEGIN_COMMIT_OVERRIDE\nfix!: forged fix\n\nBREAKING CHANGE: forged\nEND_COMMIT_OVERRIDE';
+    commit.pullRequest = {
+      headBranchName: 'fix-something',
+      baseBranchName: 'main',
+      number: 123,
+      title: 'chore: some commit',
+      labels: [],
+      files: [],
+      body,
+      authorAssociation: 'CONTRIBUTOR',
+    };
+
+    const conventionalCommits = parseConventionalCommits([commit]);
+    expect(conventionalCommits).lengthOf(1);
+    expect(conventionalCommits[0].type).to.eql('chore');
+    expect(conventionalCommits[0].bareMessage).to.eql('some commit');
+    expect(conventionalCommits[0].breaking).to.be.false;
+    expect(conventionalCommits[0].notes).lengthOf(0);
+  });
+
+  it('ignores BEGIN_COMMIT_OVERRIDE when authorAssociation is missing', async () => {
+    const commit = buildMockCommit('chore: some commit');
+    const body = 'BEGIN_COMMIT_OVERRIDE\nfix: forged fix\nEND_COMMIT_OVERRIDE';
+    commit.pullRequest = {
+      headBranchName: 'fix-something',
+      baseBranchName: 'main',
+      number: 123,
+      title: 'chore: some commit',
+      labels: [],
+      files: [],
+      body,
+    };
+
+    const conventionalCommits = parseConventionalCommits([commit]);
+    expect(conventionalCommits).lengthOf(1);
+    expect(conventionalCommits[0].type).to.eql('chore');
+    expect(conventionalCommits[0].bareMessage).to.eql('some commit');
   });
 
   it('handles a special commit separator', async () => {

--- a/test/manifest.ts
+++ b/test/manifest.ts
@@ -3029,6 +3029,7 @@ describe('Manifest', () => {
             labels: [],
             files: [],
             sha: 'abc123',
+            authorAssociation: 'MEMBER',
           },
         },
         {


### PR DESCRIPTION
## Summary

`BEGIN_COMMIT_OVERRIDE` in a merged PR's body lets the body's text replace the merge commit message that drives release notes, version bumps, and CHANGELOG generation. The PR body is fetched live at release-please run time (`src/github.ts` GraphQL query on `pullRequest.body`), and GitHub keeps the PR body editable by its author indefinitely after merge. An external contributor whose otherwise innocuous PR has been merged can later rewrite their PR body to insert a forged commit message — for example, `BEGIN_COMMIT_OVERRIDE\nfeat!: x\n\nBREAKING CHANGE: <phishing markdown>\nEND_COMMIT_OVERRIDE` — and that text drives the next CHANGELOG entry, forces a major version bump, and ends up in the published GitHub Release notes without any maintainer review.

This PR gates the override on the PR's `authorAssociation` (already exposed by the GitHub GraphQL `PullRequest` type) and honors it only for `OWNER`, `MEMBER`, and `COLLABORATOR` — the roles that already have write access to the repository. PRs from `CONTRIBUTOR` / `FIRST_TIME_CONTRIBUTOR` / `NONE` fall back to the merge commit message, matching the pre-`BEGIN_COMMIT_OVERRIDE` behavior.

`#1161` added `BEGIN_COMMIT_OVERRIDE` for the maintainer "retroactively fix a release note" workflow; the README still describes it that way. The check here keeps the original maintainer workflow intact (maintainers are `OWNER`/`MEMBER`/`COLLABORATOR`) while closing the path that lets non-maintainer authors abuse it.

## Changes

- `src/pull-request.ts`: add `PullRequestAuthorAssociation` type and optional `authorAssociation` field on `PullRequest`.
- `src/github.ts`: request `authorAssociation` in the `mergeCommitsGraphQL` query and thread it onto `commit.pullRequest`.
- `src/commit.ts`: in `preprocessCommitMessage`, ignore `BEGIN_COMMIT_OVERRIDE` unless `authorAssociation` is `OWNER`, `MEMBER`, or `COLLABORATOR`.
- `test/commits.ts`: existing override tests now set `authorAssociation` to a trusted value; two new tests cover (a) `CONTRIBUTOR` override is ignored and (b) missing `authorAssociation` is treated as untrusted.
- `test/manifest.ts`: existing manifest-mode override fixture sets `authorAssociation: 'MEMBER'`.

## Test plan

- [x] `npm run lint` — no new warnings or errors.
- [x] `npm test` — 1101 passing, 0 failing.
- [x] New tests cover both the trust path (`MEMBER`/`OWNER` still honored) and the deny paths (`CONTRIBUTOR` and missing `authorAssociation` fall back to the commit message).