### PR TITLE
fix: implement dynamic batch size backoff for GraphQL requests

### DIFF
--- a/src/github-api.ts
+++ b/src/github-api.ts
@@ -273,6 +273,20 @@ export class GitHubApi {
           this.logger.info(
             `received 502 error, ${maxRetries} attempts remaining`
           );
+          if (typeof opts.num === 'number') {
+            if (maxRetries === 1) {
+              this.logger.info('last retry, forcing batch size to 1');
+              opts.num = 1;
+            } else {
+              const nextNum = Math.floor(opts.num / 2);
+              if (nextNum >= 1) {
+                this.logger.info(
+                  `halving batch size from ${opts.num} to ${nextNum}`
+                );
+                opts.num = nextNum;
+              }
+            }
+          }
         }
         maxRetries -= 1;
         if (maxRetries >= 0) {

--- a/src/github.ts
+++ b/src/github.ts
@@ -480,6 +480,20 @@ export class GitHub implements Scm {
           this.logger.info(
             `received 502 error, ${maxRetries} attempts remaining`
           );
+          if (typeof opts.num === 'number') {
+            if (maxRetries === 1) {
+              this.logger.info('last retry, forcing batch size to 1');
+              opts.num = 1;
+            } else {
+              const nextNum = Math.floor(opts.num / 2);
+              if (nextNum >= 1) {
+                this.logger.info(
+                  `halving batch size from ${opts.num} to ${nextNum}`
+                );
+                opts.num = nextNum;
+              }
+            }
+          }
         }
         maxRetries -= 1;
         if (maxRetries >= 0) {

--- a/test/github.ts
+++ b/test/github.ts
@@ -1215,4 +1215,54 @@ describe('GitHub', () => {
       req.done();
     });
   });
+
+  describe('graphqlRequest backoff', () => {
+    let clock: sinon.SinonFakeTimers;
+    let realSetInterval: typeof setInterval;
+    let realClearInterval: typeof clearInterval;
+    beforeEach(() => {
+      realSetInterval = global.setInterval;
+      realClearInterval = global.clearInterval;
+      clock = sandbox.useFakeTimers();
+    });
+
+    afterEach(() => {
+      clock.restore();
+    });
+
+    it('should halve the pagination size on 502 error retries, and force to 1 on the last attempt', async () => {
+      let attempt = 0;
+      req = nock('https://api.github.com')
+        .post('/graphql')
+        .times(6)
+        .reply((_uri, requestBody: any) => {
+          attempt++;
+          const body =
+            typeof requestBody === 'string'
+              ? JSON.parse(requestBody)
+              : requestBody;
+          if (attempt === 1) expect(body.variables.num).to.eql(100);
+          if (attempt === 2) expect(body.variables.num).to.eql(50);
+          if (attempt === 3) expect(body.variables.num).to.eql(25);
+          if (attempt === 4) expect(body.variables.num).to.eql(12);
+          if (attempt === 5) expect(body.variables.num).to.eql(6);
+          if (attempt === 6) expect(body.variables.num).to.eql(1);
+          return [502, 'Bad Gateway'];
+        });
+
+      const promise = github.commitsSince('main', () => false, {
+        batchSize: 100,
+      });
+
+      const tickInterval = realSetInterval(() => {
+        clock.tick(10000);
+      }, 10);
+
+      await assert.rejects(promise, (error: Error) => {
+        return error instanceof GitHubAPIError && error.status === 502;
+      });
+      realClearInterval(tickInterval);
+      req.done();
+    });
+  });
 });


### PR DESCRIPTION
When queries timeout on the GitHub backend we experience 502 errors. Automatically reduce pagination size when encountering 502 Bad Gateway GraphQL timeouts to ensure resilient history retrieval.
- Halve pagination size (`opts.num`) on each caught 502 error retry attempt.
- Force pagination size to exactly 1 on the final retry attempt to maximize successful recovery.
- Ensure pagination size never drops below 1 on earlier attempts.

Validated this change by running this against a repo I saw having this issue and verified the dynamic backoff eliminated the problem when processing troubling commits where code at HEAD fails:

```
release-please release-pr \
  --token=${GITHUB_ACCESS_TOKEN} \
  --repo-url=googleapis/google-cloud-node \
  --manifest-file=.release-please-manifest.json \
  --config-file=release-please-config.json \
  --debug --dry-run
```

Internal Bug: b/514772414
Fixes: #2592