### PR TITLE
fix(commit-parser): fall back to header-only parsing when body is unparseable

### DIFF
--- a/src/commit.ts
+++ b/src/commit.ts
@@ -421,31 +421,49 @@ export function parseConventionalCommits(
     for (const commitMessage of splitMessages(
       preprocessCommitMessage(commit)
     )) {
+      const pushParsedCommit = (
+        parsedCommit: parser.ConventionalChangelogCommit
+      ) => {
+        const breaking =
+          parsedCommit.notes.filter(note => note.title === 'BREAKING CHANGE')
+            .length > 0;
+        conventionalCommits.push({
+          sha: commit.sha,
+          message: parsedCommit.header,
+          files: commit.files,
+          pullRequest: commit.pullRequest,
+          type: parsedCommit.type,
+          scope: parsedCommit.scope,
+          bareMessage: parsedCommit.subject,
+          notes: parsedCommit.notes,
+          references: parsedCommit.references,
+          breaking,
+        });
+      };
       try {
         for (const parsedCommit of parseCommits(commitMessage)) {
-          const breaking =
-            parsedCommit.notes.filter(note => note.title === 'BREAKING CHANGE')
-              .length > 0;
-          conventionalCommits.push({
-            sha: commit.sha,
-            message: parsedCommit.header,
-            files: commit.files,
-            pullRequest: commit.pullRequest,
-            type: parsedCommit.type,
-            scope: parsedCommit.scope,
-            bareMessage: parsedCommit.subject,
-            notes: parsedCommit.notes,
-            references: parsedCommit.references,
-            breaking,
-          });
+          pushParsedCommit(parsedCommit);
         }
       } catch (_err) {
-        logger.debug(
-          `commit could not be parsed: ${commit.sha} ${
-            commit.message.split('\n')[0]
-          }`
-        );
-        logger.debug(`error message: ${_err}`);
+        // Full-message parsing failed. The @conventional-commits/parser
+        // grammar is strict about body content — e.g. an unbalanced `(` on
+        // a wrapped line will throw `unexpected token '\n' ... valid
+        // tokens [)]`. Fall back to parsing just the header so the commit
+        // still appears in the changelog. Footer-derived metadata
+        // (BREAKING CHANGE notes, issue references) is lost on this path.
+        const header = commitMessage.split('\n')[0];
+        try {
+          for (const parsedCommit of parseCommits(header)) {
+            pushParsedCommit(parsedCommit);
+          }
+          logger.warn(
+            `commit body could not be parsed, used header only: ${commit.sha} ${header}`
+          );
+          logger.debug(`error message: ${_err}`);
+        } catch (_headerErr) {
+          logger.debug(`commit could not be parsed: ${commit.sha} ${header}`);
+          logger.debug(`error message: ${_err}`);
+        }
       }
     }
   }

--- a/test/commits.ts
+++ b/test/commits.ts
@@ -237,6 +237,32 @@ describe('parseConventionalCommits', () => {
     expect(conventionalCommits[1].bareMessage).to.eql('another feature');
   });
 
+  it('falls back to header-only parsing when the body is unparseable', async () => {
+    // A body line that opens `(` without closing it on the same line trips
+    // the @conventional-commits/parser grammar with
+    // `unexpected token '\n' ... valid tokens [)]`. This commonly happens
+    // when a GitHub PR body wraps a function call across two lines.
+    // Without the fallback, the commit silently disappears from the
+    // changelog.
+    const message = [
+      'feat(parser): handle wrapped function calls',
+      '',
+      'Body wraps a call:',
+      'computeValue(longArgumentName',
+      '= true)',
+      'so the upstream parser throws on the unmatched paren.',
+    ].join('\n');
+    const commits = [buildMockCommit(message)];
+    const conventionalCommits = parseConventionalCommits(commits);
+    expect(conventionalCommits).lengthOf(1);
+    expect(conventionalCommits[0].type).to.equal('feat');
+    expect(conventionalCommits[0].scope).to.equal('parser');
+    expect(conventionalCommits[0].bareMessage).to.equal(
+      'handle wrapped function calls'
+    );
+    expect(conventionalCommits[0].breaking).to.be.false;
+  });
+
   it('handles a special commit separator', async () => {
     const commits = [buildCommitFromFixture('multiple-commits-with-separator')];
     const conventionalCommits = parseConventionalCommits(commits);


### PR DESCRIPTION
Fixes #2564 🦕

## Problem

`parseConventionalCommits` silently drops commits whose body trips the `@conventional-commits/parser` grammar. The grammar requires that any `(` on a body line have its matching `)` on the same line. GitHub's PR-body line-wrap routinely produces commits that violate this — e.g. a function call whose closing paren ends up on the next line:

```
Body wraps a call:
computeValue(longArgumentName
= true)
```

This throws `unexpected token '\n' at LINE:COL, valid tokens [)]` from inside the parser's `scope()` rule. The header itself parses fine; only the body is broken.

The existing `catch` in `parseConventionalCommits` (`src/commit.ts`) logs at debug level and skips the commit, so the entry never reaches the release PR's changelog. #2564 is the canonical bug report for this symptom.

## Root cause

Upstream in `@conventional-commits/parser`, `scope()` throws on a newline before `)` rather than returning a recoverable error. An open PR ([conventional-commits/parser#48](https://github.com/conventional-commits/parser/pull/48)) targets this exact case but has been stalled since March 2024; the parser has not had an npm release since January 2021. We can't realistically wait for an upstream fix.

## Fix

When full-message parsing throws, retry with just the first line of the commit message. If the header parses, push it as a `ConventionalCommit` and log a `warn` so users know the body was discarded. If the header also fails to parse, fall through to the existing debug log and skip the commit (unchanged behavior).

Preserved on the fallback path: `type`, `scope`, `bareMessage`, `breaking` (via `!` in the header), `references` from the header, `pullRequest`, `sha`, `files`.

Lost on the fallback path: body-derived `BREAKING CHANGE` notes, body-derived references, footer trailers. The user-visible improvement is "commit appears in the changelog" rather than "commit silently vanishes."

## Test

Added a `parseConventionalCommits` test with a body that wraps a function call across lines. Without the fix it returns `[]`; with the fix it returns one parsed commit with the correct type/scope/subject.

## Checklist

- [x] Tests and linter pass locally (`npm test`: 1101 passing, 0 failing; `npm run lint`: no new errors)
- [x] Code coverage does not decrease (added test exercises the new branch)
- [x] No doc changes required (behavior change is internal recovery path)
- [x] CLA signed — pending; will follow up
