### PR TITLE
fix: use `artifact_id` instead of `distribution_name_override` in librarian.yaml

### DIFF
--- a/src/updaters/java/librarian-yaml.ts
+++ b/src/updaters/java/librarian-yaml.ts
@@ -91,8 +91,8 @@ export class LibrarianYamlUpdater extends DefaultUpdater {
     if (artifact) {
       return artifact;
     }
-    if (library.java && library.java.distribution_name_override) {
-      return library.java.distribution_name_override.split(':')[1];
+    if (library.java && library.java.artifact_id) {
+      return library.java.artifact_id;
     }
     return `google-cloud-${library.name}`;
   }

--- a/src/updaters/java/librarian-yaml.ts
+++ b/src/updaters/java/librarian-yaml.ts
@@ -17,14 +17,14 @@ import * as yaml from 'yaml';
 import {logger as defaultLogger, Logger} from '../../util/logger';
 
 export interface JavaModule {
-  artifact_id?: string;
+  artifact_id: string;
   [key: string]: any;
 }
 
 export interface LibrarianLibrary {
   name: string;
   version: string;
-  java?: JavaModule;
+  java: JavaModule;
   [key: string]: any;
 }
 

--- a/src/updaters/java/librarian-yaml.ts
+++ b/src/updaters/java/librarian-yaml.ts
@@ -17,14 +17,14 @@ import * as yaml from 'yaml';
 import {logger as defaultLogger, Logger} from '../../util/logger';
 
 export interface JavaModule {
-  distribution_name_override: string;
+  artifact_id?: string;
   [key: string]: any;
 }
 
 export interface LibrarianLibrary {
   name: string;
   version: string;
-  java: JavaModule;
+  java?: JavaModule;
   [key: string]: any;
 }
 

--- a/test/updaters/java-librarian-yaml.ts
+++ b/test/updaters/java-librarian-yaml.ts
@@ -36,7 +36,8 @@ libraries:
     java:
       api_description_override: The CSS API is used to manage your CSS and control your CSS Products portfolio
       non_cloud_api: true
-      distribution_name_override: com.google.shopping:google-shopping-css
+      artifact_id: google-shopping-css
+      group_id: com.google.shopping
       name_pretty_override: CSS API
       java_apis:
         - additional_protos:
@@ -68,7 +69,8 @@ libraries:
     java:
       api_description_override: The CSS API is used to manage your CSS and control your CSS Products portfolio
       non_cloud_api: true
-      distribution_name_override: com.google.shopping:google-shopping-css
+      artifact_id: google-shopping-css
+      group_id: com.google.shopping
       name_pretty_override: CSS API
       java_apis:
         - additional_protos:


### PR DESCRIPTION
In this pull request:

- Update JavaModule interface to expect `artifact_id` instead of `distribution_name_override`.
- Make the `java` property optional in the `LibrarianLibrary` interface.
- Update tests to reflect the new schema structure.

Fixes https://github.com/googleapis/librarian/issues/6190
