### PR TITLE
fix: upgrade tmp to 0.2.6 to resolve path traversal vulnerability

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5282,9 +5282,9 @@
       "integrity": "sha512-w89qg7PI8wAdvX60bMDP+bFoD5Dvhm9oLheFp5O4a2QF0cSBGsBX4qZmadPMvVqlLJBBci+WqGGOAPvcDeNSVg=="
     },
     "node_modules/tmp": {
-      "version": "0.2.5",
-      "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.2.5.tgz",
-      "integrity": "sha512-voyz6MApa1rQGUxT3E+BK7/ROe8itEx7vD8/HEvt4xwXucvQ5G5oeEiHkmHZJuBO21RpOf+YYm9MOivj709jow==",
+      "version": "0.2.6",
+      "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.2.6.tgz",
+      "integrity": "sha512-5sJPdPjfI5Kx+qbrDesxkglRBxW//g7hCsqspEjwkewGvBMGIKMOTKzLt1hFVJzyadba3lDUN20O9qhvbQUSTA==",
       "dev": true,
       "license": "MIT",
       "engines": {

--- a/package.json
+++ b/package.json
@@ -102,7 +102,7 @@
     "node": ">=20.0.0"
   },
   "overrides": {
-    "tmp": "0.2.5",
+    "tmp": "0.2.6",
     "serialize-javascript": "^7.0.5"
   }
 }


### PR DESCRIPTION
Addresses GHSA-ph9p-34f9-6g65.

This PR upgrades the `tmp` dependency override from `0.2.5` to `0.2.6` to resolve a high-severity path traversal vulnerability.

