### PR TITLE
fix: disable git hooks only for git checkout

### DIFF
--- a/src/local-github.ts
+++ b/src/local-github.ts
@@ -124,7 +124,11 @@ export class LocalGitHub implements Scm {
       await execFile('git', fetchArgs, {cwd: repoDir});
 
       logger.debug(`Executing: git checkout ${branch}`);
-      await execFile('git', ['checkout', branch], {cwd: repoDir});
+      await execFile(
+        'git',
+        ['-c', 'core.hooksPath=/dev/null', 'checkout', branch],
+        {cwd: repoDir}
+      );
 
       logger.debug(`Executing: git reset --hard origin/${branch}`);
       await execFile('git', ['reset', '--hard', `origin/${branch}`], {


### PR DESCRIPTION
This PR disables git hooks specifically for the `git checkout` command by passing `-c core.hooksPath=/dev/null`.

### Rationale:
1. In the current upstream version of `release-please`, local `git commit` and `git push` have been removed in favor of the GitHub API (`code-suggester`), so we no longer need to protect those.
2. Among the remaining local git commands executed in `LocalGitHub` (like `ls-tree`, `show`, `log`, `rev-parse`), the only one that can trigger a hook is `git checkout` (which triggers the `post-checkout` hook).
3. Other commands do not trigger hooks, so applying the global option to all commands was unnecessary. This PR targets only the `git checkout` command to avoid running unintended `post-checkout` hooks.

TAG=agy
CONV=6ccca40c-ae16-4bff-a10b-e7f61521a5f1
