### PR TITLE
feat: add go-librarian release strategy

### DIFF
--- a/__snapshots__/cli.js
+++ b/__snapshots__/cli.js
@@ -49,11 +49,11 @@ Options:
                                                                         [string]
   --release-type                what type of repo is a release being created
                                 for?
-  [choices: "bazel", "dart", "dotnet-yoshi", "elixir", "expo", "go", "go-yoshi",
-          "helm", "java", "java-backport", "java-bom", "java-lts", "java-yoshi",
-     "java-yoshi-mono-repo", "krm-blueprint", "maven", "node", "node-librarian",
-       "ocaml", "php", "php-yoshi", "python", "r", "ruby", "ruby-yoshi", "rust",
-                             "salesforce", "sfdx", "simple", "terraform-module"]
+              [choices: "bazel", "dart", "dotnet-yoshi", "elixir", "expo", "go",
+        "go-librarian", "go-yoshi", "helm", "java", "java-backport", "java-bom",
+     "java-lts", "java-yoshi", "java-yoshi-mono-repo", "krm-blueprint", "maven",
+   "node", "node-librarian", "ocaml", "php", "php-yoshi", "python", "r", "ruby",
+       "ruby-yoshi", "rust", "salesforce", "sfdx", "simple", "terraform-module"]
   --config-file                 where can the config file be found in the
                                 project? [default: "release-please-config.json"]
   --manifest-file               where can the manifest file be found in the
@@ -276,11 +276,11 @@ Options:
                                                                         [string]
   --release-type                    what type of repo is a release being created
                                     for?
-  [choices: "bazel", "dart", "dotnet-yoshi", "elixir", "expo", "go", "go-yoshi",
-          "helm", "java", "java-backport", "java-bom", "java-lts", "java-yoshi",
-     "java-yoshi-mono-repo", "krm-blueprint", "maven", "node", "node-librarian",
-       "ocaml", "php", "php-yoshi", "python", "r", "ruby", "ruby-yoshi", "rust",
-                             "salesforce", "sfdx", "simple", "terraform-module"]
+              [choices: "bazel", "dart", "dotnet-yoshi", "elixir", "expo", "go",
+        "go-librarian", "go-yoshi", "helm", "java", "java-backport", "java-bom",
+     "java-lts", "java-yoshi", "java-yoshi-mono-repo", "krm-blueprint", "maven",
+   "node", "node-librarian", "ocaml", "php", "php-yoshi", "python", "r", "ruby",
+       "ruby-yoshi", "rust", "salesforce", "sfdx", "simple", "terraform-module"]
   --config-file                     where can the config file be found in the
                                     project?
                                          [default: "release-please-config.json"]

--- a/src/factory.ts
+++ b/src/factory.ts
@@ -25,6 +25,7 @@ import {Elixir} from './strategies/elixir';
 import {Expo} from './strategies/expo';
 import {Go} from './strategies/go';
 import {GoYoshi} from './strategies/go-yoshi';
+import {GoLibrarian} from './strategies/go-librarian';
 import {Helm} from './strategies/helm';
 import {Java} from './strategies/java';
 import {JavaYoshi} from './strategies/java-yoshi';
@@ -71,6 +72,7 @@ const releasers: Record<string, ReleaseBuilder> = {
   'dotnet-yoshi': options => new DotnetYoshi(options),
   go: options => new Go(options),
   'go-yoshi': options => new GoYoshi(options),
+  'go-librarian': options => new GoLibrarian(options),
   java: options => new Java(options),
   maven: options => new Maven(options),
   'java-yoshi': options => new JavaYoshi(options),

--- a/src/strategies/go-librarian.ts
+++ b/src/strategies/go-librarian.ts
@@ -1,0 +1,76 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import {BaseStrategy, BuildUpdatesOptions, BaseStrategyOptions} from './base';
+import {Update} from '../update';
+import {Changelog} from '../updaters/changelog';
+import {LibrarianYamlUpdater} from '../updaters/go/librarian-yaml';
+import {Version} from '../version';
+import {VersionGo} from '../updaters/go/version-go';
+
+export class GoLibrarian extends BaseStrategy {
+  readonly versionFile: string;
+  constructor(options: BaseStrategyOptions) {
+    options.changelogPath = options.changelogPath ?? 'CHANGELOG.md';
+    super(options);
+    this.versionFile = options.versionFile ?? 'internal/version.go';
+  }
+
+  protected async buildUpdates(
+    options: BuildUpdatesOptions
+  ): Promise<Update[]> {
+    const updates: Update[] = [];
+    const version = options.newVersion;
+
+    if (!this.skipChangelog) {
+      updates.push({
+        path: this.addPath(this.changelogPath),
+        createIfMissing: true,
+        updater: new Changelog({
+          version,
+          changelogEntry: options.changelogEntry,
+        }),
+      });
+    }
+
+    if (this.versionFile) {
+      updates.push({
+        path: this.addPath(this.versionFile),
+        createIfMissing: false,
+        updater: new VersionGo({
+          version,
+        }),
+      });
+    }
+
+    updates.push({
+      path: 'librarian.yaml',
+      createIfMissing: false,
+      updater: new LibrarianYamlUpdater({
+        version,
+        packagePath: this.path,
+        component: this.component,
+      }),
+    });
+
+    return updates;
+  }
+
+  protected initialReleaseVersion(): Version {
+    if (this.initialVersion) {
+      return Version.parse(this.initialVersion);
+    }
+    return Version.parse('1.0.0');
+  }
+}

--- a/src/strategies/go-librarian.ts
+++ b/src/strategies/go-librarian.ts
@@ -22,7 +22,7 @@ import {VersionGo} from '../updaters/go/version-go';
 export class GoLibrarian extends BaseStrategy {
   readonly versionFile: string;
   constructor(options: BaseStrategyOptions) {
-    options.changelogPath = options.changelogPath ?? 'CHANGELOG.md';
+    options.changelogPath = options.changelogPath ?? 'CHANGES.md';
     super(options);
     this.versionFile = options.versionFile ?? 'internal/version.go';
   }

--- a/src/updaters/go/librarian-yaml.ts
+++ b/src/updaters/go/librarian-yaml.ts
@@ -1,0 +1,87 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import {DefaultUpdater, UpdateOptions} from '../default';
+import * as yaml from 'yaml';
+import {logger as defaultLogger, Logger} from '../../util/logger';
+
+export interface LibrarianLibrary {
+  name: string;
+  version: string;
+  [key: string]: any;
+}
+
+export interface LibrarianUpdateOptions extends UpdateOptions {
+  packagePath: string;
+  component?: string;
+}
+
+/**
+ * Updates a librarian.yaml file for Go.
+ */
+export class LibrarianYamlUpdater extends DefaultUpdater {
+  private readonly packagePath: string;
+  private readonly component?: string;
+
+  constructor(options: LibrarianUpdateOptions) {
+    super(options);
+    this.packagePath = options.packagePath;
+    this.component = options.component;
+  }
+
+  /**
+   * Given initial file contents, return updated contents.
+   * @param {string} content The initial content
+   * @returns {string} The updated content
+   */
+  updateContent(content: string, _logger: Logger = defaultLogger): string {
+    // Use yaml package to make sure librarian.yaml is not reformatted because
+    // we use different tool to format librarian.yaml.
+    const doc = yaml.parseDocument(content);
+    if (!doc || doc.errors.length > 0) {
+      throw new Error(
+        `Invalid yaml, cannot be parsed: ${doc.errors
+          .map(e => e.message)
+          .join(', ')}`
+      );
+    }
+
+    const libraries = doc.get('libraries');
+    if (!libraries || !yaml.isSeq(libraries)) {
+      return content;
+    }
+
+    let modified = false;
+    for (const library of libraries.items) {
+      if (!yaml.isMap(library)) continue;
+
+      const libraryJSON = library.toJSON() as LibrarianLibrary;
+      if (
+        libraryJSON.name === this.packagePath ||
+        (this.component && libraryJSON.name === this.component)
+      ) {
+        const newVersion = this.version.toString();
+        if (library.get('version') !== newVersion) {
+          library.set('version', newVersion);
+          modified = true;
+        }
+      }
+    }
+
+    if (modified) {
+      return doc.toString({lineWidth: 0});
+    }
+    return content;
+  }
+}

--- a/test/strategies/go-librarian.ts
+++ b/test/strategies/go-librarian.ts
@@ -1,0 +1,217 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import {describe, it, afterEach, beforeEach} from 'mocha';
+import {expect} from 'chai';
+import {GitHub} from '../../src/github';
+import {GoLibrarian} from '../../src/strategies/go-librarian';
+import * as sinon from 'sinon';
+import {assertHasUpdate} from '../helpers';
+import {buildMockConventionalCommit} from '../helpers';
+import {Changelog} from '../../src/updaters/changelog';
+import {VersionGo} from '../../src/updaters/go/version-go';
+import {LibrarianYamlUpdater} from '../../src/updaters/go/librarian-yaml';
+import {Update} from '../../src/update';
+
+const sandbox = sinon.createSandbox();
+
+const COMMITS = [
+  ...buildMockConventionalCommit(
+    'fix(deps): update dependency com.google.cloud:google-cloud-storage to v1.120.0'
+  ),
+  ...buildMockConventionalCommit(
+    'fix(deps): update dependency com.google.cloud:google-cloud-spanner to v1.50.0'
+  ),
+  ...buildMockConventionalCommit('chore: update common templates'),
+];
+
+describe('GoLibrarian', () => {
+  let github: GitHub;
+  beforeEach(async () => {
+    github = await GitHub.create({
+      owner: 'googleapis',
+      repo: 'go-test-repo',
+      defaultBranch: 'main',
+    });
+  });
+  afterEach(() => {
+    sandbox.restore();
+  });
+  describe('buildReleasePullRequest', () => {
+    it('returns release PR changes with defaultInitialVersion', async () => {
+      const expectedVersion = '1.0.0';
+      const strategy = new GoLibrarian({
+        targetBranch: 'main',
+        github,
+        component: 'google-cloud-automl',
+      });
+      const latestRelease = undefined;
+      const release = await strategy.buildReleasePullRequest(
+        COMMITS,
+        latestRelease
+      );
+      expect(release!.version?.toString()).to.eql(expectedVersion);
+    });
+
+    it('returns custom initial release version if initialVersion option is specified', async () => {
+      const expectedVersion = '2.0.0';
+      const strategy = new GoLibrarian({
+        targetBranch: 'main',
+        github,
+        component: 'google-cloud-automl',
+        initialVersion: '2.0.0',
+      });
+      const latestRelease = undefined;
+      const release = await strategy.buildReleasePullRequest(
+        COMMITS,
+        latestRelease
+      );
+      expect(release!.version?.toString()).to.eql(expectedVersion);
+    });
+  });
+  describe('buildUpdates', () => {
+    it('builds common files including version file and librarian.yaml', async () => {
+      const strategy = new GoLibrarian({
+        targetBranch: 'main',
+        github,
+        component: 'google-cloud-automl',
+        versionFile: 'internal/version.go',
+      });
+      const latestRelease = undefined;
+      const release = await strategy.buildReleasePullRequest(
+        COMMITS,
+        latestRelease
+      );
+      const updates = release!.updates;
+      assertHasUpdate(updates, 'CHANGELOG.md', Changelog);
+      assertHasUpdate(updates, 'internal/version.go', VersionGo);
+      assertHasUpdate(updates, 'librarian.yaml', LibrarianYamlUpdater);
+    });
+
+    it('defaults version file to internal/version.go when not specified', async () => {
+      const strategy = new GoLibrarian({
+        targetBranch: 'main',
+        github,
+        component: 'google-cloud-automl',
+      });
+      const latestRelease = undefined;
+      const release = await strategy.buildReleasePullRequest(
+        COMMITS,
+        latestRelease
+      );
+      const updates = release!.updates;
+      assertHasUpdate(updates, 'CHANGELOG.md', Changelog);
+      assertHasUpdate(updates, 'internal/version.go', VersionGo);
+      assertHasUpdate(updates, 'librarian.yaml', LibrarianYamlUpdater);
+    });
+
+    it('supports custom versionFile paths', async () => {
+      const strategy = new GoLibrarian({
+        targetBranch: 'main',
+        github,
+        component: 'google-cloud-automl',
+        versionFile: 'custom-version.go',
+      });
+      const latestRelease = undefined;
+      const release = await strategy.buildReleasePullRequest(
+        COMMITS,
+        latestRelease
+      );
+      const updates = release!.updates;
+      assertHasUpdate(updates, 'CHANGELOG.md', Changelog);
+      assertHasUpdate(updates, 'custom-version.go', VersionGo);
+      assertHasUpdate(updates, 'librarian.yaml', LibrarianYamlUpdater);
+    });
+
+    it('supports custom changelogPath', async () => {
+      const strategy = new GoLibrarian({
+        targetBranch: 'main',
+        github,
+        component: 'google-cloud-automl',
+        changelogPath: 'CUSTOM_CHANGELOG.md',
+      });
+      const latestRelease = undefined;
+      const release = await strategy.buildReleasePullRequest(
+        COMMITS,
+        latestRelease
+      );
+      const updates = release!.updates;
+      assertHasUpdate(updates, 'CUSTOM_CHANGELOG.md', Changelog);
+      assertHasUpdate(updates, 'internal/version.go', VersionGo);
+      assertHasUpdate(updates, 'librarian.yaml', LibrarianYamlUpdater);
+    });
+
+    it('integration: LibrarianYamlUpdater successfully updates librarian.yaml when path is empty (root) by matching component name', async () => {
+      const strategy = new GoLibrarian({
+        targetBranch: 'main',
+        github,
+        component: 'google-cloud-automl',
+        path: '', // Root level strategy
+      });
+      const latestRelease = undefined;
+      const release = await strategy.buildReleasePullRequest(
+        COMMITS,
+        latestRelease
+      );
+      const updates = release!.updates;
+      const librarianUpdate = updates.find(
+        (u: Update) => u.path === 'librarian.yaml'
+      );
+      expect(librarianUpdate).to.not.be.undefined;
+
+      const originalYaml = `language: go
+libraries:
+  - name: google-cloud-automl
+    version: 1.19.0
+`;
+      const expectedYaml = `language: go
+libraries:
+  - name: google-cloud-automl
+    version: 1.0.0
+`;
+      const updatedYaml = librarianUpdate!.updater.updateContent(originalYaml);
+      expect(updatedYaml).to.equal(expectedYaml);
+    });
+  });
+
+  describe('postProcessCommits', () => {
+    it('does not filter out commits without a scope', async () => {
+      const customGithub = await GitHub.create({
+        owner: 'googleapis',
+        repo: 'google-cloud-go',
+        defaultBranch: 'main',
+      });
+      const strategy = new GoLibrarian({
+        targetBranch: 'main',
+        github: customGithub,
+        component: 'google-cloud-automl',
+      });
+
+      const commitsWithoutScope = [
+        ...buildMockConventionalCommit(
+          'fix: some root level bugfix without scope'
+        ),
+      ];
+
+      const processedCommits = await (strategy as any).postProcessCommits(
+        commitsWithoutScope
+      );
+      // Assert that the commit is preserved (unlike GoYoshi which filters it out)
+      expect(processedCommits.length).to.equal(1);
+      expect(processedCommits[0].message).to.equal(
+        'fix: some root level bugfix without scope'
+      );
+    });
+  });
+});

--- a/test/strategies/go-librarian.ts
+++ b/test/strategies/go-librarian.ts
@@ -94,7 +94,7 @@ describe('GoLibrarian', () => {
         latestRelease
       );
       const updates = release!.updates;
-      assertHasUpdate(updates, 'CHANGELOG.md', Changelog);
+      assertHasUpdate(updates, 'CHANGES.md', Changelog);
       assertHasUpdate(updates, 'internal/version.go', VersionGo);
       assertHasUpdate(updates, 'librarian.yaml', LibrarianYamlUpdater);
     });
@@ -111,7 +111,7 @@ describe('GoLibrarian', () => {
         latestRelease
       );
       const updates = release!.updates;
-      assertHasUpdate(updates, 'CHANGELOG.md', Changelog);
+      assertHasUpdate(updates, 'CHANGES.md', Changelog);
       assertHasUpdate(updates, 'internal/version.go', VersionGo);
       assertHasUpdate(updates, 'librarian.yaml', LibrarianYamlUpdater);
     });
@@ -129,7 +129,7 @@ describe('GoLibrarian', () => {
         latestRelease
       );
       const updates = release!.updates;
-      assertHasUpdate(updates, 'CHANGELOG.md', Changelog);
+      assertHasUpdate(updates, 'CHANGES.md', Changelog);
       assertHasUpdate(updates, 'custom-version.go', VersionGo);
       assertHasUpdate(updates, 'librarian.yaml', LibrarianYamlUpdater);
     });

--- a/test/updaters/go-librarian-yaml.ts
+++ b/test/updaters/go-librarian-yaml.ts
@@ -1,0 +1,126 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import {describe, it} from 'mocha';
+import {expect} from 'chai';
+import {LibrarianYamlUpdater} from '../../src/updaters/go/librarian-yaml';
+import {Version} from '../../src/version';
+
+const oldContent = `language: go
+libraries:
+  - name: accessapproval
+    version: 1.13.0
+    apis:
+      - path: google/cloud/accessapproval/v1
+  - name: accesscontextmanager
+    version: 1.14.0
+    apis:
+      - path: google/identity/accesscontextmanager/v1
+  - name: advisorynotifications
+    version: 1.10.0
+`;
+
+const updatedAccessApprovalContent = `language: go
+libraries:
+  - name: accessapproval
+    version: 1.14.0
+    apis:
+      - path: google/cloud/accessapproval/v1
+  - name: accesscontextmanager
+    version: 1.14.0
+    apis:
+      - path: google/identity/accesscontextmanager/v1
+  - name: advisorynotifications
+    version: 1.10.0
+`;
+
+describe('GoLibrarianYamlUpdater', () => {
+  it('updates librarian.yaml with matching library name', () => {
+    const updater = new LibrarianYamlUpdater({
+      version: Version.parse('1.14.0'),
+      packagePath: 'accessapproval',
+    });
+    const newContent = updater.updateContent(oldContent);
+    expect(newContent).to.eq(updatedAccessApprovalContent);
+  });
+
+  it('returns original content if no libraries match the path', () => {
+    const updater = new LibrarianYamlUpdater({
+      version: Version.parse('1.0.0'),
+      packagePath: 'non-existent',
+    });
+    const newContent = updater.updateContent(oldContent);
+    expect(newContent).to.equal(oldContent);
+  });
+
+  it('throws an error if the librarian.yaml is malformed (e.g., uses tabs for block indentation)', () => {
+    const updater = new LibrarianYamlUpdater({
+      version: Version.parse('1.0.0'),
+      packagePath: 'accessapproval',
+    });
+    // Block collections in YAML strictly forbid tab indentation and throw a parsing error
+    const malformedYaml = `language: go
+libraries:
+\t- name: accessapproval
+`;
+    expect(() => updater.updateContent(malformedYaml)).to.throw(
+      /cannot be parsed/
+    );
+  });
+
+  it('returns original content if the libraries key is missing', () => {
+    const updater = new LibrarianYamlUpdater({
+      version: Version.parse('1.0.0'),
+      packagePath: 'accessapproval',
+    });
+    const yamlWithoutLibraries = `language: go
+some-other-key: value
+`;
+    const newContent = updater.updateContent(yamlWithoutLibraries);
+    expect(newContent).to.equal(yamlWithoutLibraries);
+  });
+
+  it('returns original content if the libraries key is not a sequence', () => {
+    const updater = new LibrarianYamlUpdater({
+      version: Version.parse('1.0.0'),
+      packagePath: 'accessapproval',
+    });
+    const yamlWithNonSeqLibraries = `language: go
+libraries: not-a-sequence-string
+`;
+    const newContent = updater.updateContent(yamlWithNonSeqLibraries);
+    expect(newContent).to.equal(yamlWithNonSeqLibraries);
+  });
+
+  it('skips elements in libraries list that are not maps', () => {
+    const updater = new LibrarianYamlUpdater({
+      version: Version.parse('1.20.0'),
+      packagePath: 'accessapproval',
+    });
+    const inputYaml = `language: go
+libraries:
+  - "not-a-map-scalar"
+  - name: accessapproval
+    version: 1.19.0
+`;
+    const expectedYaml = `language: go
+libraries:
+  - "not-a-map-scalar"
+  - name: accessapproval
+    version: 1.20.0
+`;
+    const outputYaml = updater.updateContent(inputYaml);
+    expect(outputYaml).to.equal(expectedYaml);
+  });
+});


### PR DESCRIPTION
Introduces the `go-librarian` release strategy and the associated
`LibrarianYamlUpdater` to support automated releases for Go packages
defined in `librarian.yaml`.This new strategy will be used by google-cloud-go in the future. 

This was tested using
https://github.com/codyoss/google-cloud-go/tree/rp-migration-test. I made a commit to secretmanager and then ran these local changes to create the following PR: https://github.com/codyoss/google-cloud-go/pull/8

Internal Bug: b/518756701