### PR TITLE
fix(go): support semver dot-separated prerelease suffixes in version-go regex

### DIFF
--- a/__snapshots__/version-go.js
+++ b/__snapshots__/version-go.js
@@ -1,4 +1,4 @@
-exports['version.go updateContent updates version in version.go 1'] = `
+exports['basic-update'] = `
 // Copyright 2021 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
@@ -16,4 +16,18 @@ exports['version.go updateContent updates version in version.go 1'] = `
 package api
 
 const Version = "0.59.0"
+`
+
+exports['double-digit-patch'] = `
+package api
+
+const Version = "0.58.12-rc02"
+
+`
+
+exports['prerelease-dots-dashes'] = `
+package api
+
+const Version = "0.58.0-rc.2"
+
 `

--- a/src/updaters/go/version-go.ts
+++ b/src/updaters/go/version-go.ts
@@ -17,7 +17,7 @@ import {DefaultUpdater} from '../default';
 export class VersionGo extends DefaultUpdater {
   updateContent(content: string): string {
     return content.replace(
-      /const Version = "[0-9]+\.[0-9]+\.[0-9]+(-[0-9A-Za-z-.]+)?"/,
+      /const Version = "[0-9]+\.[0-9]+\.[0-9]+(-[0-9A-Za-z-]+(\.[0-9A-Za-z-]+)*)?"/,
       `const Version = "${this.version.toString()}"`
     );
   }

--- a/src/updaters/go/version-go.ts
+++ b/src/updaters/go/version-go.ts
@@ -17,7 +17,7 @@ import {DefaultUpdater} from '../default';
 export class VersionGo extends DefaultUpdater {
   updateContent(content: string): string {
     return content.replace(
-      /const Version = "[0-9]+\.[0-9]+\.[0-9]+(-[0-9A-Za-z-.]+)??"/,
+      /const Version = "[0-9]+\.[0-9]+\.[0-9]+(-[0-9A-Za-z-.]+)?"/,
       `const Version = "${this.version.toString()}"`
     );
   }

--- a/src/updaters/go/version-go.ts
+++ b/src/updaters/go/version-go.ts
@@ -17,7 +17,7 @@ import {DefaultUpdater} from '../default';
 export class VersionGo extends DefaultUpdater {
   updateContent(content: string): string {
     return content.replace(
-      /const Version = "[0-9]+\.[0-9]+\.[0-9](-\w+)?"/,
+      /const Version = "[0-9]+\.[0-9]+\.[0-9]+(-[0-9A-Za-z-.]+)??"/,
       `const Version = "${this.version.toString()}"`
     );
   }

--- a/test/updaters/version-go.ts
+++ b/test/updaters/version-go.ts
@@ -32,7 +32,25 @@ describe('version.go', () => {
         version: Version.parse('0.59.0'),
       });
       const newContent = version.updateContent(oldContent);
-      snapshot(newContent);
+      snapshot('basic-update', newContent);
+    });
+
+    it('updates prerelease version with dots and dashes in version.go', async () => {
+      const oldContent = 'package api\n\nconst Version = "0.58.0-rc.1"\n';
+      const version = new VersionGo({
+        version: Version.parse('0.58.0-rc.2'),
+      });
+      const newContent = version.updateContent(oldContent);
+      snapshot('prerelease-dots-dashes', newContent);
+    });
+
+    it('updates double digit patch versions in version.go', async () => {
+      const oldContent = 'package api\n\nconst Version = "0.58.12-rc01"\n';
+      const version = new VersionGo({
+        version: Version.parse('0.58.12-rc02'),
+      });
+      const newContent = version.updateContent(oldContent);
+      snapshot('double-digit-patch', newContent);
     });
   });
 });

--- a/test/updaters/version-go.ts
+++ b/test/updaters/version-go.ts
@@ -52,5 +52,16 @@ describe('version.go', () => {
       const newContent = version.updateContent(oldContent);
       snapshot('double-digit-patch', newContent);
     });
+
+    it('does not update versions with consecutive dots in prerelease in version.go', async () => {
+      const oldContent = 'package api\n\nconst Version = "0.58.0-rc..1"\n';
+      const version = new VersionGo({
+        version: Version.parse('0.58.0-rc.2'),
+      });
+      const newContent = version.updateContent(oldContent);
+      if (newContent !== oldContent) {
+        throw new Error(`Content was modified: ${newContent}`);
+      }
+    });
   });
 });


### PR DESCRIPTION
If the version value in `internal/verison.go` had a SemVer prerelease suffix with dot separated segments (https://semver.org/#spec-item-9) e.g. `1.2.3-rc.1`, the version updater wouldn't match the string and wouldn't update it with the new version.

Discovered this while testing release-please for previews (https://github.com/googleapis/librarian/issues/6115#issuecomment-4597146301), where we expect to use dot-separated prerelease segments.