### PR TITLE
chore: remove blunderbuss config

### DIFF
--- a/.github/blunderbuss.yml
+++ b/.github/blunderbuss.yml
@@ -1,4 +1,0 @@
-assign_issues:
-  - chingor13
-assign_prs:
-  - chingor13


### PR DESCRIPTION
The `cloud-sdk-platform-team` is helping support `release-please` now, and we are auto assigned as reviewers on PRs, so we no longer need to assign Jeff on every PR and issue. Issues should not be autoassigned either.