### PR TITLE
feat: upgrade project to Node 22

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node: [20]
+        node: [22]
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v3
@@ -29,7 +29,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node: [20]
+        node: [22]
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v3
@@ -46,7 +46,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v3
         with:
-          node-version: 20
+          node-version: 22
       - run: npm ci
       - run: npm test
         env:
@@ -57,7 +57,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v3
         with:
-          node-version: 20
+          node-version: 22
       - run: npm ci
       - run: npm run lint
   docs:
@@ -66,7 +66,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v3
         with:
-          node-version: 20
+          node-version: 22
       - run: npm ci
       - run: npm run docs
       - uses: JustinBeckwith/linkinator-action@v1
@@ -81,6 +81,6 @@ jobs:
           ref: main
       - uses: actions/setup-node@v3
         with:
-          node-version: 20
+          node-version: 22
       - run: npm install --save googleapis/release-please#${{ github.ref }}
       - run: npm run build

--- a/package-lock.json
+++ b/package-lock.json
@@ -54,7 +54,7 @@
         "@types/js-yaml": "^4.0.0",
         "@types/jsonpath": "^0.2.0",
         "@types/mocha": "^10.0.0",
-        "@types/node": "^18.0.0",
+        "@types/node": "^22.0.0",
         "@types/npmlog": "^7.0.0",
         "@types/semver": "^7.0.0",
         "@types/sinon": "^17.0.0",
@@ -74,7 +74,7 @@
         "snap-shot-it": "^7.9.10"
       },
       "engines": {
-        "node": ">=20.0.0"
+        "node": ">=22.0.0"
       }
     },
     "node_modules/@babel/code-frame": {
@@ -975,10 +975,14 @@
       "dev": true
     },
     "node_modules/@types/node": {
-      "version": "18.11.18",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.11.18.tgz",
-      "integrity": "sha512-DHQpWGjyQKSHj3ebjFI/wRKcqQcdR+MoFBygntYOZytCqNfkd2ZC4ARDJ2DQqhjH5p85Nnd3jhUJIXrszFX/JA==",
-      "dev": true
+      "version": "22.19.21",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.19.21.tgz",
+      "integrity": "sha512-VMeFBSCKQKmm2swI2kW51SFusDqekC6q9trBCvJ/JliDchFSuoYYKN7yVNjPthP1HKZcx3U1gI/wTcEBjEFKTA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~6.21.0"
+      }
     },
     "node_modules/@types/normalize-package-data": {
       "version": "2.4.1",
@@ -5361,6 +5365,13 @@
       "engines": {
         "node": ">=0.8.0"
       }
+    },
+    "node_modules/undici-types": {
+      "version": "6.21.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
+      "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/unist-util-is": {
       "version": "4.1.0",

--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
     "@types/js-yaml": "^4.0.0",
     "@types/jsonpath": "^0.2.0",
     "@types/mocha": "^10.0.0",
-    "@types/node": "^18.0.0",
+    "@types/node": "^22.0.0",
     "@types/npmlog": "^7.0.0",
     "@types/semver": "^7.0.0",
     "@types/sinon": "^17.0.0",
@@ -100,7 +100,7 @@
     "yargs": "^17.0.0"
   },
   "engines": {
-    "node": ">=20.0.0"
+    "node": ">=22.0.0"
   },
   "overrides": {
     "tmp": "0.2.6",


### PR DESCRIPTION
- Bump engines.node to >=22.0.0 in package.json
- Bump @types/node to ^22.0.0 and update package-lock.json
- Update CI workflows to test against Node 22