### PR TITLE
fix: allow prerelease-type at root of manifest config schema

### DIFF
--- a/schemas/config.json
+++ b/schemas/config.json
@@ -471,6 +471,7 @@
     "release-type": true,
     "bump-minor-pre-major": true,
     "bump-patch-for-minor-pre-major": true,
+    "prerelease-type": true,
     "versioning": true,
     "changelog-sections": true,
     "release-as": true,


### PR DESCRIPTION
Adds the missing `prerelease-type` key to the root `properties` allow-list in `schemas/config.json`.

Fixes #2814 🦕