### PR TITLE
fix(yoshi-java-monorepo): do not update released_version for java beta snapshot

### DIFF
--- a/src/updaters/librarian-yaml.ts
+++ b/src/updaters/librarian-yaml.ts
@@ -141,7 +141,8 @@ export class LibrarianYamlUpdater extends DefaultUpdater {
             modified = true;
           }
           if (this.versionsMap) {
-            const isSnapshot = newVersion.preRelease === 'SNAPSHOT';
+            // Multi-version (Java style): updates released_version for non-SNAPSHOTs
+            const isSnapshot = !!newVersion.preRelease?.includes('SNAPSHOT');
             if (!isSnapshot) {
               const javaNode = this.getOrCreateSubsection(library, 'java', doc);
               if (

--- a/test/updaters/librarian-yaml.ts
+++ b/test/updaters/librarian-yaml.ts
@@ -461,7 +461,10 @@ libraries:
       released_version: 0.214.0-beta
 `;
       const versionsMap = new Map<string, Version>();
-      versionsMap.set('google-cloud-errorreporting', Version.parse('0.215.0-beta-SNAPSHOT'));
+      versionsMap.set(
+        'google-cloud-errorreporting',
+        Version.parse('0.215.0-beta-SNAPSHOT')
+      );
 
       const updater = new LibrarianYamlUpdater({
         version: Version.parse('1.0.0'), // Unused
@@ -470,7 +473,6 @@ libraries:
       const newContent = updater.updateContent(content);
       expect(newContent).to.eq(expected);
     });
-
 
     it('adds released_version if it is missing and new version is not SNAPSHOT', () => {
       const oldContentMissing = `language: java

--- a/test/updaters/librarian-yaml.ts
+++ b/test/updaters/librarian-yaml.ts
@@ -445,6 +445,33 @@ libraries:
       expect(newContent).to.eq(snapshotUpdatedContent);
     });
 
+    it('does not update released_version for beta-SNAPSHOT versions', () => {
+      const content = `language: java
+libraries:
+  - name: errorreporting
+    version: 0.214.0-beta
+    java:
+      released_version: 0.214.0-beta
+`;
+      const expected = `language: java
+libraries:
+  - name: errorreporting
+    version: 0.215.0-beta-SNAPSHOT
+    java:
+      released_version: 0.214.0-beta
+`;
+      const versionsMap = new Map<string, Version>();
+      versionsMap.set('google-cloud-errorreporting', Version.parse('0.215.0-beta-SNAPSHOT'));
+
+      const updater = new LibrarianYamlUpdater({
+        version: Version.parse('1.0.0'), // Unused
+        versionsMap,
+      });
+      const newContent = updater.updateContent(content);
+      expect(newContent).to.eq(expected);
+    });
+
+
     it('adds released_version if it is missing and new version is not SNAPSHOT', () => {
       const oldContentMissing = `language: java
 libraries:


### PR DESCRIPTION
In LibrarianYamlUpdater, when checking if a version is a snapshot, a strict equality match (preRelease === 'SNAPSHOT') was used. For Java libraries with preview or beta tags (such as '0.215.0-beta-SNAPSHOT' for `errorreporting`), the parsed preRelease field is 'beta-SNAPSHOT', which caused the updater to falsely identify it as a non-snapshot release and incorrectly update the 'released_version' field in librarian.yaml.

This is fixed by checking if the preRelease string contains 'SNAPSHOT'. Also added a test case reproducing this scenario using the 'errorreporting' library.

Fixes https://github.com/googleapis/librarian/issues/6422