### PR TITLE
fix(go-librarian): support Go v2 subdirectory releases without branch collisions

### DIFF
--- a/src/manifest.ts
+++ b/src/manifest.ts
@@ -323,7 +323,7 @@ export class Manifest {
   private snapshotLabels: string[];
   readonly plugins: ManifestPlugin[];
   private _strategiesByPath?: Record<string, Strategy>;
-  private _pathsByComponent?: Record<string, string>;
+  private _pathsByComponent?: Record<string, string[]>;
   private manifestPath: string;
   private bootstrapSha?: string;
   private lastReleaseSha?: string;
@@ -559,30 +559,34 @@ export class Manifest {
         continue;
       }
       const component = tagName.component || DEFAULT_COMPONENT_NAME;
-      const path = pathsByComponent[component];
-      if (!path) {
+      const paths = pathsByComponent[component] || [];
+      if (paths.length === 0) {
         this.logger.warn(
           `Found release tag with component '${component}', but not configured in manifest`
         );
         continue;
       }
-      const expectedVersion = this.releasedVersions[path];
-      if (!expectedVersion) {
-        this.logger.warn(
-          `Unable to find expected version for path '${path}' in manifest`
-        );
-        continue;
-      }
-      if (expectedVersion.toString() === tagName.version.toString()) {
-        this.logger.debug(`Found release for path ${path}, ${release.tagName}`);
-        releaseShasByPath[path] = release.sha;
-        releasesByPath[path] = {
-          name: release.name,
-          tag: tagName,
-          sha: release.sha,
-          notes: release.notes || '',
-        };
-        releasesFound += 1;
+      for (const path of paths) {
+        const expectedVersion = this.releasedVersions[path];
+        if (!expectedVersion) {
+          this.logger.warn(
+            `Unable to find expected version for path '${path}' in manifest`
+          );
+          continue;
+        }
+        if (expectedVersion.toString() === tagName.version.toString()) {
+          this.logger.debug(
+            `Found release for path ${path}, ${release.tagName}`
+          );
+          releaseShasByPath[path] = release.sha;
+          releasesByPath[path] = {
+            name: release.name,
+            tag: tagName,
+            sha: release.sha,
+            notes: release.notes || '',
+          };
+          releasesFound += 1;
+        }
       }
 
       if (releasesFound >= expectedReleases) {
@@ -1359,19 +1363,17 @@ export class Manifest {
     return this._strategiesByPath;
   }
 
-  private async getPathsByComponent(): Promise<Record<string, string>> {
+  private async getPathsByComponent(): Promise<Record<string, string[]>> {
     if (!this._pathsByComponent) {
       this._pathsByComponent = {};
       const strategiesByPath = await this.getStrategiesByPath();
       for (const path in this.repositoryConfig) {
         const strategy = strategiesByPath[path];
         const component = (await strategy.getComponent()) || '';
-        if (this._pathsByComponent[component]) {
-          this.logger.warn(
-            `Multiple paths for ${component}: ${this._pathsByComponent[component]}, ${path}`
-          );
+        if (!this._pathsByComponent[component]) {
+          this._pathsByComponent[component] = [];
         }
-        this._pathsByComponent[component] = path;
+        this._pathsByComponent[component].push(path);
       }
     }
     return this._pathsByComponent;

--- a/src/strategies/base.ts
+++ b/src/strategies/base.ts
@@ -632,6 +632,18 @@ export abstract class BaseStrategy implements Strategy {
       this.logger.error(`Bad branch name: ${mergedPullRequest.headBranchName}`);
       return;
     }
+    const branchComponent = await this.getBranchComponent();
+    if (branchName.isComponent()) {
+      if (
+        this.normalizeComponent(branchName.component) !==
+        this.normalizeComponent(branchComponent)
+      ) {
+        this.logger.info(
+          `PR branch component: ${branchName.component} does not match configured branch component: ${branchComponent}`
+        );
+        return;
+      }
+    }
     const pullRequestBody = await this.parsePullRequestBody(
       mergedPullRequest.body
     );

--- a/src/strategies/go-librarian.ts
+++ b/src/strategies/go-librarian.ts
@@ -27,6 +27,22 @@ export class GoLibrarian extends BaseStrategy {
     this.versionFile = options.versionFile ?? 'internal/version.go';
   }
 
+  async getComponent(): Promise<string | undefined> {
+    const component = await super.getComponent();
+    if (component) {
+      const match = component.match(/^(.*)\/v[2-9]\d*$/);
+      if (match) {
+        return match[1];
+      }
+    }
+    return component;
+  }
+
+  async getBranchComponent(): Promise<string | undefined> {
+    const component = await super.getBranchComponent();
+    return component ? component.replace(/\//g, '-') : undefined;
+  }
+
   protected async buildUpdates(
     options: BuildUpdatesOptions
   ): Promise<Update[]> {

--- a/src/util/branch-name.ts
+++ b/src/util/branch-name.ts
@@ -103,6 +103,9 @@ export class BranchName {
   toString(): string {
     return '';
   }
+  isComponent(): boolean {
+    return false;
+  }
 }
 
 /**
@@ -183,6 +186,9 @@ class V12ComponentBranchName extends BranchName {
   toString(): string {
     return `${RELEASE_PLEASE}/branches/${this.targetBranch}/components/${this.component}`;
   }
+  isComponent(): boolean {
+    return true;
+  }
 }
 
 const DEFAULT_PATTERN = `^${RELEASE_PLEASE}--branches--(?<branch>.+)$`;
@@ -217,6 +223,9 @@ class ComponentBranchName extends BranchName {
   }
   toString(): string {
     return `${RELEASE_PLEASE}--branches--${this.targetBranch}--components--${this.component}`;
+  }
+  isComponent(): boolean {
+    return true;
   }
 }
 

--- a/test/manifest.ts
+++ b/test/manifest.ts
@@ -2019,6 +2019,111 @@ describe('Manifest', () => {
       snapshot(dateSafe(pullRequests[1].body.toString()));
     });
 
+    describe('Go v2 subdirectories (GoLibrarian)', () => {
+      it('should handle Go v2 subdirectories sharing the tag component name without collisions', async () => {
+        mockReleases(sandbox, github, [
+          {
+            id: 111,
+            sha: 'sha-v1',
+            tagName: 'pubsub/v1.0.0',
+            url: 'https://github.com/fake-owner/fake-repo/releases/tag/pubsub/v1.0.0',
+          },
+          {
+            id: 222,
+            sha: 'sha-v2',
+            tagName: 'pubsub/v2.0.0',
+            url: 'https://github.com/fake-owner/fake-repo/releases/tag/pubsub/v2.0.0',
+          },
+        ]);
+        mockCommits(sandbox, github, [
+          {
+            sha: 'commit-v1-fix',
+            message: 'fix: a bugfix in v1',
+            files: ['pubsub/file.go'],
+          },
+          {
+            sha: 'sha-v1',
+            message: 'chore: release pubsub v1.0.0',
+            files: [],
+            pullRequest: {
+              headBranchName:
+                'release-please--branches--main--components--pubsub',
+              baseBranchName: 'main',
+              number: 111,
+              title: 'chore: release pubsub v1.0.0',
+              body: '',
+              labels: [],
+              files: [],
+              sha: 'sha-v1',
+            },
+          },
+          {
+            sha: 'commit-v2-fix',
+            message: 'feat: a new feature in v2',
+            files: ['pubsub/v2/file.go'],
+          },
+          {
+            sha: 'sha-v2',
+            message: 'chore: release pubsub v2.0.0',
+            files: [],
+            pullRequest: {
+              headBranchName:
+                'release-please--branches--main--components--pubsub-v2',
+              baseBranchName: 'main',
+              number: 222,
+              title: 'chore: release pubsub v2.0.0',
+              body: '',
+              labels: [],
+              files: [],
+              sha: 'sha-v2',
+            },
+          },
+        ]);
+
+        const manifest = new Manifest(
+          github,
+          'main',
+          {
+            pubsub: {
+              releaseType: 'go-librarian',
+              component: 'pubsub',
+              tagSeparator: '/',
+              excludePaths: ['pubsub/v2'],
+            },
+            'pubsub/v2': {
+              releaseType: 'go-librarian',
+              component: 'pubsub/v2',
+              tagSeparator: '/',
+            },
+          },
+          {
+            pubsub: Version.parse('1.0.0'),
+            'pubsub/v2': Version.parse('2.0.0'),
+          },
+          {
+            separatePullRequests: true,
+          }
+        );
+
+        const pullRequests = await manifest.buildPullRequests();
+        expect(pullRequests).lengthOf(2);
+
+        // Find the PR for pubsub v1
+        const prV1 = pullRequests.find(pr =>
+          pr.headRefName.endsWith('--pubsub')
+        );
+        expect(prV1).to.not.be.undefined;
+        expect(prV1!.version?.toString()).to.eql('1.0.1');
+
+        // Find the PR for pubsub v2
+        const prV2 = pullRequests.find(pr =>
+          pr.headRefName.endsWith('--pubsub-v2')
+        );
+        expect(prV2).to.not.be.undefined;
+        expect(prV2!.version?.toString()).to.eql('2.1.0');
+      });
+    });
+
     it('should allow forcing release-as on a single component', async () => {
       mockReleases(sandbox, github, [
         {

--- a/test/strategies/base.ts
+++ b/test/strategies/base.ts
@@ -13,12 +13,14 @@
 // limitations under the License.
 
 import {describe, it, afterEach, beforeEach} from 'mocha';
+import '../../src/manifest';
 import * as sinon from 'sinon';
 import {expect} from 'chai';
 import {BaseStrategy} from '../../src/strategies/base';
 import {Update} from '../../src/update';
 import {GitHub} from '../../src/github';
 import {PullRequestBody} from '../../src/util/pull-request-body';
+import {Version} from '../../src/version';
 import snapshot = require('snap-shot-it');
 import {
   dateSafe,
@@ -513,6 +515,35 @@ describe('Strategy', () => {
       });
       expect(release, 'Release').to.not.be.undefined;
       expect(release!.name).to.eql('v1.2.3');
+    });
+    it('skips release if branch component does not match strategy branch component', async () => {
+      class TestStrategyWithBranchComponent extends TestStrategy {
+        async getBranchComponent() {
+          return 'pubsub-v2';
+        }
+      }
+      const strategy = new TestStrategyWithBranchComponent({
+        targetBranch: 'main',
+        github,
+        component: 'pubsub',
+      });
+      const release = await strategy.buildRelease({
+        title: 'chore(main): release pubsub v2.0.0',
+        headBranchName: 'release-please--branches--main--components--pubsub',
+        baseBranchName: 'main',
+        number: 1234,
+        body: new PullRequestBody([
+          {
+            component: 'pubsub',
+            version: Version.parse('2.0.0'),
+            notes: 'some notes',
+          },
+        ]).toString(),
+        labels: [],
+        files: [],
+        sha: 'abc123',
+      });
+      expect(release).to.be.undefined;
     });
   });
 });

--- a/test/strategies/go-librarian.ts
+++ b/test/strategies/go-librarian.ts
@@ -214,4 +214,38 @@ libraries:
       );
     });
   });
+
+  describe('getComponent and getBranchComponent for v2+ subdirectories', () => {
+    it('returns parent directory for getComponent but full sanitized path for getBranchComponent', async () => {
+      const strategy = new GoLibrarian({
+        targetBranch: 'main',
+        github,
+        component: 'pubsub/v2',
+      });
+      expect(await strategy.getComponent()).to.equal('pubsub');
+      expect(await strategy.getBranchComponent()).to.equal('pubsub-v2');
+    });
+
+    it('does not modify component if it does not end with major version suffix', async () => {
+      const strategy = new GoLibrarian({
+        targetBranch: 'main',
+        github,
+        component: 'pubsub/foo',
+      });
+      expect(await strategy.getComponent()).to.equal('pubsub/foo');
+      expect(await strategy.getBranchComponent()).to.equal('pubsub-foo');
+    });
+
+    it('handles deep v2 paths correctly', async () => {
+      const strategy = new GoLibrarian({
+        targetBranch: 'main',
+        github,
+        component: 'cloud/google/pubsub/v3',
+      });
+      expect(await strategy.getComponent()).to.equal('cloud/google/pubsub');
+      expect(await strategy.getBranchComponent()).to.equal(
+        'cloud-google-pubsub-v3'
+      );
+    });
+  });
 });

--- a/test/util/branch-name.ts
+++ b/test/util/branch-name.ts
@@ -150,4 +150,47 @@ describe('BranchName', () => {
       );
     });
   });
+
+  describe('isComponent', () => {
+    it('returns false for default branch name', () => {
+      const branchName = BranchName.parse('release-please--branches--main');
+      expect(branchName?.isComponent()).to.be.false;
+    });
+
+    it('returns true for component branch name', () => {
+      const branchName = BranchName.parse(
+        'release-please--branches--main--components--storage'
+      );
+      expect(branchName?.isComponent()).to.be.true;
+    });
+
+    it('returns false for group branch name', () => {
+      const branchName = BranchName.parse(
+        'release-please--branches--main--groups--my-group'
+      );
+      expect(branchName?.isComponent()).to.be.false;
+    });
+
+    it('returns false for autorelease branch name', () => {
+      const branchName = BranchName.parse('release-v1.2.3');
+      expect(branchName?.isComponent()).to.be.false;
+    });
+
+    it('returns false for autorelease with component branch name', () => {
+      const branchName = BranchName.parse('release-storage-v1.2.3');
+      expect(branchName?.isComponent()).to.be.false;
+    });
+
+    it('returns false for v12 default branch name', () => {
+      const branchName = BranchName.parse('release-please/branches/main');
+      expect(branchName?.isComponent()).to.be.false;
+    });
+
+    it('returns true for v12 component branch name', () => {
+      const branchName = BranchName.parse(
+        'release-please/branches/main/components/storage'
+      );
+      expect(branchName?.isComponent()).to.be.true;
+    });
+  });
 });


### PR DESCRIPTION
Automatically handles Go v2+ subdirectory modules (e.g. `pubsub/v2`) by stripping the `/v2` suffix for tag names (generating `pubsub/v2.X.X` tags) but preserving a sanitized version of it for branch names (`pubsub-v2`) to avoid Git collisions.

Also updates Manifest lookup mappings to support multiple paths sharing a tag component name, and adds strict validation during release generation to prevent wrong cross-component releases.

Example config and setup:
- Config: https://github.com/codyoss/google-cloud-go/blob/rp-patch/release-please-individual-config.json
- Example PR1(pubsub): https://github.com/codyoss/google-cloud-go/pull/11
- Example PR2(pubsub/v2): https://github.com/codyoss/google-cloud-go/pull/10 

Fixes: #2817