### PR TITLE
fix(go-librarian): use path-based matching over component-based matching in librarian.yaml updates

### DIFF
--- a/src/updaters/librarian-yaml.ts
+++ b/src/updaters/librarian-yaml.ts
@@ -112,8 +112,12 @@ export class LibrarianYamlUpdater extends DefaultUpdater {
           newVersion = this.version;
         } else {
           const isGoMatch =
-            (this.packagePath && libraryJSON.name === this.packagePath) ||
-            (this.component && libraryJSON.name === this.component);
+            (this.packagePath &&
+              this.packagePath !== '.' &&
+              libraryJSON.name === this.packagePath) ||
+            ((!this.packagePath || this.packagePath === '.') &&
+              this.component &&
+              libraryJSON.name === this.component);
 
           const isPythonNodeMatch =
             this.packagePath &&


### PR DESCRIPTION
The go-librarian strategy was incorrectly using an OR condition to match libraries in librarian.yaml files, allowing both packagePath and component fields to trigger updates independently. This caused the same library entry to be matched and updated multiple times when both fields were set to different values.

The fix in `src/updaters/librarian-yaml.ts` changes the matching logic to prioritize path-based matching. When packagePath is provided (and not the root path '.'), it matches libraries by packagePath only. Component-based matching is now used as a fallback only when packagePath is not provided or is the root path. This ensures each library is matched exactly once per update cycle.

Fixes #2826
