### PR TITLE
test: increase timeout for LocalGitHub tests

### DIFF
--- a/test/local-github.ts
+++ b/test/local-github.ts
@@ -16,7 +16,8 @@ import {expect} from 'chai';
 import {describe, it, before} from 'mocha';
 import {LocalGitHub} from '../src/local-github';
 
-describe('LocalGitHub', () => {
+describe('LocalGitHub', function () {
+  this.timeout(60000);
   let localGitHub: LocalGitHub;
 
   before(async () => {


### PR DESCRIPTION
The `LocalGitHub` tests clone the repository in a `before` hook. On slow runners (like Windows CI), this operation can easily exceed the default 5-second timeout, causing the build to fail. Increase the timeout to 60 seconds to prevent these flakes.