### PR TITLE
chore(renovate): pin github action version updates

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,6 +1,6 @@
 {
   "extends": [
-    "config:base",
+    "config:best-practices",
     "docker:disable",
     ":disableDependencyDashboard"
   ],


### PR DESCRIPTION
This PR replaces config:base with config:best-practices in the Renovate configuration to enable security best practices, including pinning GitHub Actions to digests.