### PR TITLE
fix(src/updaters): add google-cloud-pom-parent to specialArtifacts in librarian-yaml

### DIFF
--- a/src/updaters/librarian-yaml.ts
+++ b/src/updaters/librarian-yaml.ts
@@ -55,6 +55,7 @@ export class LibrarianYamlUpdater extends DefaultUpdater {
 
   private readonly specialArtifacts: ReadonlyMap<string, string> = new Map([
     ['google-cloud-java', 'google-cloud-java'],
+    ['google-cloud-pom-parent', 'google-cloud-pom-parent'],
   ]);
 
   constructor(options: LibrarianUpdateOptions) {

--- a/test/updaters/librarian-yaml.ts
+++ b/test/updaters/librarian-yaml.ts
@@ -558,6 +558,32 @@ libraries:
       const newContent = updater.updateContent(oldContentMissingJava);
       expect(newContent).to.eq(expectedContent);
     });
+
+    it('updates specialArtifacts like google-cloud-pom-parent without adding prefix', () => {
+      const content = `language: java
+libraries:
+  - name: google-cloud-pom-parent
+    version: 0.1.0
+    skip_generate: true
+`;
+      const expected = `language: java
+libraries:
+  - name: google-cloud-pom-parent
+    version: 0.2.0
+    skip_generate: true
+    java:
+      released_version: 0.2.0
+`;
+      const versionsMap = new Map<string, Version>();
+      versionsMap.set('google-cloud-pom-parent', Version.parse('0.2.0'));
+
+      const updater = new LibrarianYamlUpdater({
+        version: Version.parse('1.0.0'), // Unused
+        versionsMap,
+      });
+      const newContent = updater.updateContent(content);
+      expect(newContent).to.eq(expected);
+    });
   });
 
   describe('Preview Version Match Logic', () => {


### PR DESCRIPTION
Ensure `google-cloud-pom-parent` is recognized as a special artifact by the librarian-yaml updater so its artifact ID defaults to `google-cloud-pom-parent` without a `google-cloud-` prefix.

Fixes https://github.com/googleapis/librarian/issues/6683