### PR TITLE
fix(github-api): restore proxy-server support with undici dispatcher

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -35,6 +35,7 @@
         "semver": "^7.5.3",
         "type-fest": "^3.0.0",
         "typescript": "^4.6.4",
+        "undici": "^7.28.0",
         "unist-util-visit": "^2.0.3",
         "unist-util-visit-parents": "^3.1.1",
         "xpath": "^0.0.34",
@@ -5296,6 +5297,15 @@
       },
       "engines": {
         "node": ">=0.8.0"
+      }
+    },
+    "node_modules/undici": {
+      "version": "7.28.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-7.28.0.tgz",
+      "integrity": "sha512-cRZYrTDwWznlnRiPjggAGxZXanty6M8RV1ff8Wm4LWXBp7/IG8v5DnOm74DtUBp9OONpK75YlPnIjQqX0dBDtA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.18.1"
       }
     },
     "node_modules/undici-types": {

--- a/package.json
+++ b/package.json
@@ -93,6 +93,7 @@
     "semver": "^7.5.3",
     "type-fest": "^3.0.0",
     "typescript": "^4.6.4",
+    "undici": "^7.28.0",
     "unist-util-visit": "^2.0.3",
     "unist-util-visit-parents": "^3.1.1",
     "xpath": "^0.0.34",

--- a/src/github-api.ts
+++ b/src/github-api.ts
@@ -34,8 +34,7 @@ import {
 import {logger as defaultLogger} from './util/logger';
 
 import {graphql} from '@octokit/graphql';
-import {HttpsProxyAgent} from 'https-proxy-agent';
-import {HttpProxyAgent} from 'http-proxy-agent';
+import {ProxyAgent} from 'undici';
 
 export const GH_API_URL = 'https://api.github.com';
 export const GH_GRAPHQL_URL = 'https://api.github.com';
@@ -167,30 +166,32 @@ export class GitHubApi {
     this.logger = options.logger ?? defaultLogger;
   }
 
-  static createDefaultAgent(baseUrl: string, defaultProxy?: ProxyOption) {
+  static createProxyFetch(defaultProxy?: ProxyOption) {
     if (!defaultProxy) {
       return undefined;
     }
 
     const {host, port} = defaultProxy;
-    if (new URL(baseUrl).protocol.replace(':', '') === 'http') {
-      return new HttpProxyAgent(`http://${host}:${port}`);
-    } else {
-      return new HttpsProxyAgent(`https://${host}:${port}`);
-    }
+    const dispatcher = new ProxyAgent(`http://${host}:${port}`);
+
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    return (url: string, opts?: any) => {
+      return fetch(url, {...opts, dispatcher});
+    };
   }
 
   static async create(options: GitHubCreateOptions): Promise<GitHubApi> {
     const apiUrl = options.apiUrl ?? GH_API_URL;
     const graphqlUrl = options.graphqlUrl ?? GH_GRAPHQL_URL;
     const releasePleaseVersion = require('../../package.json').version;
+    const proxyFetch = this.createProxyFetch(options.proxy);
+    const fetchToUse = options.fetch ?? proxyFetch;
     const apis = options.octokitAPIs ?? {
       octokit: new Octokit({
         baseUrl: apiUrl,
         auth: options.token,
         request: {
-          agent: this.createDefaultAgent(apiUrl, options.proxy),
-          fetch: options.fetch,
+          fetch: fetchToUse,
         },
       }),
       request: request.defaults({
@@ -199,13 +200,12 @@ export class GitHubApi {
           'user-agent': `release-please/${releasePleaseVersion}`,
           Authorization: `token ${options.token}`,
         },
-        fetch: options.fetch,
+        fetch: fetchToUse,
       }),
       graphql: graphql.defaults({
         baseUrl: graphqlUrl,
         request: {
-          agent: this.createDefaultAgent(graphqlUrl, options.proxy),
-          fetch: options.fetch,
+          fetch: fetchToUse,
         },
         headers: {
           'user-agent': `release-please/${releasePleaseVersion}`,

--- a/test/github.ts
+++ b/test/github.ts
@@ -24,7 +24,7 @@ import * as sinon from 'sinon';
 import * as codeSuggester from '../src/util/code-suggester';
 
 import {GitHub, GitHubRelease} from '../src/github';
-import {GitHubApi, GH_API_URL} from '../src/github-api';
+import {GitHubApi} from '../src/github-api';
 import {PullRequest} from '../src/pull-request';
 import {TagName} from '../src/util/tag-name';
 import {Version} from '../src/version';
@@ -38,8 +38,6 @@ import {fail} from 'assert';
 import {PullRequestBody} from '../src/util/pull-request-body';
 import {PullRequestTitle} from '../src/util/pull-request-title';
 import {ReleasePleaseManifest} from '../src/updaters/release-please-manifest';
-import {HttpsProxyAgent} from 'https-proxy-agent';
-import {HttpProxyAgent} from 'http-proxy-agent';
 import {Commit} from '../src/commit';
 import {mockReleaseData, MockPullRequestOverflowHandler} from './helpers';
 const fetch = require('node-fetch');
@@ -101,35 +99,16 @@ describe('GitHub', () => {
       expect(github.repository.defaultBranch).to.eql('some-branch-from-api');
     });
 
-    it('default agent is undefined when no proxy option passed ', () => {
-      expect(GitHubApi.createDefaultAgent('test_url')).eq(undefined);
+    it('proxy fetch is undefined when no proxy option passed', () => {
+      expect(GitHubApi.createProxyFetch()).eq(undefined);
     });
 
-    it('should return a https agent', () => {
-      expect(
-        GitHubApi.createDefaultAgent(GH_API_URL, {
-          host: 'http://proxy.com',
-          port: 3000,
-        })
-      ).instanceof(HttpsProxyAgent);
-    });
-
-    it('should throw error when baseUrl is an invalid url', () => {
-      expect(() => {
-        GitHubApi.createDefaultAgent('invalid_url', {
-          host: 'http://proxy.com',
-          port: 3000,
-        });
-      }).to.throw('Invalid URL');
-    });
-
-    it('should return a http agent', () => {
-      expect(
-        GitHubApi.createDefaultAgent('http://www.github.com', {
-          host: 'http://proxy.com',
-          port: 3000,
-        })
-      ).instanceof(HttpProxyAgent);
+    it('should return a proxy fetch function', () => {
+      const proxyFetch = GitHubApi.createProxyFetch({
+        host: 'proxy.com',
+        port: 3000,
+      });
+      expect(proxyFetch).to.be.a('function');
     });
   });
 


### PR DESCRIPTION
The `proxy-server` input was silently ignored because `@octokit/request` v8 dropped support for `request.agent` in favor of native fetch with dispatchers. The proxy configuration was being passed as `request.agent` to Octokit and GraphQL clients, but this parameter is filtered out before reaching the fetch call.

This change replaces the `createDefaultAgent` method with `createProxyFetch` that creates a custom fetch function using undici's `ProxyAgent` as a dispatcher. The proxy agent is now properly passed through the fetch options, which is compatible with `@octokit/request` v8's architecture. The fix adds undici as a dependency and updates tests to validate the new proxy fetch implementation.

Users who relied on the `NODE_USE_ENV_PROXY` + `HTTPS_PROXY` workaround will continue to work as expected, and the documented `proxy-server` input now functions correctly.

Fixes #2838
