### PR TITLE
fix: make workspace plugins release correctly with separate-pull-requests

### DIFF
--- a/src/factories/plugin-factory.ts
+++ b/src/factories/plugin-factory.ts
@@ -39,6 +39,7 @@ export interface PluginFactoryOptions {
   repositoryConfig: RepositoryConfig;
   manifestPath: string;
   separatePullRequests?: boolean;
+  labels?: string[];
 
   // node options
   alwaysLinkLocal?: boolean;

--- a/src/manifest.ts
+++ b/src/manifest.ts
@@ -414,6 +414,7 @@ export class Manifest {
         repositoryConfig: this.repositoryConfig,
         manifestPath: this.manifestPath,
         separatePullRequests: this.separatePullRequests,
+        labels: this.labels,
       })
     );
     this.pullRequestOverflowHandler = new FilePullRequestOverflowHandler(

--- a/src/plugins/cargo-workspace.ts
+++ b/src/plugins/cargo-workspace.ts
@@ -267,9 +267,15 @@ export class CargoWorkspace extends WorkspacePlugin<CrateInfo> {
     const strategy = this.strategiesByPath[updatedPackage.path];
     const latestRelease = this.releasesByPath[updatedPackage.path];
     const basePullRequest = strategy
-      ? await strategy.buildReleasePullRequest([], latestRelease, false, [], {
-          newVersion: version,
-        })
+      ? await strategy.buildReleasePullRequest(
+          [],
+          latestRelease,
+          false,
+          this.labels,
+          {
+            newVersion: version,
+          }
+        )
       : undefined;
 
     if (basePullRequest) {
@@ -314,7 +320,7 @@ export class CargoWorkspace extends WorkspacePlugin<CrateInfo> {
           }),
         },
       ],
-      labels: [],
+      labels: this.labels,
       headRefName: BranchName.ofTargetBranch(this.targetBranch).toString(),
       version,
       draft: false,

--- a/src/plugins/maven-workspace.ts
+++ b/src/plugins/maven-workspace.ts
@@ -437,7 +437,7 @@ export class MavenWorkspace extends WorkspacePlugin<MavenArtifact> {
           }),
         },
       ],
-      labels: [],
+      labels: this.labels,
       headRefName: BranchName.ofTargetBranch(this.targetBranch).toString(),
       version,
       draft: false,

--- a/src/plugins/node-workspace.ts
+++ b/src/plugins/node-workspace.ts
@@ -275,9 +275,15 @@ export class NodeWorkspace extends WorkspacePlugin<Package> {
     const latestRelease = this.releasesByPath[updatedPackage.path];
 
     const basePullRequest = strategy
-      ? await strategy.buildReleasePullRequest([], latestRelease, false, [], {
-          newVersion,
-        })
+      ? await strategy.buildReleasePullRequest(
+          [],
+          latestRelease,
+          false,
+          this.labels,
+          {
+            newVersion,
+          }
+        )
       : undefined;
 
     if (basePullRequest) {
@@ -339,7 +345,7 @@ export class NodeWorkspace extends WorkspacePlugin<Package> {
           }),
         },
       ],
-      labels: [],
+      labels: this.labels,
       headRefName: BranchName.ofTargetBranch(this.targetBranch).toString(),
       version: newVersion,
       draft: false,

--- a/src/plugins/workspace.ts
+++ b/src/plugins/workspace.ts
@@ -36,6 +36,7 @@ export interface WorkspacePluginOptions {
   updateAllPackages?: boolean;
   merge?: boolean;
   logger?: Logger;
+  labels?: string[];
 }
 
 export interface AllPackages<T> {
@@ -58,6 +59,7 @@ export abstract class WorkspacePlugin<T> extends ManifestPlugin {
   private updateAllPackages: boolean;
   private manifestPath: string;
   private merge: boolean;
+  protected labels: string[];
   constructor(
     github: Scm,
     targetBranch: string,
@@ -68,6 +70,7 @@ export abstract class WorkspacePlugin<T> extends ManifestPlugin {
     this.manifestPath = options.manifestPath ?? DEFAULT_RELEASE_PLEASE_MANIFEST;
     this.updateAllPackages = options.updateAllPackages ?? false;
     this.merge = options.merge ?? true;
+    this.labels = options.labels ?? [];
   }
   async run(
     candidates: CandidateReleasePullRequest[]
@@ -176,15 +179,41 @@ export abstract class WorkspacePlugin<T> extends ManifestPlugin {
       newCandidates = await mergePlugin.run(newCandidates);
     }
 
-    const newUpdates = newCandidates[0].pullRequest.updates;
-    newUpdates.push({
-      path: this.manifestPath,
-      createIfMissing: false,
-      updater: new ReleasePleaseManifest({
-        version: newCandidates[0].pullRequest.version!,
-        versionsMap: updatedPathVersions,
-      }),
-    });
+    if (this.merge) {
+      // All in-scope candidates have been merged into a single pull request,
+      // so a single update covering every bumped path is attached to it.
+      const newUpdates = newCandidates[0].pullRequest.updates;
+      newUpdates.push({
+        path: this.manifestPath,
+        createIfMissing: false,
+        updater: new ReleasePleaseManifest({
+          version: newCandidates[0].pullRequest.version!,
+          versionsMap: updatedPathVersions,
+        }),
+      });
+    } else {
+      // Candidates are kept as separate pull requests (e.g. with
+      // `separate-pull-requests: true`), so each pull request must carry the
+      // manifest entry for its own path — attaching every entry to the first
+      // candidate would strand the other versions when pull requests are
+      // merged independently. Candidates built from real releases already
+      // received their manifest entry from the manifest pull request builder;
+      // only forced version bumps (dependency-only updates) are in
+      // updatedPathVersions and handled here.
+      for (const candidate of newCandidates) {
+        const version = updatedPathVersions.get(candidate.path);
+        if (version) {
+          candidate.pullRequest.updates.push({
+            path: this.manifestPath,
+            createIfMissing: false,
+            updater: new ReleasePleaseManifest({
+              version: candidate.pullRequest.version!,
+              versionsMap: new Map([[candidate.path, version]]),
+            }),
+          });
+        }
+      }
+    }
 
     this.logger.info(
       `Post-processing ${newCandidates.length} in-scope candidates`

--- a/test/plugins/compatibility/separate-pull-requests-workspace.ts
+++ b/test/plugins/compatibility/separate-pull-requests-workspace.ts
@@ -23,12 +23,14 @@ import {
   mockCommits,
   safeSnapshot,
   stubFilesFromFixtures,
+  assertHasUpdate,
   assertHasUpdates,
 } from '../../helpers';
 import {Version} from '../../../src/version';
 import {PackageJson} from '../../../src/updaters/node/package-json';
 import {expect} from 'chai';
 import {Changelog} from '../../../src/updaters/changelog';
+import {ReleasePleaseManifest} from '../../../src/updaters/release-please-manifest';
 
 const sandbox = sinon.createSandbox();
 const fixturesPath = './test/fixtures/plugins/node-workspace';
@@ -171,6 +173,21 @@ describe('Plugin compatibility', () => {
         ) as Update
       ).updater as Changelog;
       expect(updaterA.version.toString()).to.eql('1.0.1');
+      // the pull request must carry the pending-release label, otherwise
+      // it is invisible to the tagging phase after being merged
+      expect(pullRequest1.labels).to.eql(['autorelease: pending']);
+      // the pull request must update its own manifest entry, otherwise the
+      // manifest falls out of sync when it is merged independently
+      const manifestUpdaterA = (
+        assertHasUpdate(
+          pullRequest1.updates,
+          '.release-please-manifest.json',
+          ReleasePleaseManifest
+        ) as Update
+      ).updater as ReleasePleaseManifest;
+      expect(
+        manifestUpdaterA.versionsMap?.get('packages/node1')?.toString()
+      ).to.eql('1.0.1');
 
       const pullRequest2 = pullRequests[1];
       safeSnapshot(pullRequest2.body.toString());
@@ -182,6 +199,17 @@ describe('Plugin compatibility', () => {
         ) as Update
       ).updater as Changelog;
       expect(updaterB.version.toString()).to.eql('1.0.1');
+      expect(pullRequest2.labels).to.eql(['autorelease: pending']);
+      const manifestUpdaterB = (
+        assertHasUpdate(
+          pullRequest2.updates,
+          '.release-please-manifest.json',
+          ReleasePleaseManifest
+        ) as Update
+      ).updater as ReleasePleaseManifest;
+      expect(
+        manifestUpdaterB.versionsMap?.get('packages/node2')?.toString()
+      ).to.eql('1.0.1');
 
       const pullRequest3 = pullRequests[2];
       safeSnapshot(pullRequest3.body.toString());
@@ -193,6 +221,12 @@ describe('Plugin compatibility', () => {
         ) as Update
       ).updater as Changelog;
       expect(updaterC.version.toString()).to.eql('1.1.0');
+      expect(pullRequest3.labels).to.eql(['autorelease: pending']);
+      assertHasUpdate(
+        pullRequest3.updates,
+        '.release-please-manifest.json',
+        ReleasePleaseManifest
+      );
     });
   });
 });


### PR DESCRIPTION
Thank you for opening a Pull Request! Before submitting your PR, there are a few things you can do to make sure it goes smoothly:
- [x] Make sure to open an issue as a [bug/issue](https://github.com/googleapis/release-please/issues/new/choose) before writing your code!  That way we can discuss the change, evaluate designs, and agree on the general idea
- [x] Ensure the tests and linter pass
- [x] Code coverage does not decrease (if any source code was changed)
- [x] Appropriate docs were updated (if necessary)

Fixes #2172 🦕

## Problem

Since #2310, workspace plugins default to `merge: false` when `separate-pull-requests: true` is configured. On that code path, a candidate created for a dependency-only version bump ("cascade") is broken in two ways — both leftovers from when in-scope candidates were always merged into a single pull request:

1. **No release labels.** `newCandidate()` hardcodes `labels: []` (and passes `[]` to `strategy.buildReleasePullRequest`). Under `merge: true` this was harmless because the `Merge` plugin unions labels from the real candidates, but as a standalone PR the cascade never carries `autorelease: pending`. Consequences:
   - `findMergedReleasePullRequests` filters merged PRs by these labels, so after the cascade PR is merged, **no tag or GitHub release is ever created** for it.
   - `findOpenReleasePullRequests` uses the same filter, so release-please does not recognize its own open cascade PRs and force-pushes their branches on every run.
2. **Manifest entries attached to the wrong pull request.** The manifest update covering *all* force-bumped paths is pushed onto `newCandidates[0]` only (introduced in #1429, when `newCandidates[0]` was by construction the single merged PR). With separate PRs it lands on whichever candidate sorts first alphabetically. Merging any *other* cascade PR leaves `.release-please-manifest.json` out of sync, and each subsequent run re-bumps from the package manifest and opens another doomed PR one patch higher. (If the first candidate's body happens to be unchanged, `maybeUpdateExistingPullRequest` skips the push entirely and the manifest update is silently dropped.)

Observed in production on a pnpm monorepo: dependency-only releases escalated three patch versions in a single day without a single tag or publish, while the manifest entries for those packages accumulated on an unrelated package's release PR.

## Fix

- Pass the manifest's configured `labels` through `buildPlugin` to the workspace plugins (`node-workspace`, `cargo-workspace`, `maven-workspace`), and use them in `newCandidate()` — both the `strategy.buildReleasePullRequest` path and the fallback literal. Under `merge: true` this is a no-op (label union is unchanged).
- In `WorkspacePlugin.run()`, keep the existing single combined manifest update when `merge` is enabled; when it is disabled, attach each forced bump's manifest entry to **its own** candidate pull request. Candidates built from real releases already receive their manifest entry from the manifest PR builder, so nothing is duplicated.

## Tests

Extended the plugin-compatibility test added in #2310 (`test/plugins/compatibility/separate-pull-requests-workspace.ts`) to also assert that each separate pull request carries the pending-release label and the manifest entry for its own path. Without the fix these assertions fail (`expected [] to deeply equal [ 'autorelease: pending' ]`); with it, the full suite passes (1201 tests).
