### PR TITLE
chore: dynamically replace changelog reference keyword with 'refs'

### DIFF
--- a/__snapshots__/default-changelog-notes.js
+++ b/__snapshots__/default-changelog-notes.js
@@ -128,7 +128,7 @@ exports['DefaultChangelogNotes buildNotes with commit parsing should handle bug 
 
 ### Bug Fixes
 
-* some fix ([71489e6](https://github.com/googleapis/java-asset/commit/71489e63ad212c54598f5bdcbedec5f6)), closes [#123](https://github.com/googleapis/java-asset/issues/123)
+* some fix ([71489e6](https://github.com/googleapis/java-asset/commit/71489e63ad212c54598f5bdcbedec5f6)), refs [#123](https://github.com/googleapis/java-asset/issues/123)
 `
 
 exports['DefaultChangelogNotes buildNotes with commit parsing should handle git trailers 1'] = `

--- a/src/changelog-notes/default.ts
+++ b/src/changelog-notes/default.ts
@@ -67,8 +67,11 @@ export class DefaultChangelogNotes implements ChangelogNotes {
       config.types = options.changelogSections;
     }
     const preset = await presetFactory(config);
+    // Replace the default ", closes" keyword with ", refs" to prevent GitHub from
+    // automatically closing referenced issues when the release PR is merged.
     preset.writerOpts.commitPartial =
-      this.commitPartial || preset.writerOpts.commitPartial;
+      this.commitPartial ||
+      preset.writerOpts.commitPartial?.replace(/,\s*closes/g, ', refs');
     preset.writerOpts.headerPartial =
       this.headerPartial || preset.writerOpts.headerPartial;
     preset.writerOpts.mainTemplate =


### PR DESCRIPTION
Dynamically replace ', closes' with ', refs' in the upstream commit.hbs Handlebars partial in-memory. This prevents GitHub from auto-closing issues when release PRs are merged without needing to duplicate or maintain the full Handlebars template in release-please.

### Problem
The upstream `conventional-changelog-conventionalcommits` preset hardcodes `, closes #<issue>` for referenced issues in changelog notes. When `release-please` writes these notes into the Release Pull Request body, merging the Release PR causes GitHub to automatically close all referenced issues—even when commits only intended to reference them (e.g., `for #123` or `refs #123`).

### Why Dynamic Replacement?
Modifying the loaded template in-memory avoids duplicating and maintaining a static `commit.hbs` file, eliminating the risk of template drift when upstream dependencies update.


BEGIN_COMMIT_OVERRIDE
fix: dynamically replace changelog reference keyword with 'refs'
END_COMMIT_OVERRIDE