### PR TITLE
fix(cargo-workspace): don't release publish = false members pulled in as dependents

### DIFF
--- a/docs/manifest-releaser.md
+++ b/docs/manifest-releaser.md
@@ -564,6 +564,15 @@ workspace, and updates any packages that were directly bumped by release-please,
 or that should be patch-bumped because one of their transitive dependencies was
 bumped. The cargo lockfile is also updated.
 
+A workspace member whose manifest sets `publish = false` is still bumped so that
+its own dependents stay consistent, but it does not get a release of its own: no
+release pull request, tag, or `.release-please-manifest.json` entry is created
+for it when it is pulled in only as a dependent. A `publish = false` crate that
+is listed in your release-please config and has changes of its own is released
+as usual (its version is tracked and tagged); `publish = false` only suppresses
+the release of a crate that would otherwise be released solely because a
+dependency was bumped.
+
 Note: when the Rust releaser is used standalone (with the `release-pr` /
 `github-release` commands), it also tries to update monorepo dependencies, but
 it doesn't build a crate graph. When the Rust releaser is used in conjunction

--- a/src/plugins/cargo-workspace.ts
+++ b/src/plugins/cargo-workspace.ts
@@ -72,6 +72,11 @@ interface CrateInfo {
    * Parsed cargo manifest
    */
   manifest: CargoManifest;
+
+  /**
+   * `false` when the manifest sets `publish = false`.
+   */
+  publishable: boolean;
 }
 
 /**
@@ -163,6 +168,7 @@ export class CargoWorkspace extends WorkspacePlugin<CrateInfo> {
         manifest,
         manifestContent: manifestContent.parsedContent,
         manifestPath,
+        publishable: manifest.package?.publish !== false,
       });
     }
     return {
@@ -392,6 +398,10 @@ export class CargoWorkspace extends WorkspacePlugin<CrateInfo> {
 
   protected inScope(candidate: CandidateReleasePullRequest): boolean {
     return candidate.config.releaseType === 'rust';
+  }
+
+  protected shouldCreateReleasePullRequest(pkg: CrateInfo): boolean {
+    return pkg.publishable;
   }
 
   protected packageNameFromPackage(pkg: CrateInfo): string {

--- a/src/plugins/workspace.ts
+++ b/src/plugins/workspace.ts
@@ -147,6 +147,14 @@ export abstract class WorkspacePlugin<T> extends ManifestPlugin {
           newCandidatePaths.add(newCandidate.path);
           newCandidates.push(newCandidate);
         }
+      } else if (!this.shouldCreateReleasePullRequest(pkg)) {
+        // Dependent-only bump: its version is already in `updatedVersions`, so
+        // dependents are still updated, but it opts out of its own release.
+        this.logger.info(
+          `Skipping release pull request for ${this.packageNameFromPackage(
+            pkg
+          )}`
+        );
       } else {
         // otherwise, build a new pull request with changelog and entry update
         this.logger.info(
@@ -266,7 +274,10 @@ export abstract class WorkspacePlugin<T> extends ManifestPlugin {
         const version = this.bumpVersion(pkg);
         this.logger.debug(`version: ${version} forced bump`);
         updatedVersions.set(packageName, version);
-        if (this.isReleaseVersion(version)) {
+        if (
+          this.isReleaseVersion(version) &&
+          this.shouldCreateReleasePullRequest(pkg)
+        ) {
           updatedPathVersions.set(this.pathFromPackage(pkg), version);
         }
       }
@@ -283,6 +294,15 @@ export abstract class WorkspacePlugin<T> extends ManifestPlugin {
    * @param {Version} _version The release version
    */
   protected isReleaseVersion(_version: Version): boolean {
+    return true;
+  }
+
+  /**
+   * Whether a dependent-only package should get its own release pull request.
+   * Defaults to `true`; the package is version-bumped regardless.
+   * @param {T} _pkg The dependent package being considered
+   */
+  protected shouldCreateReleasePullRequest(_pkg: T): boolean {
     return true;
   }
 

--- a/src/updaters/rust/common.ts
+++ b/src/updaters/rust/common.ts
@@ -45,6 +45,9 @@ export interface CargoWorkspace {
 export interface CargoPackage {
   name?: string;
   version?: string;
+  // `publish = false` (or an allow-list of registries). When `false`, the
+  // crate is a workspace member that is never published to a registry.
+  publish?: boolean | string[];
 }
 
 export interface CargoDependencies {

--- a/test/fixtures/plugins/cargo-workspace-publish-false/Cargo.lock
+++ b/test/fixtures/plugins/cargo-workspace-publish-false/Cargo.lock
@@ -1,0 +1,7 @@
+[[package]]
+name = "pkgA"
+version = "1.1.1"
+
+[[package]]
+name = "pkgUnpub"
+version = "6.6.6"

--- a/test/fixtures/plugins/cargo-workspace-publish-false/Cargo.toml
+++ b/test/fixtures/plugins/cargo-workspace-publish-false/Cargo.toml
@@ -1,0 +1,2 @@
+[workspace]
+members = ["packages/rustA", "packages/rustUnpub"]

--- a/test/fixtures/plugins/cargo-workspace-publish-false/packages/rustA/Cargo.toml
+++ b/test/fixtures/plugins/cargo-workspace-publish-false/packages/rustA/Cargo.toml
@@ -1,0 +1,6 @@
+[package]
+name = "pkgA"
+version = "1.1.1"
+
+[dependencies]
+tracing = "1.0.0"

--- a/test/fixtures/plugins/cargo-workspace-publish-false/packages/rustUnpub/Cargo.toml
+++ b/test/fixtures/plugins/cargo-workspace-publish-false/packages/rustUnpub/Cargo.toml
@@ -1,0 +1,8 @@
+[package]
+name = "pkgUnpub"
+version = "6.6.6"
+publish = false
+
+[dependencies]
+pkgA = { version = "1.1.1", path = "../pkgA" }
+tracing = "1.0.0"

--- a/test/plugins/cargo-workspace.ts
+++ b/test/plugins/cargo-workspace.ts
@@ -312,6 +312,59 @@ describe('CargoWorkspace plugin', () => {
       assertHasUpdate(updates, 'packages/rustE/Cargo.toml', RawContent);
       snapshot(dateSafe(rustCandidate!.pullRequest.body.toString()));
     });
+    it('does not open a release pull request for a publish = false dependent', async () => {
+      const publishFalsePath =
+        './test/fixtures/plugins/cargo-workspace-publish-false';
+      // Only pkgA has a release candidate; pkgUnpub (publish = false) depends
+      // on it and is pulled into the graph only as a dependent.
+      const candidates: CandidateReleasePullRequest[] = [
+        buildMockCandidatePullRequest('packages/rustA', 'rust', '1.1.2', {
+          component: 'pkgA',
+          updates: [
+            buildMockPackageUpdate(
+              'packages/rustA/Cargo.toml',
+              'packages/rustA/Cargo.toml'
+            ),
+          ],
+        }),
+      ];
+      stubFilesFromFixtures({
+        sandbox,
+        github,
+        fixturePath: publishFalsePath,
+        files: [
+          'Cargo.toml',
+          'packages/rustA/Cargo.toml',
+          'packages/rustUnpub/Cargo.toml',
+        ],
+        flatten: false,
+        targetBranch: 'main',
+      });
+      sandbox
+        .stub(github, 'findFilesByGlobAndRef')
+        .withArgs('packages/rustA', 'main')
+        .resolves(['packages/rustA'])
+        .withArgs('packages/rustUnpub', 'main')
+        .resolves(['packages/rustUnpub']);
+      plugin = new CargoWorkspace(
+        github,
+        'main',
+        {
+          'packages/rustA': {
+            releaseType: 'rust',
+          },
+        },
+        {
+          merge: false,
+        }
+      );
+      const newCandidates = await plugin.run(candidates);
+      // Only pkgA is released — no standalone candidate for the publish = false
+      // crate.
+      expect(newCandidates).lengthOf(1);
+      expect(newCandidates.find(c => c.path === 'packages/rustUnpub')).to.be
+        .undefined;
+    });
     it('can skip merging rust packages', async () => {
       // This is the same setup as 'walks dependency tree and updates previously untouched packages'
       const candidates: CandidateReleasePullRequest[] = [


### PR DESCRIPTION
Thank you for opening a Pull Request! Before submitting your PR, there are a few things you can do to make sure it goes smoothly:
- [x] Make sure to open an issue as a [bug/issue](https://github.com/googleapis/release-please/issues/new/choose) before writing your code! That way we can discuss the change, evaluate designs, and agree on the general idea
- [x] Ensure the tests and linter pass
- [x] Code coverage does not decrease (if any source code was changed)
- [x] Appropriate docs were updated (if necessary)

Fixes #1980 🦕

### Problem

With the `cargo-workspace` plugin, every workspace member is pulled into the dependency graph and version-bumped when a dependency is bumped — including crates marked `publish = false`. When `separate-pull-requests` is enabled, a `publish = false` crate that only appears as a *transitive dependent* gets its own standalone release pull request (and tag / manifest entry), even though it is never published anywhere. This produces an empty, noisy release PR on every release.

This is the request in #1980. The discussion there raised a valid concern: some teams *do* want their `publish = false` crates released (version bumped, GitHub release made) — `publish = false` only means "don't push to a registry". So a blanket "skip all `publish = false` crates" would be wrong.

### Solution

Suppress the standalone release **only** for a `publish = false` crate that is pulled in *solely as a dependent* (i.e. it has no release candidate of its own):

- It is **still version-bumped**, so its dependents' `Cargo.toml` entries and the lockfile stay consistent.
- It gets **no** release pull request, tag, or `.release-please-manifest.json` entry.

Teams that *want* a `publish = false` crate released simply list it in their release-please `packages` config as usual — it then has its own release candidate, and this new behavior does not apply to it. Both camps from #1980 are satisfied with no new configuration.

### Implementation

- Adds a `shouldCreateReleasePullRequest(pkg)` hook to the base `WorkspacePlugin` (defaults to `true`, so `node-workspace` and `maven-workspace` are unchanged).
- `CargoWorkspace` overrides it to return `false` for crates whose manifest sets `publish = false`.
- The hook is consulted only on the dependent-only path (no existing candidate), and gates both candidate creation and the manifest (`updatedPathVersions`) entry — the version bump itself is unaffected.

### Tests / docs

- New fixture (`test/fixtures/plugins/cargo-workspace-publish-false`) and test asserting a `publish = false` dependent is not turned into a release PR.
- Existing `cargo-workspace` / `node-workspace` / `maven-workspace` suites unchanged and passing.
- `docs/manifest-releaser.md` cargo-workspace section documents the behavior.
