### PR TITLE
fix: handle separate workspace release PRs

### DIFF
--- a/src/factories/plugin-factory.ts
+++ b/src/factories/plugin-factory.ts
@@ -39,6 +39,7 @@ export interface PluginFactoryOptions {
   repositoryConfig: RepositoryConfig;
   manifestPath: string;
   separatePullRequests?: boolean;
+  labels?: string[];
 
   // node options
   alwaysLinkLocal?: boolean;

--- a/src/manifest.ts
+++ b/src/manifest.ts
@@ -414,6 +414,7 @@ export class Manifest {
         repositoryConfig: this.repositoryConfig,
         manifestPath: this.manifestPath,
         separatePullRequests: this.separatePullRequests,
+        labels: this.labels,
       })
     );
     this.pullRequestOverflowHandler = new FilePullRequestOverflowHandler(

--- a/src/plugins/workspace.ts
+++ b/src/plugins/workspace.ts
@@ -35,6 +35,7 @@ export interface WorkspacePluginOptions {
   manifestPath?: string;
   updateAllPackages?: boolean;
   merge?: boolean;
+  labels?: string[];
   logger?: Logger;
 }
 
@@ -58,6 +59,7 @@ export abstract class WorkspacePlugin<T> extends ManifestPlugin {
   private updateAllPackages: boolean;
   private manifestPath: string;
   private merge: boolean;
+  private labels: string[];
   constructor(
     github: Scm,
     targetBranch: string,
@@ -68,6 +70,7 @@ export abstract class WorkspacePlugin<T> extends ManifestPlugin {
     this.manifestPath = options.manifestPath ?? DEFAULT_RELEASE_PLEASE_MANIFEST;
     this.updateAllPackages = options.updateAllPackages ?? false;
     this.merge = options.merge ?? true;
+    this.labels = options.labels ?? [];
   }
   async run(
     candidates: CandidateReleasePullRequest[]
@@ -161,6 +164,11 @@ export abstract class WorkspacePlugin<T> extends ManifestPlugin {
           );
         } else {
           newCandidatePaths.add(newCandidate.path);
+          for (const label of this.labels) {
+            if (!newCandidate.pullRequest.labels.includes(label)) {
+              newCandidate.pullRequest.labels.push(label);
+            }
+          }
           newCandidates.push(newCandidate);
         }
       }

--- a/src/plugins/workspace.ts
+++ b/src/plugins/workspace.ts
@@ -176,15 +176,31 @@ export abstract class WorkspacePlugin<T> extends ManifestPlugin {
       newCandidates = await mergePlugin.run(newCandidates);
     }
 
-    const newUpdates = newCandidates[0].pullRequest.updates;
-    newUpdates.push({
-      path: this.manifestPath,
-      createIfMissing: false,
-      updater: new ReleasePleaseManifest({
-        version: newCandidates[0].pullRequest.version!,
-        versionsMap: updatedPathVersions,
-      }),
-    });
+    if (this.merge) {
+      const candidate = newCandidates[0];
+      candidate.pullRequest.updates.push({
+        path: this.manifestPath,
+        createIfMissing: false,
+        updater: new ReleasePleaseManifest({
+          version: candidate.pullRequest.version!,
+          versionsMap: updatedPathVersions,
+        }),
+      });
+    } else {
+      for (const candidate of newCandidates) {
+        const version = updatedPathVersions.get(candidate.path);
+        if (version) {
+          candidate.pullRequest.updates.push({
+            path: this.manifestPath,
+            createIfMissing: false,
+            updater: new ReleasePleaseManifest({
+              version: candidate.pullRequest.version!,
+              versionsMap: new Map([[candidate.path, version]]),
+            }),
+          });
+        }
+      }
+    }
 
     this.logger.info(
       `Post-processing ${newCandidates.length} in-scope candidates`

--- a/test/plugins/node-workspace.ts
+++ b/test/plugins/node-workspace.ts
@@ -315,7 +315,7 @@ describe('NodeWorkspace plugin', () => {
       expect(updater.versionsMap?.get('node5')?.toString()).to.eql('1.0.1');
       snapshot(dateSafe(nodeCandidate!.pullRequest.body.toString()));
     });
-    it('adds separate manifest updates to new candidates', async () => {
+    it('adds separate manifest updates and labels to new candidates', async () => {
       const candidates: CandidateReleasePullRequest[] = [
         buildMockCandidatePullRequest('node1', 'node', '3.3.4', {
           component: '@here/pkgA',
@@ -346,6 +346,7 @@ describe('NodeWorkspace plugin', () => {
         },
         {
           merge: false,
+          labels: ['autorelease: pending'],
         }
       );
 
@@ -378,6 +379,12 @@ describe('NodeWorkspace plugin', () => {
         ReleasePleaseManifest
       ).updater as ReleasePleaseManifest;
       expect(Array.from(node5Manifest.versionsMap!.keys())).to.eql(['node5']);
+      expect(node2Candidate.pullRequest.labels).to.include(
+        'autorelease: pending'
+      );
+      expect(node5Candidate.pullRequest.labels).to.include(
+        'autorelease: pending'
+      );
     });
     it('walks dependency tree and updates previously untouched packages (prerelease)', async () => {
       const candidates: CandidateReleasePullRequest[] = [

--- a/test/plugins/node-workspace.ts
+++ b/test/plugins/node-workspace.ts
@@ -315,6 +315,70 @@ describe('NodeWorkspace plugin', () => {
       expect(updater.versionsMap?.get('node5')?.toString()).to.eql('1.0.1');
       snapshot(dateSafe(nodeCandidate!.pullRequest.body.toString()));
     });
+    it('adds separate manifest updates to new candidates', async () => {
+      const candidates: CandidateReleasePullRequest[] = [
+        buildMockCandidatePullRequest('node1', 'node', '3.3.4', {
+          component: '@here/pkgA',
+          updates: [
+            buildMockPackageUpdate('node1/package.json', 'node1/package.json'),
+          ],
+        }),
+      ];
+      stubFilesFromFixtures({
+        sandbox,
+        github,
+        fixturePath: fixturesPath,
+        files: [
+          'node1/package.json',
+          'node2/package.json',
+          'node5/package.json',
+        ],
+        flatten: false,
+        targetBranch: 'main',
+      });
+      plugin = new NodeWorkspace(
+        github,
+        'main',
+        {
+          node1: {releaseType: 'node'},
+          node2: {releaseType: 'node'},
+          node5: {releaseType: 'node'},
+        },
+        {
+          merge: false,
+        }
+      );
+
+      const newCandidates = await plugin.run(candidates);
+      expect(newCandidates).lengthOf(3);
+
+      const node1Candidate = newCandidates.find(
+        candidate => candidate.path === 'node1'
+      )!;
+      const node2Candidate = newCandidates.find(
+        candidate => candidate.path === 'node2'
+      )!;
+      const node5Candidate = newCandidates.find(
+        candidate => candidate.path === 'node5'
+      )!;
+
+      assertNoHasUpdate(
+        node1Candidate.pullRequest.updates,
+        '.release-please-manifest.json'
+      );
+      const node2Manifest = assertHasUpdate(
+        node2Candidate.pullRequest.updates,
+        '.release-please-manifest.json',
+        ReleasePleaseManifest
+      ).updater as ReleasePleaseManifest;
+      expect(Array.from(node2Manifest.versionsMap!.keys())).to.eql(['node2']);
+      const node5Manifest = assertHasUpdate(
+        node5Candidate.pullRequest.updates,
+        '.release-please-manifest.json',
+        ReleasePleaseManifest
+      ).updater as ReleasePleaseManifest;
+      expect(Array.from(node5Manifest.versionsMap!.keys())).to.eql(['node5']);
+    });
     it('walks dependency tree and updates previously untouched packages (prerelease)', async () => {
       const candidates: CandidateReleasePullRequest[] = [
         buildMockCandidatePullRequest('node1', 'node', '3.3.4-beta', {


### PR DESCRIPTION
Thank you for opening a Pull Request! Before submitting your PR, there are a few things you can do to make sure it goes smoothly:
- [x] Make sure to open an issue as a [bug/issue](https://github.com/googleapis/release-please/issues/new/choose) before writing your code!  That way we can discuss the change, evaluate designs, and agree on the general idea
- [x] Ensure the tests and linter pass
- [x] Code coverage does not decrease (if any source code was changed)
- [x] Appropriate docs were updated (if necessary)

Fixes #2853 🦕

- attach each dependency-bump manifest entry to its corresponding workspace
  candidate when `merge: false`
- preserve the combined manifest update when workspace candidates are merged
- propagate configured release PR labels to candidates created by workspace
  plugins
- add regression coverage for separate dependency-only candidates

The workspace plugin unconditionally attached the complete
`updatedPathVersions` map to `newCandidates[0]`. This was valid after merging
candidates, but with `merge: false` it placed every manifest entry in the first
PR and left the other dependency-bump PRs without manifest updates.

Workspace-created candidates also did not receive the labels configured by the
manifest, making them invisible to release and open-PR discovery logic.