### PR TITLE
feat: add ruby-librarian strategy

### DIFF
--- a/__snapshots__/cli.js
+++ b/__snapshots__/cli.js
@@ -290,3 +290,7 @@ Options:
                                     project?
                                       [default: ".release-please-manifest.json"]
 `
+
+exports['CLI handleError handles an error 1'] = [
+  "command foobar failed with status 404"
+]

--- a/__snapshots__/cli.js
+++ b/__snapshots__/cli.js
@@ -53,8 +53,8 @@ Options:
         "go-librarian", "go-yoshi", "helm", "java", "java-backport", "java-bom",
      "java-lts", "java-yoshi", "java-yoshi-mono-repo", "krm-blueprint", "maven",
                 "node", "node-librarian", "ocaml", "php", "php-yoshi", "python",
-    "python-librarian", "r", "ruby", "ruby-yoshi", "rust", "salesforce", "sfdx",
-                                                   "simple", "terraform-module"]
+        "python-librarian", "r", "ruby", "ruby-librarian", "ruby-yoshi", "rust",
+                             "salesforce", "sfdx", "simple", "terraform-module"]
   --config-file                 where can the config file be found in the
                                 project? [default: "release-please-config.json"]
   --manifest-file               where can the manifest file be found in the
@@ -281,8 +281,8 @@ Options:
         "go-librarian", "go-yoshi", "helm", "java", "java-backport", "java-bom",
      "java-lts", "java-yoshi", "java-yoshi-mono-repo", "krm-blueprint", "maven",
                 "node", "node-librarian", "ocaml", "php", "php-yoshi", "python",
-    "python-librarian", "r", "ruby", "ruby-yoshi", "rust", "salesforce", "sfdx",
-                                                   "simple", "terraform-module"]
+        "python-librarian", "r", "ruby", "ruby-librarian", "ruby-yoshi", "rust",
+                             "salesforce", "sfdx", "simple", "terraform-module"]
   --config-file                     where can the config file be found in the
                                     project?
                                          [default: "release-please-config.json"]
@@ -290,7 +290,3 @@ Options:
                                     project?
                                       [default: ".release-please-manifest.json"]
 `
-
-exports['CLI handleError handles an error 1'] = [
-  "command foobar failed with status 404"
-]

--- a/src/factory.ts
+++ b/src/factory.ts
@@ -42,6 +42,7 @@ import {PythonLibrarian} from './strategies/python-librarian';
 import {R} from './strategies/r';
 import {Ruby} from './strategies/ruby';
 import {RubyYoshi} from './strategies/ruby-yoshi';
+import {RubyLibrarian} from './strategies/ruby-librarian';
 import {Rust} from './strategies/rust';
 import {Sfdx} from './strategies/sfdx';
 import {Simple} from './strategies/simple';
@@ -108,6 +109,7 @@ const releasers: Record<string, ReleaseBuilder> = {
   r: options => new R(options),
   ruby: options => new Ruby(options),
   'ruby-yoshi': options => new RubyYoshi(options),
+  'ruby-librarian': options => new RubyLibrarian(options),
   rust: options => new Rust(options),
   salesforce: options => new Sfdx(options),
   sfdx: options => new Sfdx(options),

--- a/src/strategies/ruby-librarian.ts
+++ b/src/strategies/ruby-librarian.ts
@@ -1,0 +1,38 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import {Ruby} from './ruby';
+import {BuildUpdatesOptions} from './base';
+import {Update} from '../update';
+import {LibrarianYamlUpdater} from '../updaters/librarian-yaml';
+
+export class RubyLibrarian extends Ruby {
+  protected async buildUpdates(
+    options: BuildUpdatesOptions
+  ): Promise<Update[]> {
+    const updates = await super.buildUpdates(options);
+
+    // Update librarian.yaml if this package exists within it.
+    updates.push({
+      path: 'librarian.yaml',
+      createIfMissing: false,
+      updater: new LibrarianYamlUpdater({
+        version: options.newVersion,
+        packagePath: this.path,
+      }),
+    });
+
+    return updates;
+  }
+}

--- a/src/strategies/ruby-librarian.ts
+++ b/src/strategies/ruby-librarian.ts
@@ -12,12 +12,12 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import {Ruby} from './ruby';
+import {RubyYoshi} from './ruby-yoshi';
 import {BuildUpdatesOptions} from './base';
 import {Update} from '../update';
 import {LibrarianYamlUpdater} from '../updaters/librarian-yaml';
 
-export class RubyLibrarian extends Ruby {
+export class RubyLibrarian extends RubyYoshi {
   protected async buildUpdates(
     options: BuildUpdatesOptions
   ): Promise<Update[]> {

--- a/test/strategies/ruby-librarian.ts
+++ b/test/strategies/ruby-librarian.ts
@@ -113,11 +113,15 @@ describe('RubyLibrarian', () => {
 
       const originalYaml = `language: ruby
 libraries:
+  - name: google-cloud-asset
+    version: 0.8.0
   - name: google-cloud-asset-v1
     version: 0.5.0
 `;
       const expectedYaml = `language: ruby
 libraries:
+  - name: google-cloud-asset
+    version: 0.8.0
   - name: google-cloud-asset-v1
     version: 1.0.0
 `;

--- a/test/strategies/ruby-librarian.ts
+++ b/test/strategies/ruby-librarian.ts
@@ -1,0 +1,128 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import {describe, it, afterEach, beforeEach} from 'mocha';
+import {expect} from 'chai';
+import {GitHub} from '../../src/github';
+import {RubyLibrarian} from '../../src/strategies/ruby-librarian';
+import * as sinon from 'sinon';
+import {assertHasUpdate, buildMockConventionalCommit} from '../helpers';
+import {Changelog} from '../../src/updaters/changelog';
+import {VersionRB} from '../../src/updaters/ruby/version-rb';
+import {GemfileLock} from '../../src/updaters/ruby/gemfile-lock';
+import {LibrarianYamlUpdater} from '../../src/updaters/librarian-yaml';
+import {Update} from '../../src/update';
+
+const sandbox = sinon.createSandbox();
+
+const COMMITS = [
+  ...buildMockConventionalCommit('fix: resolve issue in ruby client'),
+];
+
+describe('RubyLibrarian', () => {
+  let github: GitHub;
+  beforeEach(async () => {
+    github = await GitHub.create({
+      owner: 'googleapis',
+      repo: 'ruby-test-repo',
+      defaultBranch: 'main',
+    });
+  });
+  afterEach(() => {
+    sandbox.restore();
+  });
+
+  describe('buildReleasePullRequest', () => {
+    it('returns release PR changes with defaultInitialVersion', async () => {
+      const expectedVersion = '1.0.0';
+      const strategy = new RubyLibrarian({
+        targetBranch: 'main',
+        github,
+        component: 'google-cloud-storage',
+      });
+      const latestRelease = undefined;
+      const release = await strategy.buildReleasePullRequest(
+        COMMITS,
+        latestRelease
+      );
+      expect(release!.version?.toString()).to.eql(expectedVersion);
+    });
+  });
+
+  describe('buildUpdates', () => {
+    it('builds common ruby files and appends librarian.yaml correctly', async () => {
+      const strategy = new RubyLibrarian({
+        targetBranch: 'main',
+        github,
+        component: 'google-cloud-storage',
+      });
+      const latestRelease = undefined;
+      const release = await strategy.buildReleasePullRequest(
+        COMMITS,
+        latestRelease
+      );
+      const updates = release!.updates;
+
+      // Verify standard ruby updates (inherited from Ruby strategy)
+      assertHasUpdate(updates, 'CHANGELOG.md', Changelog);
+      assertHasUpdate(updates, 'lib/google/cloud/storage/version.rb', VersionRB);
+      assertHasUpdate(updates, 'Gemfile.lock', GemfileLock);
+
+      // Verify librarian.yaml is correctly registered as an update
+      const update = assertHasUpdate(
+        updates,
+        'librarian.yaml',
+        LibrarianYamlUpdater
+      );
+      expect(update.createIfMissing).to.be.false;
+
+      // Verify updater is correctly configured
+      const updater = update.updater as LibrarianYamlUpdater;
+      expect(updater.version?.toString()).to.eql('1.0.0');
+      expect((updater as any).packagePath).to.eql('.');
+    });
+
+    it('integration: LibrarianYamlUpdater updates librarian.yaml with new version for matching gem component', async () => {
+      const strategy = new RubyLibrarian({
+        targetBranch: 'main',
+        github,
+        component: 'google-cloud-storage',
+        path: 'google-cloud-storage',
+      });
+      const latestRelease = undefined;
+      const release = await strategy.buildReleasePullRequest(
+        COMMITS,
+        latestRelease
+      );
+      const updates = release!.updates;
+      const librarianUpdate = updates.find(
+        (u: Update) => u.path === 'librarian.yaml'
+      );
+      expect(librarianUpdate).to.not.be.undefined;
+
+      const originalYaml = `language: ruby
+libraries:
+  - name: google-cloud-storage
+    version: 0.5.0
+`;
+      const expectedYaml = `language: ruby
+libraries:
+  - name: google-cloud-storage
+    version: 1.0.0
+`;
+      const updatedYaml = librarianUpdate!.updater.updateContent(originalYaml);
+      expect(updatedYaml).to.equal(expectedYaml);
+    });
+  });
+});

--- a/test/strategies/ruby-librarian.ts
+++ b/test/strategies/ruby-librarian.ts
@@ -49,7 +49,7 @@ describe('RubyLibrarian', () => {
       const strategy = new RubyLibrarian({
         targetBranch: 'main',
         github,
-        component: 'google-cloud-storage',
+        component: 'google-cloud-asset',
       });
       const latestRelease = undefined;
       const release = await strategy.buildReleasePullRequest(
@@ -65,7 +65,7 @@ describe('RubyLibrarian', () => {
       const strategy = new RubyLibrarian({
         targetBranch: 'main',
         github,
-        component: 'google-cloud-storage',
+        component: 'google-cloud-asset',
       });
       const latestRelease = undefined;
       const release = await strategy.buildReleasePullRequest(
@@ -76,11 +76,7 @@ describe('RubyLibrarian', () => {
 
       // Verify standard ruby updates (inherited from Ruby strategy)
       assertHasUpdate(updates, 'CHANGELOG.md', Changelog);
-      assertHasUpdate(
-        updates,
-        'lib/google/cloud/storage/version.rb',
-        VersionRB
-      );
+      assertHasUpdate(updates, 'lib/google/cloud/asset/version.rb', VersionRB);
       assertHasUpdate(updates, 'Gemfile.lock', GemfileLock);
 
       // Verify librarian.yaml is correctly registered as an update
@@ -101,8 +97,8 @@ describe('RubyLibrarian', () => {
       const strategy = new RubyLibrarian({
         targetBranch: 'main',
         github,
-        component: 'google-cloud-storage',
-        path: 'google-cloud-storage',
+        component: 'google-cloud-asset-v1',
+        path: 'google-cloud-asset-v1',
       });
       const latestRelease = undefined;
       const release = await strategy.buildReleasePullRequest(
@@ -117,12 +113,12 @@ describe('RubyLibrarian', () => {
 
       const originalYaml = `language: ruby
 libraries:
-  - name: google-cloud-storage
+  - name: google-cloud-asset-v1
     version: 0.5.0
 `;
       const expectedYaml = `language: ruby
 libraries:
-  - name: google-cloud-storage
+  - name: google-cloud-asset-v1
     version: 1.0.0
 `;
       const updatedYaml = librarianUpdate!.updater.updateContent(originalYaml);

--- a/test/strategies/ruby-librarian.ts
+++ b/test/strategies/ruby-librarian.ts
@@ -76,7 +76,11 @@ describe('RubyLibrarian', () => {
 
       // Verify standard ruby updates (inherited from Ruby strategy)
       assertHasUpdate(updates, 'CHANGELOG.md', Changelog);
-      assertHasUpdate(updates, 'lib/google/cloud/storage/version.rb', VersionRB);
+      assertHasUpdate(
+        updates,
+        'lib/google/cloud/storage/version.rb',
+        VersionRB
+      );
       assertHasUpdate(updates, 'Gemfile.lock', GemfileLock);
 
       // Verify librarian.yaml is correctly registered as an update

--- a/test/strategies/ruby-librarian.ts
+++ b/test/strategies/ruby-librarian.ts
@@ -20,7 +20,6 @@ import * as sinon from 'sinon';
 import {assertHasUpdate, buildMockConventionalCommit} from '../helpers';
 import {Changelog} from '../../src/updaters/changelog';
 import {VersionRB} from '../../src/updaters/ruby/version-rb';
-import {GemfileLock} from '../../src/updaters/ruby/gemfile-lock';
 import {LibrarianYamlUpdater} from '../../src/updaters/librarian-yaml';
 import {Update} from '../../src/update';
 
@@ -61,7 +60,7 @@ describe('RubyLibrarian', () => {
   });
 
   describe('buildUpdates', () => {
-    it('builds common ruby files and appends librarian.yaml correctly', async () => {
+    it('builds common ruby-yoshi files and appends librarian.yaml correctly', async () => {
       const strategy = new RubyLibrarian({
         targetBranch: 'main',
         github,
@@ -74,10 +73,9 @@ describe('RubyLibrarian', () => {
       );
       const updates = release!.updates;
 
-      // Verify standard ruby updates (inherited from Ruby strategy)
+      // Verify standard ruby-yoshi updates (inherited from RubyYoshi strategy)
       assertHasUpdate(updates, 'CHANGELOG.md', Changelog);
       assertHasUpdate(updates, 'lib/google/cloud/asset/version.rb', VersionRB);
-      assertHasUpdate(updates, 'Gemfile.lock', GemfileLock);
 
       // Verify librarian.yaml is correctly registered as an update
       const update = assertHasUpdate(

--- a/test/strategies/ruby-librarian.ts
+++ b/test/strategies/ruby-librarian.ts
@@ -97,8 +97,8 @@ describe('RubyLibrarian', () => {
       const strategy = new RubyLibrarian({
         targetBranch: 'main',
         github,
-        component: 'google-cloud-asset-v1',
-        path: 'google-cloud-asset-v1',
+        component: 'google-cloud-asset',
+        path: 'google-cloud-asset',
       });
       const latestRelease = undefined;
       const release = await strategy.buildReleasePullRequest(
@@ -121,9 +121,9 @@ libraries:
       const expectedYaml = `language: ruby
 libraries:
   - name: google-cloud-asset
-    version: 0.8.0
-  - name: google-cloud-asset-v1
     version: 1.0.0
+  - name: google-cloud-asset-v1
+    version: 0.5.0
 `;
       const updatedYaml = librarianUpdate!.updater.updateContent(originalYaml);
       expect(updatedYaml).to.equal(expectedYaml);


### PR DESCRIPTION
### Problem
When Ruby gem folders in monorepos (such as `google-cloud-ruby`) transition to using Librarian, Release Please needs to update the gem's `version` field in `librarian.yaml` alongside updating `version.rb` and `CHANGELOG.md` upon releases.

### Solution
This PR introduces the `ruby-librarian` release strategy in Release Please.

- **`RubyLibrarian` Strategy**: Extends `RubyYoshi` and appends `LibrarianYamlUpdater` to update the `version` field in `librarian.yaml` for matching gem components upon release.
- **Extending `RubyYoshi`**: `RubyLibrarian` extends `RubyYoshi` (rather than standard `Ruby`) because repositories like `google-cloud-ruby` configure gems with `"release-type": "ruby-yoshi"` (see [`google-cloud-ruby/release-please-config.json#L8`](https://github.com/googleapis/google-cloud-ruby/blob/cbfa331069c1416def7bfd6a58612c977a67d23a/release-please-config.json#L8)). Extending `RubyYoshi` ensures that standard Google Cloud Ruby release note formatting, commit indentation, and changelog section filtering are preserved.

Fixes https://github.com/googleapis/librarian/issues/7046