### PR TITLE
feat: add PHPLibrarian strategy

### DIFF
--- a/__snapshots__/cli.js
+++ b/__snapshots__/cli.js
@@ -52,9 +52,9 @@ Options:
               [choices: "bazel", "dart", "dotnet-yoshi", "elixir", "expo", "go",
         "go-librarian", "go-yoshi", "helm", "java", "java-backport", "java-bom",
      "java-lts", "java-yoshi", "java-yoshi-mono-repo", "krm-blueprint", "maven",
-                "node", "node-librarian", "ocaml", "php", "php-yoshi", "python",
-        "python-librarian", "r", "ruby", "ruby-librarian", "ruby-yoshi", "rust",
-                             "salesforce", "sfdx", "simple", "terraform-module"]
+         "node", "node-librarian", "ocaml", "php", "php-librarian", "php-yoshi",
+      "python", "python-librarian", "r", "ruby", "ruby-librarian", "ruby-yoshi",
+                     "rust", "salesforce", "sfdx", "simple", "terraform-module"]
   --config-file                 where can the config file be found in the
                                 project? [default: "release-please-config.json"]
   --manifest-file               where can the manifest file be found in the
@@ -280,9 +280,9 @@ Options:
               [choices: "bazel", "dart", "dotnet-yoshi", "elixir", "expo", "go",
         "go-librarian", "go-yoshi", "helm", "java", "java-backport", "java-bom",
      "java-lts", "java-yoshi", "java-yoshi-mono-repo", "krm-blueprint", "maven",
-                "node", "node-librarian", "ocaml", "php", "php-yoshi", "python",
-        "python-librarian", "r", "ruby", "ruby-librarian", "ruby-yoshi", "rust",
-                             "salesforce", "sfdx", "simple", "terraform-module"]
+         "node", "node-librarian", "ocaml", "php", "php-librarian", "php-yoshi",
+      "python", "python-librarian", "r", "ruby", "ruby-librarian", "ruby-yoshi",
+                     "rust", "salesforce", "sfdx", "simple", "terraform-module"]
   --config-file                     where can the config file be found in the
                                     project?
                                          [default: "release-please-config.json"]

--- a/src/factory.ts
+++ b/src/factory.ts
@@ -37,6 +37,7 @@ import {NodeLibrarian} from './strategies/node-librarian';
 import {OCaml} from './strategies/ocaml';
 import {PHP} from './strategies/php';
 import {PHPYoshi} from './strategies/php-yoshi';
+import {PHPLibrarian} from './strategies/php-librarian';
 import {Python} from './strategies/python';
 import {PythonLibrarian} from './strategies/python-librarian';
 import {R} from './strategies/r';
@@ -104,6 +105,7 @@ const releasers: Record<string, ReleaseBuilder> = {
   ocaml: options => new OCaml(options),
   php: options => new PHP(options),
   'php-yoshi': options => new PHPYoshi(options),
+  'php-librarian': options => new PHPLibrarian(options),
   python: options => new Python(options),
   'python-librarian': options => new PythonLibrarian(options),
   r: options => new R(options),

--- a/src/strategies/php-librarian.ts
+++ b/src/strategies/php-librarian.ts
@@ -1,0 +1,38 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import {PHPYoshi} from './php-yoshi';
+import {BuildUpdatesOptions} from './base';
+import {Update} from '../update';
+import {LibrarianYamlUpdater} from '../updaters/librarian-yaml';
+
+export class PHPLibrarian extends PHPYoshi {
+  protected async buildUpdates(
+    options: BuildUpdatesOptions
+  ): Promise<Update[]> {
+    const updates = await super.buildUpdates(options);
+
+    // Update librarian.yaml if this package exists within it.
+    updates.push({
+      path: 'librarian.yaml',
+      createIfMissing: false,
+      updater: new LibrarianYamlUpdater({
+        version: options.newVersion,
+        packagePath: this.path,
+      }),
+    });
+
+    return updates;
+  }
+}

--- a/test/strategies/php-librarian.ts
+++ b/test/strategies/php-librarian.ts
@@ -1,0 +1,132 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import {describe, it, afterEach, beforeEach} from 'mocha';
+import {expect} from 'chai';
+import {GitHub} from '../../src/github';
+import {PHPLibrarian} from '../../src/strategies/php-librarian';
+import * as sinon from 'sinon';
+import {assertHasUpdate, buildMockConventionalCommit} from '../helpers';
+import {Changelog} from '../../src/updaters/changelog';
+import {RootComposerUpdatePackages} from '../../src/updaters/php/root-composer-update-packages';
+import {DefaultUpdater} from '../../src/updaters/default';
+import {LibrarianYamlUpdater} from '../../src/updaters/librarian-yaml';
+import {Update} from '../../src/update';
+
+const sandbox = sinon.createSandbox();
+
+const COMMITS = [
+  ...buildMockConventionalCommit('fix: resolve issue in php client'),
+];
+
+describe('PHPLibrarian', () => {
+  let github: GitHub;
+  beforeEach(async () => {
+    github = await GitHub.create({
+      owner: 'googleapis',
+      repo: 'php-test-repo',
+      defaultBranch: 'main',
+    });
+  });
+  afterEach(() => {
+    sandbox.restore();
+  });
+
+  describe('buildReleasePullRequest', () => {
+    it('returns release PR changes with defaultInitialVersion', async () => {
+      const expectedVersion = '1.0.0';
+      const strategy = new PHPLibrarian({
+        targetBranch: 'main',
+        github,
+        component: 'google-cloud-asset',
+      });
+      const latestRelease = undefined;
+      const release = await strategy.buildReleasePullRequest(
+        COMMITS,
+        latestRelease
+      );
+      expect(release!.version?.toString()).to.eql(expectedVersion);
+    });
+  });
+
+  describe('buildUpdates', () => {
+    it('builds common php-yoshi files and appends librarian.yaml correctly', async () => {
+      const strategy = new PHPLibrarian({
+        targetBranch: 'main',
+        github,
+        component: 'google/cloud-asset',
+      });
+      const latestRelease = undefined;
+      const release = await strategy.buildReleasePullRequest(
+        COMMITS,
+        latestRelease
+      );
+      const updates = release!.updates;
+
+      // Verify standard php-yoshi updates (inherited from PHPYoshi strategy)
+      assertHasUpdate(updates, 'CHANGELOG.md', Changelog);
+      assertHasUpdate(updates, 'VERSION', DefaultUpdater);
+      assertHasUpdate(updates, 'composer.json', RootComposerUpdatePackages);
+
+      // Verify librarian.yaml is correctly registered as an update
+      const update = assertHasUpdate(
+        updates,
+        'librarian.yaml',
+        LibrarianYamlUpdater
+      );
+      expect(update.createIfMissing).to.be.false;
+
+      // Verify updater is correctly configured
+      const updater = update.updater as LibrarianYamlUpdater;
+      expect(updater.version?.toString()).to.eql('1.0.0');
+      expect((updater as any).packagePath).to.eql('.');
+    });
+
+    it('integration: LibrarianYamlUpdater updates librarian.yaml with new version for matching php component', async () => {
+      const strategy = new PHPLibrarian({
+        targetBranch: 'main',
+        github,
+        component: 'google/cloud-asset',
+        path: 'Asset',
+      });
+      const latestRelease = undefined;
+      const release = await strategy.buildReleasePullRequest(
+        COMMITS,
+        latestRelease
+      );
+      const updates = release!.updates;
+      const librarianUpdate = updates.find(
+        (u: Update) => u.path === 'librarian.yaml'
+      );
+      expect(librarianUpdate).to.not.be.undefined;
+
+      const originalYaml = `language: php
+libraries:
+  - name: Asset
+    version: 0.8.0
+  - name: AutoMl
+    version: 0.5.0
+`;
+      const expectedYaml = `language: php
+libraries:
+  - name: Asset
+    version: 1.0.0
+  - name: AutoMl
+    version: 0.5.0
+`;
+      const updatedYaml = librarianUpdate!.updater.updateContent(originalYaml);
+      expect(updatedYaml).to.equal(expectedYaml);
+    });
+  });
+});


### PR DESCRIPTION
Add `PHPLibrarian` strategy extending `PHPYoshi` to automatically update `librarian.yaml` during release PR creation, along with unit tests verifying update generation and content modifications.

For https://github.com/googleapis/librarian/issues/6670
