### PR TITLE
fix(commit): preserve author metadata in parseConventionalCommits

### DIFF
--- a/src/commit.ts
+++ b/src/commit.ts
@@ -431,6 +431,7 @@ export function parseConventionalCommits(
             message: parsedCommit.header,
             files: commit.files,
             pullRequest: commit.pullRequest,
+            author: commit.author,
             type: parsedCommit.type,
             scope: parsedCommit.scope,
             bareMessage: parsedCommit.subject,

--- a/test/commits.ts
+++ b/test/commits.ts
@@ -263,6 +263,21 @@ describe('parseConventionalCommits', () => {
     expect(commit.type).to.eql('chore');
   });
 
+  it('preserves author metadata when parsing commits', async () => {
+    const commit = buildMockCommit('feat: some feature');
+    commit.author = {
+      name: 'Jane Developer',
+      email: 'jane@example.com',
+      username: 'janedev',
+    };
+    const conventionalCommits = parseConventionalCommits([commit]);
+    expect(conventionalCommits).lengthOf(1);
+    expect(conventionalCommits[0].author).to.not.be.undefined;
+    expect(conventionalCommits[0].author!.name).to.equal('Jane Developer');
+    expect(conventionalCommits[0].author!.email).to.equal('jane@example.com');
+    expect(conventionalCommits[0].author!.username).to.equal('janedev');
+  });
+
   // it('ignores reverted commits', async () => {
   //   const commits = [
   //     {sha: 'sha1', message: 'feat: some feature', files: ['path1/file1.txt']},


### PR DESCRIPTION
The `parseConventionalCommits()` function in `src/commit.ts` was dropping the `author` field when transforming `Commit` objects into `ConventionalCommit` objects. This caused author metadata to be lost before changelog rendering, even though the `include-commit-authors` config option was enabled and the GitHub API provided author data.

The fix adds `author: commit.author` to the object literal at line 434 where other fields like `sha`, `message`, `files`, and `pullRequest` are already being preserved. This ensures that author information flows through the entire pipeline from commit fetch to changelog generation.

A regression test was added to verify that author metadata (name, email, username) is correctly preserved when parsing conventional commits.

Fixes #2761
