### PR TITLE
chore: update js-yaml to 4.3.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3328,7 +3328,7 @@
     },
     "node_modules/js-yaml": {
       "version": "4.3.1",
-      "resolved": "https://us-npm.pkg.dev/artifact-foundry-prod/ah-3p-staging-npm/js-yaml/-/js-yaml-4.3.1.tgz",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.1.tgz",
       "integrity": "sha512-CY6crGq313MX8GkwvB7tzgp99vjQxY1++5y10/BKN/GUfHqWaOGQMNZkBvqSzsZKWk/ijwHlWzzkLulsGHhjWQ==",
       "funding": [
         {

--- a/package-lock.json
+++ b/package-lock.json
@@ -28,7 +28,7 @@
         "figures": "^3.0.0",
         "http-proxy-agent": "^7.0.0",
         "https-proxy-agent": "^7.0.0",
-        "js-yaml": "^4.3.0",
+        "js-yaml": "^4.3.1",
         "jsonpath-plus": "^10.0.0",
         "node-html-parser": "^6.0.0",
         "parse-github-repo-url": "^1.4.1",
@@ -3327,9 +3327,9 @@
       "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ=="
     },
     "node_modules/js-yaml": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.0.tgz",
-      "integrity": "sha512-1td788aAnnZ5qs7V2QIRl1owjtYpbKt749Y3xauqQgwIIGF/xXWz1wMTEBx5O3LK3lXLVuqXPdPxj2BoFHaW9Q==",
+      "version": "4.3.1",
+      "resolved": "https://us-npm.pkg.dev/artifact-foundry-prod/ah-3p-staging-npm/js-yaml/-/js-yaml-4.3.1.tgz",
+      "integrity": "sha512-CY6crGq313MX8GkwvB7tzgp99vjQxY1++5y10/BKN/GUfHqWaOGQMNZkBvqSzsZKWk/ijwHlWzzkLulsGHhjWQ==",
       "funding": [
         {
           "type": "github",

--- a/package.json
+++ b/package.json
@@ -86,7 +86,7 @@
     "figures": "^3.0.0",
     "http-proxy-agent": "^7.0.0",
     "https-proxy-agent": "^7.0.0",
-    "js-yaml": "^4.3.0",
+    "js-yaml": "^4.3.1",
     "jsonpath-plus": "^10.0.0",
     "node-html-parser": "^6.0.0",
     "parse-github-repo-url": "^1.4.1",
@@ -105,7 +105,7 @@
   "overrides": {
     "tmp": "^0.2.7",
     "serialize-javascript": "^7.0.5",
-    "js-yaml": "^4.3.0",
+    "js-yaml": "^4.3.1",
     "brace-expansion": "^5.0.8",
     "debug": "^4.3.4"
   }


### PR DESCRIPTION
Fixes https://github.com/googleapis/release-please/security/dependabot/103