### PR TITLE
fix: allow component-no-space in config schema

### DIFF
--- a/schemas/config.json
+++ b/schemas/config.json
@@ -501,6 +501,6 @@
     "snapshot-label": true,
     "initial-version": true,
     "exclude-paths": true,
-    "component-no-space": false
+    "component-no-space": true
   }
 }

--- a/test/schemas.ts
+++ b/test/schemas.ts
@@ -67,5 +67,35 @@ describe('schemas', () => {
       expect(error.instancePath).to.eql('');
       expect(error.params.additionalProperty).to.eql('extraField');
     });
+
+    it('accepts component-no-space as a boolean', () => {
+      for (const componentNoSpace of [undefined, false, true]) {
+        const config = {
+          packages: {
+            '.': {},
+          },
+          ...(componentNoSpace === undefined
+            ? {}
+            : {'component-no-space': componentNoSpace}),
+        };
+        expect(configValidator(config)).to.be.true;
+        expect(configValidator.errors).to.be.null;
+      }
+    });
+
+    it('rejects a non-boolean component-no-space', () => {
+      const config = {
+        packages: {
+          '.': {},
+        },
+        'component-no-space': 'true',
+      };
+      expect(configValidator(config)).to.be.false;
+      expect(configValidator.errors).lengthOf(1);
+      expect(configValidator.errors![0].instancePath).to.eql(
+        '/component-no-space'
+      );
+      expect(configValidator.errors![0].message).to.eql('must be boolean');
+    });
   });
 });


### PR DESCRIPTION
`component-no-space` is already declared as a boolean in `ReleaserConfigOptions`, but the root property allowlist marks it as `false`. As a result, otherwise valid top-level configurations are rejected by the published schema.

This allows the property at the root and adds schema tests for omitted, `false`, `true`, and invalid non-boolean values.

- [x] Make sure to open an issue as a [bug/issue](https://github.com/googleapis/release-please/issues/new/choose) before writing your code! That way we can discuss the change, evaluate designs, and agree on the general idea
- [x] Ensure the tests and linter pass
- [x] Code coverage does not decrease (if any source code was changed)
- [x] Appropriate docs were updated (the option is already documented)

Fixes #2471 🦕