### PR TITLE
fix: avoid re-triggering release PR updates when content and tree areunchanged

### DIFF
--- a/src/manifest.ts
+++ b/src/manifest.ts
@@ -1090,17 +1090,17 @@ export class Manifest {
     return newPullRequest;
   }
 
-  private normalizePullRequestBody(body: string): string {
-    return body.replace(/\r\n/g, '\n').trim();
+  private normalizePullRequestBody(body: string | undefined | null): string {
+    return (body ?? '').replace(/\r\n|\r/g, '\n').trim();
   }
 
   private isPullRequestUnchanged(
     existing: PullRequest,
     pullRequest: ReleasePullRequest
   ): boolean {
-    const existingBody = this.normalizePullRequestBody(existing.body || '');
+    const existingBody = this.normalizePullRequestBody(existing.body);
     const candidateBody = this.normalizePullRequestBody(
-      pullRequest.body.toString()
+      pullRequest.body?.toString()
     );
     return existingBody === candidateBody;
   }

--- a/src/manifest.ts
+++ b/src/manifest.ts
@@ -1089,10 +1089,26 @@ export class Manifest {
     return newPullRequest;
   }
 
+  /**
+   * Normalizes pull request body content by converting CRLF (\r\n) and CR (\r) line endings
+   * to standard LF (\n) and trimming leading/trailing whitespace. This prevents false-positive
+   * diffs caused by GitHub's markdown normalization during API round-trips.
+   *
+   * @param {string | undefined | null} body The raw pull request body text
+   * @returns {string} The normalized body string
+   */
   private normalizePullRequestBody(body: string | undefined | null): string {
     return (body ?? '').replace(/\r\n|\r/g, '\n').trim();
   }
 
+  /**
+   * Checks whether an existing pull request has identical release note content
+   * compared to a newly computed candidate release pull request.
+   *
+   * @param {PullRequest} existing The existing open or snoozed pull request
+   * @param {ReleasePullRequest} pullRequest The computed candidate pull request
+   * @returns {boolean} True if the normalized release note bodies are identical
+   */
   private isPullRequestUnchanged(
     existing: PullRequest,
     pullRequest: ReleasePullRequest

--- a/src/manifest.ts
+++ b/src/manifest.ts
@@ -328,7 +328,6 @@ export class Manifest {
   private bootstrapSha?: string;
   private lastReleaseSha?: string;
   private draft?: boolean;
-  private prerelease?: boolean;
   private draftPullRequest?: boolean;
   private groupPullRequestTitlePattern?: string;
   readonly releaseSearchDepth: number;
@@ -923,7 +922,7 @@ export class Manifest {
    *
    * @returns {PullRequest[]} Pull request numbers of release pull requests
    */
-  async createPullRequests(): Promise<(PullRequest | undefined)[]> {
+  async createPullRequests(): Promise<PullRequest[]> {
     const candidatePullRequests = await this.buildPullRequests();
     if (candidatePullRequests.length === 0) {
       return [];
@@ -967,7 +966,7 @@ export class Manifest {
       }
       const pullNumbers = await Promise.all(promises);
       // reject any pull numbers that were not created or updated
-      return pullNumbers.filter(number => !!number);
+      return pullNumbers.filter((pr): pr is PullRequest => !!pr);
     }
   }
 
@@ -1105,7 +1104,9 @@ export class Manifest {
     return existingBody === candidateBody;
   }
 
-  /// only update an existing pull request if it has release note changes
+  /**
+   * Only update an existing pull request if it has release note changes
+   */
   private async maybeUpdateExistingPullRequest(
     existing: PullRequest,
     pullRequest: ReleasePullRequest
@@ -1117,10 +1118,12 @@ export class Manifest {
       );
       return undefined;
     }
-    return await this.updateExistingPullRequest(existing, pullRequest);
+    return this.updateExistingPullRequest(existing, pullRequest);
   }
 
-  /// only update a snoozed pull request if it has release note changes
+  /**
+   * Only update a snoozed pull request if it has release note changes
+   */
   private async maybeUpdateSnoozedPullRequest(
     snoozed: PullRequest,
     pullRequest: ReleasePullRequest
@@ -1141,7 +1144,9 @@ export class Manifest {
     return updatedPullRequest;
   }
 
-  /// force an update to an existing pull request
+  /**
+   * Force an update to an existing pull request
+   */
   private async updateExistingPullRequest(
     existing: PullRequest,
     pullRequest: ReleasePullRequest
@@ -1199,7 +1204,7 @@ export class Manifest {
     const strategiesByPath = await this.getStrategiesByPath();
 
     // Find merged release pull requests
-    const generator = await this.findMergedReleasePullRequests();
+    const generator = this.findMergedReleasePullRequests();
     const candidateReleases: CandidateRelease[] = [];
     for await (const pullRequest of generator) {
       for (const path in this.repositoryConfig) {

--- a/src/manifest.ts
+++ b/src/manifest.ts
@@ -1090,13 +1090,28 @@ export class Manifest {
     return newPullRequest;
   }
 
+  private normalizePullRequestBody(body: string): string {
+    return body.replace(/\r\n/g, '\n').trim();
+  }
+
+  private isPullRequestUnchanged(
+    existing: PullRequest,
+    pullRequest: ReleasePullRequest
+  ): boolean {
+    const existingBody = this.normalizePullRequestBody(existing.body || '');
+    const candidateBody = this.normalizePullRequestBody(
+      pullRequest.body.toString()
+    );
+    return existingBody === candidateBody;
+  }
+
   /// only update an existing pull request if it has release note changes
   private async maybeUpdateExistingPullRequest(
     existing: PullRequest,
     pullRequest: ReleasePullRequest
   ): Promise<PullRequest | undefined> {
     // If unchanged, no need to push updates
-    if (existing.body === pullRequest.body.toString()) {
+    if (this.isPullRequestUnchanged(existing, pullRequest)) {
       this.logger.info(
         `PR https://github.com/${this.repository.owner}/${this.repository.repo}/pull/${existing.number} remained the same`
       );
@@ -1111,7 +1126,7 @@ export class Manifest {
     pullRequest: ReleasePullRequest
   ): Promise<PullRequest | undefined> {
     // If unchanged, no need to push updates
-    if (snoozed.body === pullRequest.body.toString()) {
+    if (this.isPullRequestUnchanged(snoozed, pullRequest)) {
       this.logger.info(
         `PR https://github.com/${this.repository.owner}/${this.repository.repo}/pull/${snoozed.number} remained the same`
       );

--- a/src/manifest.ts
+++ b/src/manifest.ts
@@ -1121,7 +1121,11 @@ export class Manifest {
   }
 
   /**
-   * Only update an existing pull request if it has release note changes
+   * Only update an existing pull request if it has release note changes.
+   *
+   * @param {PullRequest} existing The existing open release pull request
+   * @param {ReleasePullRequest} pullRequest The newly computed candidate pull request
+   * @returns {Promise<PullRequest | undefined>} The updated pull request, or undefined if skipped
    */
   private async maybeUpdateExistingPullRequest(
     existing: PullRequest,
@@ -1138,7 +1142,12 @@ export class Manifest {
   }
 
   /**
-   * Only update a snoozed pull request if it has release note changes
+   * Only update a snoozed pull request if it has release note changes.
+   * If updated, the snooze label is removed.
+   *
+   * @param {PullRequest} snoozed The existing snoozed release pull request
+   * @param {ReleasePullRequest} pullRequest The newly computed candidate pull request
+   * @returns {Promise<PullRequest | undefined>} The updated pull request, or undefined if skipped
    */
   private async maybeUpdateSnoozedPullRequest(
     snoozed: PullRequest,
@@ -1161,7 +1170,11 @@ export class Manifest {
   }
 
   /**
-   * Force an update to an existing pull request
+   * Force an update to an existing pull request.
+   *
+   * @param {PullRequest} existing The existing pull request
+   * @param {ReleasePullRequest} pullRequest The updated release pull request data
+   * @returns {Promise<PullRequest>} The updated pull request
    */
   private async updateExistingPullRequest(
     existing: PullRequest,
@@ -1179,6 +1192,11 @@ export class Manifest {
     );
   }
 
+  /**
+   * Generator that yields merged release pull requests on the target branch.
+   *
+   * @yields {PullRequest} Merged release pull requests matching release labels
+   */
   private async *findMergedReleasePullRequests() {
     // Find merged release pull requests
     const pullRequestGenerator = this.github.pullRequestIterator(

--- a/src/util/code-suggester/github/commit-and-push.ts
+++ b/src/util/code-suggester/github/commit-and-push.ts
@@ -105,7 +105,8 @@ export async function createTree(
     );
     return treeSha;
   } catch (e) {
-    throw new CommitError(`Error adding to tree: ${refHead}`, e as Error);
+    const cause = e instanceof Error ? e : new Error(String(e));
+    throw new CommitError(`Error adding to tree: ${refHead}`, cause);
   }
 }
 
@@ -135,14 +136,15 @@ export async function updateRef(
     });
     logger.info(`Successfully updated reference ${origin.branch} to ${newSha}`);
   } catch (e) {
+    const cause = e instanceof Error ? e : new Error(String(e));
     throw new CommitError(
       `Error updating ref heads/${origin.branch} to ${newSha}`,
-      e as Error
+      cause
     );
   }
 }
 
-interface CommitAndPushOptions extends CreateCommitOptions {
+export interface CommitAndPushOptions extends CreateCommitOptions {
   filesPerCommit?: number;
 }
 
@@ -152,10 +154,10 @@ interface CommitAndPushOptions extends CreateCommitOptions {
  * @param {Octokit} octokit The authenticated octokit instance
  * @param {string} refHead the base of the new commit(s)
  * @param {Changes} changes the set of repository changes
- * @param {RepoDomain} origin the the remote repository to push changes to
- * @param {string} originBranchName the remote branch that will contain the new changes
+ * @param {BranchDomain} originBranch the remote branch that will contain the new changes
  * @param {string} commitMessage the message of the new commit
  * @param {boolean} force to force the commit changes given refHead
+ * @param {CommitAndPushOptions} [options] commit and push options
  * @returns {Promise<void>}
  * @throws {CommitError}
  */
@@ -167,7 +169,12 @@ export async function commitAndPush(
   commitMessage: string,
   force: boolean,
   options?: CommitAndPushOptions
-) {
+): Promise<void> {
+  if (changes.size === 0) {
+    logger.info('No changes to commit. Skipping.');
+    return;
+  }
+
   const filesPerCommit = options?.filesPerCommit ?? DEFAULT_FILES_PER_COMMIT;
   const tree = generateTreeObjects(changes);
   let finalTreeSha = '';
@@ -202,8 +209,13 @@ export async function commitAndPush(
         return;
       }
     }
-  } catch (err) {
-    logger.debug(`Could not check existing branch tree: ${err}`);
+  } catch (err: unknown) {
+    const status = (err as {status?: number})?.status;
+    if (status === 404) {
+      logger.debug(`Branch heads/${originBranch.branch} does not exist yet.`);
+    } else {
+      logger.debug(`Could not check existing branch tree: ${err}`);
+    }
   }
 
   await updateRef(octokit, originBranch, refHead, force);

--- a/src/util/code-suggester/github/commit-and-push.ts
+++ b/src/util/code-suggester/github/commit-and-push.ts
@@ -170,16 +170,41 @@ export async function commitAndPush(
 ) {
   const filesPerCommit = options?.filesPerCommit ?? DEFAULT_FILES_PER_COMMIT;
   const tree = generateTreeObjects(changes);
+  let finalTreeSha = '';
   for (const treeGroup of inGroupsOf(tree, filesPerCommit)) {
-    const treeSha = await createTree(octokit, originBranch, refHead, treeGroup);
+    finalTreeSha = await createTree(octokit, originBranch, refHead, treeGroup);
     refHead = await createCommit(
       octokit,
       originBranch,
       refHead,
-      treeSha,
+      finalTreeSha,
       commitMessage,
       options
     );
   }
+
+  try {
+    const existingRef = await octokit.git.getRef({
+      owner: originBranch.owner,
+      repo: originBranch.repo,
+      ref: `heads/${originBranch.branch}`,
+    });
+    if (existingRef?.data?.object?.sha) {
+      const existingCommit = await octokit.git.getCommit({
+        owner: originBranch.owner,
+        repo: originBranch.repo,
+        commit_sha: existingRef.data.object.sha,
+      });
+      if (existingCommit?.data?.tree?.sha === finalTreeSha) {
+        logger.info(
+          `Branch ${originBranch.branch} tree is already identical to ${finalTreeSha}. Skipping ref update.`
+        );
+        return;
+      }
+    }
+  } catch (err) {
+    logger.debug(`Could not check existing branch tree: ${err}`);
+  }
+
   await updateRef(octokit, originBranch, refHead, force);
 }

--- a/test/commit-and-push.ts
+++ b/test/commit-and-push.ts
@@ -503,4 +503,57 @@ describe('Commit and push function', async () => {
     sinon.assert.calledTwice(createCommitStub);
     sinon.assert.calledOnce(updateRefStub);
   });
+
+  it('skips updateRef when the existing branch already has the exact same tree SHA', async () => {
+    changes.set('foo.txt', {
+      mode: '100755',
+      content: 'some file content',
+    });
+    sandbox
+      .stub(octokit.git, 'getCommit')
+      .onFirstCall()
+      .resolves(getCommitResponse)
+      .onSecondCall()
+      .resolves({
+        headers: {},
+        status: 200,
+        url: 'http://fake-url.com',
+        data: {
+          ...commitResponseData,
+          tree: {
+            sha: createTreeResponseData.sha,
+            url: 'http://fake-url.com',
+          },
+        },
+      } as unknown as GetCommitResponse);
+    sandbox.stub(octokit.git, 'createTree').resolves(createTreeResponse);
+    sandbox.stub(octokit.git, 'createCommit').resolves(createCommitResponse);
+    sandbox.stub(octokit.git, 'getRef').resolves({
+      headers: {},
+      status: 200,
+      url: 'http://fake-url.com',
+      data: {
+        ref: 'refs/heads/test-branch-name',
+        node_id: 'MDM6UmVmMTI=',
+        url: 'http://fake-url.com',
+        object: {
+          sha: 'existing-branch-head-sha',
+          type: 'commit',
+          url: 'http://fake-url.com',
+        },
+      },
+    } as any);
+    const stubUpdateRef = sandbox.stub(octokit.git, 'updateRef');
+
+    await handler.commitAndPush(
+      octokit,
+      oldHeadSha,
+      changes,
+      {branch: branchName, ...origin},
+      message,
+      true
+    );
+
+    sinon.assert.notCalled(stubUpdateRef);
+  });
 });

--- a/test/commit-and-push.ts
+++ b/test/commit-and-push.ts
@@ -44,6 +44,10 @@ type CreateCommitResponse = GetResponseTypeFromEndpointMethod<
   typeof octokit.git.createCommit
 >;
 
+type GetRefResponse = GetResponseTypeFromEndpointMethod<
+  typeof octokit.git.getRef
+>;
+
 class FakeCommitSigner implements CommitSigner {
   signature: string;
   constructor(signature: string) {
@@ -299,6 +303,9 @@ describe('Commit and push function', async () => {
   afterEach(() => {
     sandbox.restore();
   });
+  beforeEach(() => {
+    changes.clear();
+  });
   it('When everything works it calls functions with correct parameter values', async () => {
     changes.set('foo.txt', {
       mode: '100755',
@@ -542,7 +549,7 @@ describe('Commit and push function', async () => {
           url: 'http://fake-url.com',
         },
       },
-    } as any);
+    } as unknown as GetRefResponse);
     const stubUpdateRef = sandbox.stub(octokit.git, 'updateRef');
 
     await handler.commitAndPush(
@@ -595,7 +602,7 @@ describe('Commit and push function', async () => {
           url: 'http://fake-url.com',
         },
       },
-    } as any);
+    } as unknown as GetRefResponse);
     const stubUpdateRef = sandbox.stub(octokit.git, 'updateRef');
 
     await handler.commitAndPush(
@@ -633,5 +640,26 @@ describe('Commit and push function', async () => {
     );
 
     sinon.assert.calledOnce(stubUpdateRef);
+  });
+
+  it('handles empty changes map without calling updateRef', async () => {
+    const stubGetCommit = sandbox.stub(octokit.git, 'getCommit');
+    const stubCreateTree = sandbox.stub(octokit.git, 'createTree');
+    const stubCreateCommit = sandbox.stub(octokit.git, 'createCommit');
+    const stubUpdateRef = sandbox.stub(octokit.git, 'updateRef');
+
+    await handler.commitAndPush(
+      octokit,
+      oldHeadSha,
+      new Map(),
+      {branch: branchName, ...origin},
+      message,
+      true
+    );
+
+    sinon.assert.notCalled(stubGetCommit);
+    sinon.assert.notCalled(stubCreateTree);
+    sinon.assert.notCalled(stubCreateCommit);
+    sinon.assert.notCalled(stubUpdateRef);
   });
 });

--- a/test/commit-and-push.ts
+++ b/test/commit-and-push.ts
@@ -556,4 +556,82 @@ describe('Commit and push function', async () => {
 
     sinon.assert.notCalled(stubUpdateRef);
   });
+
+  it('updates ref when existing branch has a different tree SHA', async () => {
+    changes.set('foo.txt', {
+      mode: '100755',
+      content: 'some file content',
+    });
+    sandbox
+      .stub(octokit.git, 'getCommit')
+      .onFirstCall()
+      .resolves(getCommitResponse)
+      .onSecondCall()
+      .resolves({
+        headers: {},
+        status: 200,
+        url: 'http://fake-url.com',
+        data: {
+          ...commitResponseData,
+          tree: {
+            sha: 'different-tree-sha',
+            url: 'http://fake-url.com',
+          },
+        },
+      } as unknown as GetCommitResponse);
+    sandbox.stub(octokit.git, 'createTree').resolves(createTreeResponse);
+    sandbox.stub(octokit.git, 'createCommit').resolves(createCommitResponse);
+    sandbox.stub(octokit.git, 'getRef').resolves({
+      headers: {},
+      status: 200,
+      url: 'http://fake-url.com',
+      data: {
+        ref: 'refs/heads/test-branch-name',
+        node_id: 'MDM6UmVmMTI=',
+        url: 'http://fake-url.com',
+        object: {
+          sha: 'existing-branch-head-sha',
+          type: 'commit',
+          url: 'http://fake-url.com',
+        },
+      },
+    } as any);
+    const stubUpdateRef = sandbox.stub(octokit.git, 'updateRef');
+
+    await handler.commitAndPush(
+      octokit,
+      oldHeadSha,
+      changes,
+      {branch: branchName, ...origin},
+      message,
+      true
+    );
+
+    sinon.assert.calledOnce(stubUpdateRef);
+  });
+
+  it('updates ref when getRef returns 404 (new branch)', async () => {
+    changes.set('foo.txt', {
+      mode: '100755',
+      content: 'some file content',
+    });
+    sandbox.stub(octokit.git, 'getCommit').resolves(getCommitResponse);
+    sandbox.stub(octokit.git, 'createTree').resolves(createTreeResponse);
+    sandbox.stub(octokit.git, 'createCommit').resolves(createCommitResponse);
+    sandbox
+      .stub(octokit.git, 'getRef')
+      .rejects(Object.assign(new Error('Not Found'), {status: 404}));
+    const stubUpdateRef = sandbox.stub(octokit.git, 'updateRef');
+
+    await handler.commitAndPush(
+      octokit,
+      oldHeadSha,
+      changes,
+      {branch: branchName, ...origin},
+      message,
+      true
+    );
+
+    sinon.assert.calledOnce(stubUpdateRef);
+  });
 });

--- a/test/manifest.ts
+++ b/test/manifest.ts
@@ -4281,10 +4281,19 @@ describe('Manifest', () => {
     });
 
     it('skips updating an existing pull request if the body only differs by line endings or whitespace', async () => {
-      const existingBody = pullRequestBody('release-notes/single-manifest.txt');
+      const body = new PullRequestBody(
+        [
+          {
+            component: 'pkg1',
+            version: Version.parse('1.0.0'),
+            notes: 'Some release notes',
+          },
+        ],
+        {useComponents: true}
+      );
       const existingBodyWithCRLF =
-        existingBody.replace(/\n/g, '\r\n') + '  \r\n';
-      const branchName = 'release-please--branches--main';
+        body.toString().replace(/\n/g, '\r\n') + '  \r\n';
+      const branchName = 'release-please/branches/main';
       mockPullRequests(
         github,
         [
@@ -4313,12 +4322,16 @@ describe('Manifest', () => {
         },
         {
           'path/a': Version.parse('1.0.0'),
+        },
+        {
+          separatePullRequests: true,
+          plugins: ['node-workspace'],
         }
       );
       sandbox.stub(manifest, 'buildPullRequests').resolves([
         {
           title: PullRequestTitle.ofTargetBranch('main'),
-          body: PullRequestBody.parse(existingBody)!,
+          body,
           updates: [],
           labels: [],
           headRefName: branchName,
@@ -4876,6 +4889,79 @@ describe('Manifest', () => {
       ]);
       const pullRequestNumbers = await manifest.createPullRequests();
       expect(pullRequestNumbers).lengthOf(0);
+    });
+
+    it('skips updating a snoozed pull request if the body only differs by line endings or whitespace', async () => {
+      const body = new PullRequestBody([
+        {
+          notes: '## 1.1.0\n\nSome release notes',
+        },
+      ]);
+      const existingBodyWithCRLF =
+        body.toString().replace(/\n/g, '\r\n') + '  \r\n';
+      sandbox
+        .stub(github, 'getFileContentsOnBranch')
+        .withArgs('README.md', 'main')
+        .resolves(buildGitHubFileRaw('some-content'));
+      mockPullRequests(
+        github,
+        [],
+        [],
+        [
+          {
+            number: 22,
+            title: 'pr title1',
+            body: existingBodyWithCRLF,
+            headBranchName: 'release-please/branches/main',
+            baseBranchName: 'main',
+            labels: ['autorelease: closed', 'autorelease: snooze'],
+            files: [],
+          },
+        ]
+      );
+      const manifest = new Manifest(
+        github,
+        'main',
+        {
+          'path/a': {
+            releaseType: 'node',
+            component: 'pkg1',
+          },
+        },
+        {
+          'path/a': Version.parse('1.0.0'),
+        },
+        {
+          separatePullRequests: true,
+          plugins: ['node-workspace'],
+        }
+      );
+      sandbox.stub(manifest, 'buildPullRequests').resolves([
+        {
+          title: PullRequestTitle.ofTargetBranch('main'),
+          body,
+          updates: [
+            {
+              path: 'README.md',
+              createIfMissing: false,
+              updater: new RawContent('some raw content'),
+            },
+          ],
+          labels: [],
+          headRefName: 'release-please/branches/main',
+          draft: false,
+        },
+      ]);
+      const removeLabelsStub = sandbox
+        .stub(github, 'removeIssueLabels')
+        .resolves();
+      const updatePullRequestStub = sandbox
+        .stub(github, 'updatePullRequest')
+        .resolves();
+      const pullRequestNumbers = await manifest.createPullRequests();
+      expect(pullRequestNumbers).lengthOf(0);
+      sinon.assert.notCalled(removeLabelsStub);
+      sinon.assert.notCalled(updatePullRequestStub);
     });
   });
 

--- a/test/manifest.ts
+++ b/test/manifest.ts
@@ -4280,6 +4280,57 @@ describe('Manifest', () => {
       expect(pullRequestNumbers).lengthOf(1);
     });
 
+    it('skips updating an existing pull request if the body only differs by line endings or whitespace', async () => {
+      const existingBody = pullRequestBody('release-notes/single-manifest.txt');
+      const existingBodyWithCRLF =
+        existingBody.replace(/\n/g, '\r\n') + '  \r\n';
+      const branchName = 'release-please--branches--main';
+      mockPullRequests(
+        github,
+        [
+          {
+            number: 22,
+            title: 'chore: release main',
+            body: existingBodyWithCRLF,
+            headBranchName: branchName,
+            baseBranchName: 'main',
+            labels: ['autorelease: pending'],
+            files: [],
+          },
+        ],
+        []
+      );
+      const updatePullRequestStub = sandbox.stub(github, 'updatePullRequest');
+      const createPullRequestStub = sandbox.stub(github, 'createPullRequest');
+      const manifest = new Manifest(
+        github,
+        'main',
+        {
+          'path/a': {
+            releaseType: 'node',
+            component: 'pkg1',
+          },
+        },
+        {
+          'path/a': Version.parse('1.0.0'),
+        }
+      );
+      sandbox.stub(manifest, 'buildPullRequests').resolves([
+        {
+          title: PullRequestTitle.ofTargetBranch('main'),
+          body: PullRequestBody.parse(existingBody)!,
+          updates: [],
+          labels: [],
+          headRefName: branchName,
+          draft: false,
+        },
+      ]);
+      const pullRequestNumbers = await manifest.createPullRequests();
+      expect(pullRequestNumbers).lengthOf(0);
+      sinon.assert.notCalled(updatePullRequestStub);
+      sinon.assert.notCalled(createPullRequestStub);
+    });
+
     describe('with an overflowing body', () => {
       const body = new PullRequestBody(mockReleaseData(1000), {
         useComponents: true,


### PR DESCRIPTION

- Normalize line endings (\r\n -> \n) and whitespace in Manifest.isPullRequestUnchanged when evaluating candidate release PR bodies against existing PRs.
- In code-suggester's commitAndPush, verify if the remote branch HEAD already points to the exact same git tree SHA before executing updateRef.


Fixes #2881
