### PR TITLE
fix: tolerate <details> blocks without a summary when re-parsing release pull request bodies

### DIFF
--- a/src/util/pull-request-body.ts
+++ b/src/util/pull-request-body.ts
@@ -126,7 +126,17 @@ function extractMultipleReleases(notes: string, logger: Logger): ReleaseData[] {
   const root = parse(notes);
   for (const detail of root.getElementsByTagName('details')) {
     const summaryNode = detail.getElementsByTagName('summary')[0];
-    const summary = summaryNode?.textContent;
+    if (!summaryNode) {
+      // A commit subject can legitimately contain a token like
+      // `<details>` inside an inline code span. The HTML parser does not
+      // understand markdown, so it sees that text as a real element.
+      // Skip it and let the caller fall back to single-release parsing.
+      logger.warn(
+        'found a <details> block without a <summary>, skipping it - the release notes may contain raw HTML from commit subjects'
+      );
+      continue;
+    }
+    const summary = summaryNode.textContent;
     const match = summary.match(SUMMARY_PATTERN);
     if (match?.groups) {
       detail.removeChild(summaryNode);

--- a/test/util/pull-request-body.ts
+++ b/test/util/pull-request-body.ts
@@ -135,6 +135,50 @@ describe('PullRequestBody', () => {
       expect(releaseData[0].version?.toString()).to.eql('0.1.0');
       expect(releaseData[0].notes).matches(/initial generation/);
     });
+
+    // A commit subject can contain a token like `<details>` inside an
+    // inline code span. The HTML parser does not understand markdown, so
+    // the release notes end up containing what looks like a real
+    // `<details>` element without a `<summary>`.
+    // https://github.com/googleapis/release-please/issues/2801
+    it('should tolerate a <details> element missing a <summary>', () => {
+      const body = [
+        ':robot: I have created a release *beep* *boop*',
+        '---',
+        '',
+        '',
+        '## [1.2.3](https://github.com/googleapis/release-please/compare/v1.2.2...v1.2.3) (2026-08-22)',
+        '',
+        '',
+        '### Bug Fixes',
+        '',
+        '* escape an unbalanced `<details>` tag instead of refusing the draft ([#133](https://github.com/googleapis/release-please/issues/133))',
+        '',
+        '---',
+        'This PR was generated with [Release Please](https://github.com/googleapis/release-please). See [documentation](https://github.com/googleapis/release-please#release-please).',
+      ].join('\n');
+      const pullRequestBody = PullRequestBody.parse(body);
+      expect(pullRequestBody).to.not.be.undefined;
+      const releaseData = pullRequestBody!.releaseData;
+      expect(releaseData).lengthOf(1);
+      expect(releaseData[0].version?.toString()).to.eql('1.2.3');
+      expect(releaseData[0].notes).matches(/unbalanced/);
+    });
+
+    it('should keep parsing valid components around a <details> element missing a <summary>', () => {
+      const body = readFileSync(
+        resolve(fixturesPath, './multiple.txt'),
+        'utf8'
+      );
+      // Inject a stray, summary-less <details> block before the valid ones.
+      const poisoned = body.replace(
+        '<details>',
+        '<details>\nchore: mention `</details>` handling\n</details>\n<details>'
+      );
+      const pullRequestBody = PullRequestBody.parse(poisoned);
+      expect(pullRequestBody).to.not.be.undefined;
+      expect(pullRequestBody!.releaseData.length).to.be.greaterThan(0);
+    });
   });
   describe('toString', () => {
     it('can handle multiple entries', () => {


### PR DESCRIPTION
Thank you for opening a Pull Request! Before submitting your PR, there are a few things you can do to make sure it goes smoothly:
- [x] Make sure to open an issue as a [bug/issue](https://github.com/googleapis/release-please/issues/new/choose) before writing your code!  That way we can discuss the change, evaluate designs, and agree on the general idea
- [x] Ensure the tests and linter pass
- [x] Code coverage does not decrease (if any source code was changed)
- [ ] Appropriate docs were updated (if necessary)

Fixes #2884 🦕

---

### Problem

`extractMultipleReleases()` re-parses release pull request bodies with `node-html-parser`. A commit subject may legitimately contain a token like `` `<details>` `` inside an inline code span (which `htmlEscape()` intentionally leaves untouched, see #2801). The HTML parser does not understand markdown, so that token becomes a real `<details>` element **without** a `<summary>` child, and the current code dereferences it unconditionally:

```ts
const summaryNode = detail.getElementsByTagName('summary')[0];
const summary = summaryNode?.textContent;
const match = summary.match(SUMMARY_PATTERN); // TypeError when no <summary>
```

This hard-crashes every subsequent `release-please` run (`Cannot read properties of undefined (reading 'match')`) until someone merges or manually edits the open release pull request. Reproduction and full stack trace in #2884; observed in the wild on 17.6.0 and verified still present in 17.11.1.

### Fix

Skip `<details>` blocks that have no `<summary>`, with a warning:

```ts
const summaryNode = detail.getElementsByTagName('summary')[0];
if (!summaryNode) {
  logger.warn(
    'found a <details> block without a <summary>, skipping it - ...'
  );
  continue;
}
```

Generated blocks always carry a `<summary>`, so real multi-component parsing is unchanged. For single-package bodies containing such a stray token, extraction now correctly falls back to the existing single-release path instead of throwing.

### Tests

- `should tolerate a <details> element missing a <summary>` - a body whose changelog bullet contains a backticked `<details>` token parses to one release via the fallback path (previously crashed with exactly the reported `TypeError`)
- `should keep parsing valid components around a <details> element missing a <summary>` - injecting a stray summary-less block into the multi-component fixture still yields all valid components
- Full suite: 1211 passing, `gts check` clean, coverage not decreased