### PR TITLE
fix: ignore git submodules during tree traversal to prevent 422 errors

### DIFF
--- a/src/github.ts
+++ b/src/github.ts
@@ -34,8 +34,8 @@ import {Release} from './release';
 import {ROOT_PROJECT_PATH} from './manifest';
 import {GitHubApi, GitHubCreateOptions} from './github-api';
 import {signoffCommitMessage} from './util/signoff-commit-message';
+import {RepositoryFileCache} from './util/file-cache';
 import {
-  RepositoryFileCache,
   GitHubFileContents,
   DEFAULT_FILE_MODE,
   FileNotFoundError as MissingFileError,
@@ -145,8 +145,12 @@ export class GitHub implements Scm {
     this.repository = options.repository;
     this.octokit = options.octokitAPIs.octokit;
     this.graphql = options.octokitAPIs.graphql;
-    this.fileCache = new RepositoryFileCache(this.octokit, this.repository);
     this.logger = options.logger ?? defaultLogger;
+    this.fileCache = new RepositoryFileCache(
+      this.octokit,
+      this.repository,
+      this.logger
+    );
     this.gitHubApi = new GitHubApi({
       repository: this.repository,
       octokitAPIs: options.octokitAPIs,
@@ -669,22 +673,7 @@ export class GitHub implements Scm {
       this.logger.debug(
         `finding files by filename: ${filename}, ref: ${ref}, prefix: ${prefix}`
       );
-      try {
-        return await this.fileCache.findFilesByFilename(filename, ref, prefix);
-      } catch (e) {
-        if (
-          e instanceof RequestError &&
-          (e.status === 404 || e.status === 422)
-        ) {
-          this.logger.warn(
-            `Failed to find files by filename ${filename} on ref ${ref}: ${
-              (e as Error).message
-            }`
-          );
-          return [];
-        }
-        throw e;
-      }
+      return await this.fileCache.findFilesByFilename(filename, ref, prefix);
     }
   );
 
@@ -726,22 +715,7 @@ export class GitHub implements Scm {
       this.logger.debug(
         `finding files by glob: ${glob}, ref: ${ref}, prefix: ${prefix}`
       );
-      try {
-        return await this.fileCache.findFilesByGlob(glob, ref, prefix);
-      } catch (e) {
-        if (
-          e instanceof RequestError &&
-          (e.status === 404 || e.status === 422)
-        ) {
-          this.logger.warn(
-            `Failed to find files by glob ${glob} on ref ${ref}: ${
-              (e as Error).message
-            }`
-          );
-          return [];
-        }
-        throw e;
-      }
+      return await this.fileCache.findFilesByGlob(glob, ref, prefix);
     }
   );
 
@@ -934,26 +908,10 @@ export class GitHub implements Scm {
       if (prefix) {
         prefix = normalizePrefix(prefix);
       }
-      try {
-        return await this.fileCache.findFilesByExtension(
-          extension,
-          ref,
-          prefix
-        );
-      } catch (e) {
-        if (
-          e instanceof RequestError &&
-          (e.status === 404 || e.status === 422)
-        ) {
-          this.logger.warn(
-            `Failed to find files by extension ${extension} on ref ${ref}: ${
-              (e as Error).message
-            }`
-          );
-          return [];
-        }
-        throw e;
-      }
+      this.logger.debug(
+        `finding files by extension: ${extension}, ref: ${ref}, prefix: ${prefix}`
+      );
+      return await this.fileCache.findFilesByExtension(extension, ref, prefix);
     }
   );
 

--- a/src/github.ts
+++ b/src/github.ts
@@ -612,6 +612,9 @@ export class GitHub implements Scm {
       if (e instanceof MissingFileError) {
         throw new FileNotFoundError(path);
       }
+      if (e instanceof RequestError && (e.status === 404 || e.status === 422)) {
+        throw new FileNotFoundError(path);
+      }
       throw e;
     }
   }
@@ -666,7 +669,22 @@ export class GitHub implements Scm {
       this.logger.debug(
         `finding files by filename: ${filename}, ref: ${ref}, prefix: ${prefix}`
       );
-      return await this.fileCache.findFilesByFilename(filename, ref, prefix);
+      try {
+        return await this.fileCache.findFilesByFilename(filename, ref, prefix);
+      } catch (e) {
+        if (
+          e instanceof RequestError &&
+          (e.status === 404 || e.status === 422)
+        ) {
+          this.logger.warn(
+            `Failed to find files by filename ${filename} on ref ${ref}: ${
+              (e as Error).message
+            }`
+          );
+          return [];
+        }
+        throw e;
+      }
     }
   );
 
@@ -708,7 +726,22 @@ export class GitHub implements Scm {
       this.logger.debug(
         `finding files by glob: ${glob}, ref: ${ref}, prefix: ${prefix}`
       );
-      return await this.fileCache.findFilesByGlob(glob, ref, prefix);
+      try {
+        return await this.fileCache.findFilesByGlob(glob, ref, prefix);
+      } catch (e) {
+        if (
+          e instanceof RequestError &&
+          (e.status === 404 || e.status === 422)
+        ) {
+          this.logger.warn(
+            `Failed to find files by glob ${glob} on ref ${ref}: ${
+              (e as Error).message
+            }`
+          );
+          return [];
+        }
+        throw e;
+      }
     }
   );
 
@@ -901,7 +934,26 @@ export class GitHub implements Scm {
       if (prefix) {
         prefix = normalizePrefix(prefix);
       }
-      return this.fileCache.findFilesByExtension(extension, ref, prefix);
+      try {
+        return await this.fileCache.findFilesByExtension(
+          extension,
+          ref,
+          prefix
+        );
+      } catch (e) {
+        if (
+          e instanceof RequestError &&
+          (e.status === 404 || e.status === 422)
+        ) {
+          this.logger.warn(
+            `Failed to find files by extension ${extension} on ref ${ref}: ${
+              (e as Error).message
+            }`
+          );
+          return [];
+        }
+        throw e;
+      }
     }
   );
 

--- a/src/local-github.ts
+++ b/src/local-github.ts
@@ -230,22 +230,56 @@ export class LocalGitHub implements Scm {
       `Fetching file contents for file ${path} on branch ${branch}`
     );
 
-    const ref = await this.ensureRef(branch);
-    const lsTreeResult = await execFile('git', ['ls-tree', ref, path], {
-      cwd: this.cloneDir,
-    });
+    let ref: string;
+    try {
+      ref = await this.ensureRef(branch);
+    } catch (err) {
+      this.logger.warn(
+        `Failed to resolve ref ${branch}: ${(err as Error).message}`
+      );
+      throw new FileNotFoundError(path);
+    }
+
+    let lsTreeResult;
+    try {
+      lsTreeResult = await execFile('git', ['ls-tree', ref, path], {
+        cwd: this.cloneDir,
+      });
+    } catch (err) {
+      this.logger.warn(
+        `Failed to ls-tree ${path} on ref ${ref}: ${(err as Error).message}`
+      );
+      throw new FileNotFoundError(path);
+    }
 
     if (!lsTreeResult.stdout.trim()) {
       throw new FileNotFoundError(path);
     }
 
-    const [info] = lsTreeResult.stdout.split('\t');
-    const [mode, , sha] = info.split(' ');
+    const firstLine = lsTreeResult.stdout.trim().split('\n')[0];
+    const [info] = firstLine.split('\t');
+    const [mode, type, sha] = info.split(' ');
 
-    const {stdout} = await execFile('git', ['show', `${ref}:${path}`], {
-      cwd: this.cloneDir,
-      maxBuffer: 100 * 1024 * 1024,
-    });
+    if (mode === '160000' || type === 'commit') {
+      this.logger.warn(
+        `Encountered git submodule/gitlink at ${path} on ref ${ref}, treating as not found`
+      );
+      throw new FileNotFoundError(path);
+    }
+
+    let stdout: string;
+    try {
+      const res = await execFile('git', ['show', `${ref}:${path}`], {
+        cwd: this.cloneDir,
+        maxBuffer: 100 * 1024 * 1024,
+      });
+      stdout = res.stdout;
+    } catch (err) {
+      this.logger.warn(
+        `Failed to show ${ref}:${path}: ${(err as Error).message}`
+      );
+      throw new FileNotFoundError(path);
+    }
 
     return {
       content: Buffer.from(stdout).toString('base64'),

--- a/src/local-github.ts
+++ b/src/local-github.ts
@@ -257,10 +257,12 @@ export class LocalGitHub implements Scm {
     }
 
     const firstLine = lsTreeResult.stdout.trim().split('\n')[0];
-    const [info] = firstLine.split('\t');
-    const [mode, type, sha] = info.split(' ');
+    const entry = parseLsTreeLine(firstLine);
+    if (!entry) {
+      throw new FileNotFoundError(path);
+    }
 
-    if (mode === '160000' || type === 'commit') {
+    if (entry.mode === '160000' || entry.type === 'commit') {
       this.logger.warn(
         `Encountered git submodule/gitlink at ${path} on ref ${ref}, treating as not found`
       );
@@ -284,8 +286,8 @@ export class LocalGitHub implements Scm {
     return {
       content: Buffer.from(stdout).toString('base64'),
       parsedContent: stdout,
-      sha,
-      mode,
+      sha: entry.sha,
+      mode: entry.mode,
     };
   }
 
@@ -347,18 +349,19 @@ export class LocalGitHub implements Scm {
 
     const resolvedRef = await this.ensureRef(ref);
     this.logger.trace(
-      `Executing stream: git ls-tree -r --name-only ${resolvedRef} ${treePath}`
+      `Executing stream: git ls-tree -r ${resolvedRef} ${treePath}`
     );
     const matchedPaths: string[] = [];
-    await this.execGitStream(
-      ['ls-tree', '-r', '--name-only', resolvedRef, treePath],
-      line => {
-        const trimmed = line.trim();
-        if (trimmed && path.posix.basename(trimmed) === filename) {
-          matchedPaths.push(trimmed);
-        }
+    await this.execGitStream(['ls-tree', '-r', resolvedRef, treePath], line => {
+      const entry = parseLsTreeLine(line);
+      if (!entry) return;
+      if (entry.mode === '160000' || entry.type === 'commit') {
+        return;
       }
-    );
+      if (path.posix.basename(entry.path) === filename) {
+        matchedPaths.push(entry.path);
+      }
+    });
 
     if (normalizedPrefix) {
       return matchedPaths
@@ -425,20 +428,19 @@ export class LocalGitHub implements Scm {
     const resolvedRef = await this.ensureRef(ref);
     const files: string[] = [];
     const dirs = new Set<string>();
-    await this.execGitStream(
-      ['ls-tree', '-r', '--name-only', resolvedRef, treePath],
-      line => {
-        const trimmed = line.trim();
-        if (trimmed) {
-          files.push(trimmed);
-          let dir = path.posix.dirname(trimmed);
-          while (dir !== '.' && dir !== '/') {
-            dirs.add(dir);
-            dir = path.posix.dirname(dir);
-          }
-        }
+    await this.execGitStream(['ls-tree', '-r', resolvedRef, treePath], line => {
+      const entry = parseLsTreeLine(line);
+      if (!entry) return;
+      if (entry.mode === '160000' || entry.type === 'commit') {
+        return;
       }
-    );
+      files.push(entry.path);
+      let dir = path.posix.dirname(entry.path);
+      while (dir !== '.' && dir !== '/') {
+        dirs.add(dir);
+        dir = path.posix.dirname(dir);
+      }
+    });
 
     const allPaths = [...files, ...dirs];
 
@@ -518,15 +520,16 @@ export class LocalGitHub implements Scm {
 
     const resolvedRef = await this.ensureRef(ref);
     const matchedPaths: string[] = [];
-    await this.execGitStream(
-      ['ls-tree', '-r', '--name-only', resolvedRef, treePath],
-      line => {
-        const trimmed = line.trim();
-        if (trimmed && trimmed.endsWith(`.${extension}`)) {
-          matchedPaths.push(trimmed);
-        }
+    await this.execGitStream(['ls-tree', '-r', resolvedRef, treePath], line => {
+      const entry = parseLsTreeLine(line);
+      if (!entry) return;
+      if (entry.mode === '160000' || entry.type === 'commit') {
+        return;
       }
-    );
+      if (entry.path.endsWith(`.${extension}`)) {
+        matchedPaths.push(entry.path);
+      }
+    });
 
     if (normalizedPrefix) {
       return matchedPaths
@@ -1027,4 +1030,22 @@ function globToRegex(glob: string): RegExp {
     i++;
   }
   return new RegExp(`^${reg}$`);
+}
+
+interface LsTreeEntry {
+  mode: string;
+  type: string;
+  sha: string;
+  path: string;
+}
+
+function parseLsTreeLine(line: string): LsTreeEntry | null {
+  const trimmed = line.trim();
+  if (!trimmed) return null;
+  const tabIndex = trimmed.indexOf('\t');
+  if (tabIndex === -1) return null;
+  const meta = trimmed.slice(0, tabIndex);
+  const filePath = trimmed.slice(tabIndex + 1);
+  const [mode, type, sha] = meta.split(/\s+/);
+  return {mode, type, sha, path: filePath};
 }

--- a/src/util/file-cache.ts
+++ b/src/util/file-cache.ts
@@ -1,0 +1,417 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import {Octokit} from '@octokit/rest';
+import {RequestError} from '@octokit/request-error';
+import * as path from 'path';
+/* eslint-disable-next-line node/no-extraneous-import */
+import {Minimatch} from 'minimatch';
+import {Repository} from '../repository';
+import {FileNotFoundError} from '../errors';
+import {Logger} from './code-suggester/types';
+import {
+  GitHubFileContents,
+  DEFAULT_FILE_MODE,
+} from '@google-automations/git-file-utils';
+import {ROOT_PROJECT_PATH} from '../manifest';
+
+type OctokitType = InstanceType<typeof Octokit>;
+
+export interface TreeEntry {
+  path?: string;
+  mode?: string;
+  type?: string;
+  sha?: string;
+  size?: number;
+  url?: string;
+}
+
+export interface TreeResponse {
+  tree: TreeEntry[];
+  truncated?: boolean;
+}
+
+export interface CachedTree {
+  tree: TreeEntry[];
+  recursive: boolean;
+}
+
+/**
+ * RepositoryFileCache is a read-through cache for GitHub file contents
+ * and directory trees across branches.
+ */
+export class RepositoryFileCache {
+  readonly octokit: OctokitType;
+  readonly repository: Repository;
+  private cache: Map<string, BranchFileCache>;
+  private logger?: Logger;
+
+  constructor(octokit: OctokitType, repository: Repository, logger?: Logger) {
+    this.octokit = octokit;
+    this.repository = repository;
+    this.cache = new Map();
+    this.logger = logger;
+  }
+
+  async getFileContents(
+    path: string,
+    branch: string
+  ): Promise<GitHubFileContents> {
+    const fileCache = this.getBranchFileCache(branch);
+    return await fileCache.getFileContents(path);
+  }
+
+  async findFilesByFilename(
+    filename: string,
+    branch: string,
+    pathPrefix?: string
+  ): Promise<string[]> {
+    const fileCache = this.getBranchFileCache(branch);
+    return await fileCache.findFilesByFilename(filename, pathPrefix);
+  }
+
+  async findFilesByExtension(
+    extension: string,
+    branch: string,
+    pathPrefix?: string
+  ): Promise<string[]> {
+    const fileCache = this.getBranchFileCache(branch);
+    return await fileCache.findFilesByExtension(extension, pathPrefix);
+  }
+
+  async findFilesByGlob(
+    glob: string,
+    branch: string,
+    pathPrefix?: string
+  ): Promise<string[]> {
+    const fileCache = this.getBranchFileCache(branch);
+    return await fileCache.findFilesByGlob(glob, pathPrefix);
+  }
+
+  getBranchFileCache(branch: string): BranchFileCache {
+    let fileCache = this.cache.get(branch);
+    if (!fileCache) {
+      fileCache = new BranchFileCache(
+        this.octokit,
+        this.repository,
+        branch,
+        this.logger
+      );
+      this.cache.set(branch, fileCache);
+    }
+    return fileCache;
+  }
+}
+
+/**
+ * BranchFileCache manages file and tree cache for a specific git branch or ref.
+ */
+export class BranchFileCache {
+  readonly octokit: OctokitType;
+  readonly repository: Repository;
+  readonly branch: string;
+  private cache: Map<string, GitHubFileContents>;
+  private treeCache: Map<string, CachedTree>;
+  private logger?: Logger;
+
+  constructor(
+    octokit: OctokitType,
+    repository: Repository,
+    branch: string,
+    logger?: Logger
+  ) {
+    this.octokit = octokit;
+    this.repository = repository;
+    this.branch = branch;
+    this.cache = new Map();
+    this.treeCache = new Map();
+    this.logger = logger;
+  }
+
+  async getFileContents(filePath: string): Promise<GitHubFileContents> {
+    const cached = this.cache.get(filePath);
+    if (cached) {
+      return cached;
+    }
+    const fetched = await this.fetchFileContents(filePath);
+    this.cache.set(filePath, fetched);
+    return fetched;
+  }
+
+  async findFilesByFilename(
+    filename: string,
+    pathPrefix?: string
+  ): Promise<string[]> {
+    const files: string[] = [];
+    const normalizedPrefix = pathPrefix
+      ? normalizePrefix(pathPrefix)
+      : undefined;
+    for await (const treeEntry of this.treeEntryIterator(
+      this.branch,
+      normalizedPrefix
+    )) {
+      if (path.posix.basename(treeEntry.path) === filename) {
+        files.push(treeEntry.path);
+      }
+    }
+    return stripPrefix(files, normalizedPrefix);
+  }
+
+  async findFilesByExtension(
+    extension: string,
+    pathPrefix?: string
+  ): Promise<string[]> {
+    const files: string[] = [];
+    const normalizedPrefix = pathPrefix
+      ? normalizePrefix(pathPrefix)
+      : undefined;
+    for await (const treeEntry of this.treeEntryIterator(
+      this.branch,
+      normalizedPrefix
+    )) {
+      if (path.posix.extname(treeEntry.path) === `.${extension}`) {
+        files.push(treeEntry.path);
+      }
+    }
+    return stripPrefix(files, normalizedPrefix);
+  }
+
+  async findFilesByGlob(glob: string, pathPrefix?: string): Promise<string[]> {
+    const files: string[] = [];
+    const normalizedPrefix = pathPrefix
+      ? normalizePrefix(pathPrefix)
+      : undefined;
+    const mm = new Minimatch(glob);
+    for await (const treeEntry of this.treeEntryIterator(
+      this.branch,
+      normalizedPrefix
+    )) {
+      if (mm.match(treeEntry.path)) {
+        files.push(treeEntry.path);
+      }
+    }
+    return stripPrefix(files, normalizedPrefix);
+  }
+
+  async fetchFileContents(filePath: string): Promise<GitHubFileContents> {
+    // Try to use the entire git tree if it's already available and recursive
+    const treeEntries = await this.getFullTree();
+    if (treeEntries) {
+      const found = treeEntries.find(entry => entry.path === filePath);
+      if (found?.sha) {
+        if (found.mode === '160000' || found.type === 'commit') {
+          this.logger?.warn?.(
+            `Encountered git submodule/gitlink at ${filePath}, treating as not found`
+          );
+          throw new FileNotFoundError(filePath);
+        }
+        return await this.fetchContents(found.sha, found);
+      }
+      throw new FileNotFoundError(filePath);
+    }
+
+    // Full tree was not recursive (e.g. 422 submodule or truncated), traverse down path parts
+    const parts = filePath.split('/');
+    let treeSha = this.branch;
+    let found: TreeEntry | undefined;
+    for (let i = 0; i < parts.length; i++) {
+      const part = parts[i];
+      const isLast = i === parts.length - 1;
+      const {tree} = await this.getTree(treeSha);
+      found = tree.find(item => item.path === part);
+      if (!found?.sha) {
+        throw new FileNotFoundError(filePath);
+      }
+      if (found.mode === '160000' || found.type === 'commit') {
+        this.logger?.warn?.(
+          `Encountered git submodule/gitlink at ${filePath}, treating as not found`
+        );
+        throw new FileNotFoundError(filePath);
+      }
+      if (!isLast && found.type !== 'tree') {
+        throw new FileNotFoundError(filePath);
+      }
+      treeSha = found.sha;
+    }
+    if (!found?.sha || found.mode === '160000' || found.type === 'commit') {
+      throw new FileNotFoundError(filePath);
+    }
+    return await this.fetchContents(found.sha, found);
+  }
+
+  async getFullTree(): Promise<TreeEntry[] | null> {
+    const cachedTree = await this.getTree(this.branch);
+    if (cachedTree.recursive) {
+      return cachedTree.tree;
+    }
+    return null;
+  }
+
+  async getTree(sha: string): Promise<CachedTree> {
+    const cached = this.treeCache.get(sha);
+    if (cached) {
+      return cached;
+    }
+    let fetched: TreeResponse;
+    let isRecursive = false;
+    try {
+      fetched = await this.fetchTree(sha, true);
+      if (!fetched.truncated) {
+        isRecursive = true;
+      } else {
+        fetched = await this.fetchTree(sha, false);
+        if (fetched.truncated) {
+          this.logger?.warn?.(
+            `non-recursive file list for tree ${sha} is truncated, this folder has too many files!`
+          );
+        }
+      }
+    } catch (err) {
+      if (err instanceof RequestError && err.status === 422) {
+        this.logger?.debug?.(
+          `Recursive tree fetch failed with 422 for ${sha}, falling back to non-recursive tree traversal`
+        );
+        fetched = await this.fetchTree(sha, false);
+        if (fetched.truncated) {
+          this.logger?.warn?.(
+            `non-recursive file list for tree ${sha} is truncated, this folder has too many files!`
+          );
+        }
+      } else {
+        throw err;
+      }
+    }
+
+    const cachedTree: CachedTree = {
+      tree: fetched.tree,
+      recursive: isRecursive,
+    };
+    this.treeCache.set(sha, cachedTree);
+    return cachedTree;
+  }
+
+  async fetchTree(sha: string, recursive: boolean): Promise<TreeResponse> {
+    try {
+      const {
+        data: {tree, truncated},
+      } = await this.octokit.git.getTree({
+        owner: this.repository.owner,
+        repo: this.repository.repo,
+        tree_sha: sha,
+        recursive: recursive ? 'true' : undefined,
+      });
+      return {
+        tree: tree as TreeEntry[],
+        truncated,
+      };
+    } catch (e) {
+      if (e instanceof RequestError && e.status === 409) {
+        return {
+          tree: [],
+          truncated: false,
+        };
+      }
+      throw e;
+    }
+  }
+
+  async *treeEntryIterator(
+    ref: string,
+    pathPrefix?: string
+  ): AsyncGenerator<TreeEntry & {path: string}> {
+    const treeShas: Array<{ref: string; path?: string}> = [{ref}];
+    let treeReference: {ref: string; path?: string} | undefined;
+    while ((treeReference = treeShas.shift())) {
+      const cachedTree = await this.getTree(treeReference.ref);
+      for (const treeEntry of cachedTree.tree) {
+        if (!treeEntry.path) continue;
+        const fullPath = treeReference.path
+          ? `${treeReference.path}/${treeEntry.path}`
+          : treeEntry.path;
+
+        // Skip submodule gitlink: mode 160000 or type commit
+        if (treeEntry.mode === '160000' || treeEntry.type === 'commit') {
+          continue;
+        }
+
+        if (!cachedTree.recursive && treeEntry.type === 'tree') {
+          if (
+            !pathPrefix ||
+            pathPrefix.startsWith(fullPath) ||
+            fullPath.startsWith(pathPrefix)
+          ) {
+            if (treeEntry.sha) {
+              treeShas.push({ref: treeEntry.sha, path: fullPath});
+            }
+          }
+          continue;
+        }
+
+        if (pathPrefix && !fullPath.startsWith(pathPrefix)) {
+          continue;
+        }
+
+        yield {
+          ...treeEntry,
+          path: fullPath,
+        };
+      }
+    }
+  }
+
+  async fetchContents(
+    blobSha: string,
+    treeEntry: TreeEntry
+  ): Promise<GitHubFileContents> {
+    const {
+      data: {content},
+    } = await this.octokit.git.getBlob({
+      owner: this.repository.owner,
+      repo: this.repository.repo,
+      file_sha: blobSha,
+    });
+    return {
+      sha: blobSha,
+      mode: treeEntry.mode || DEFAULT_FILE_MODE,
+      content,
+      parsedContent: Buffer.from(content, 'base64').toString('utf8'),
+    };
+  }
+}
+
+export function normalizePrefix(prefix: string): string {
+  const normalized = prefix.replace(/^[/\\]+/, '').replace(/[/\\]+$/, '');
+  if (normalized === ROOT_PROJECT_PATH || normalized === '.') {
+    return '';
+  }
+  return normalized;
+}
+
+function escapeRegex(str: string): string {
+  return str.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+}
+
+export function stripPrefix(files: string[], prefix?: string): string[] {
+  if (!prefix) {
+    return files;
+  }
+  const normalized = normalizePrefix(prefix);
+  if (!normalized) {
+    return files;
+  }
+  const prefixRegex = new RegExp(`^${escapeRegex(normalized)}[/\\\\]`);
+  return files
+    .filter(file => file.startsWith(`${normalized}/`))
+    .map(file => file.replace(prefixRegex, ''));
+}

--- a/test/github.ts
+++ b/test/github.ts
@@ -171,6 +171,28 @@ describe('GitHub', () => {
         expect(pomFiles).to.deep.equal(['pom.xml', 'foo/pom.xml']);
       });
     });
+
+    it('returns empty array when GitHub returns 422 (e.g. invalid object / submodule)', async () => {
+      req.get('/repos/fake/fake/git/trees/main?recursive=true').reply(422, {
+        message:
+          'Invalid object requested. SHA must identify a commit or a tree.',
+      });
+      const pomFiles = await github.findFilesByFilename('pom.xml');
+      expect(pomFiles).to.deep.equal([]);
+      req.done();
+    });
+  });
+
+  describe('findFilesByGlob', () => {
+    it('returns empty array when GitHub returns 422 (e.g. invalid object / submodule)', async () => {
+      req.get('/repos/fake/fake/git/trees/main?recursive=true').reply(422, {
+        message:
+          'Invalid object requested. SHA must identify a commit or a tree.',
+      });
+      const files = await github.findFilesByGlob('*.xml');
+      expect(files).to.deep.equal([]);
+      req.done();
+    });
   });
 
   describe('findFilesByExtension', () => {
@@ -183,6 +205,16 @@ describe('GitHub', () => {
         .reply(200, fileSearchResponse);
       const pomFiles = await github.findFilesByExtension('xml');
       snapshot(pomFiles);
+      req.done();
+    });
+
+    it('returns empty array when GitHub returns 422', async () => {
+      req.get('/repos/fake/fake/git/trees/main?recursive=true').reply(422, {
+        message:
+          'Invalid object requested. SHA must identify a commit or a tree.',
+      });
+      const pomFiles = await github.findFilesByExtension('xml');
+      expect(pomFiles).to.deep.equal([]);
       req.done();
     });
 
@@ -275,6 +307,19 @@ describe('GitHub', () => {
       await assert.rejects(async () => {
         await github.getFileContents('non-existent-file');
       }, FileNotFoundError);
+    });
+  });
+
+  describe('getFileContents on 422 tree response', () => {
+    it('should throw a missing file error when GitHub returns 422', async () => {
+      req.get('/repos/fake/fake/git/trees/main?recursive=true').reply(422, {
+        message:
+          'Invalid object requested. SHA must identify a commit or a tree.',
+      });
+      await assert.rejects(async () => {
+        await github.getFileContents('submodule-file');
+      }, FileNotFoundError);
+      req.done();
     });
   });
 

--- a/test/github.ts
+++ b/test/github.ts
@@ -172,25 +172,137 @@ describe('GitHub', () => {
       });
     });
 
-    it('returns empty array when GitHub returns 422 (e.g. invalid object / submodule)', async () => {
+    it('falls back to non-recursive tree traversal when 422 is returned and finds files across subtrees while ignoring submodules', async () => {
       req.get('/repos/fake/fake/git/trees/main?recursive=true').reply(422, {
         message:
           'Invalid object requested. SHA must identify a commit or a tree.',
       });
+      req.get('/repos/fake/fake/git/trees/main').reply(200, {
+        sha: 'main-tree-sha',
+        tree: [
+          {
+            path: 'pom.xml',
+            mode: '100644',
+            type: 'blob',
+            sha: 'pom-blob-sha',
+          },
+          {
+            path: 'submodule-crc32c',
+            mode: '160000',
+            type: 'commit',
+            sha: 'submodule-sha-12345',
+          },
+          {
+            path: 'packages',
+            mode: '040000',
+            type: 'tree',
+            sha: 'packages-tree-sha',
+          },
+        ],
+        truncated: false,
+      });
+      req
+        .get('/repos/fake/fake/git/trees/packages-tree-sha?recursive=true')
+        .reply(200, {
+          sha: 'packages-tree-sha',
+          tree: [
+            {
+              path: 'pkg/setup.py',
+              mode: '100644',
+              type: 'blob',
+              sha: 'setup-blob-sha',
+            },
+            {
+              path: 'pkg/pom.xml',
+              mode: '100644',
+              type: 'blob',
+              sha: 'pkg-pom-blob-sha',
+            },
+            {
+              path: 'pkg/submodule-nested',
+              mode: '160000',
+              type: 'commit',
+              sha: 'nested-submodule-sha',
+            },
+          ],
+          truncated: false,
+        });
       const pomFiles = await github.findFilesByFilename('pom.xml');
-      expect(pomFiles).to.deep.equal([]);
+      expect(pomFiles).to.deep.equal(['pom.xml', 'packages/pkg/pom.xml']);
+      req.done();
+    });
+
+    it('throws GitHubAPIError when tree request fails with 404 (e.g. invalid branch)', async () => {
+      req
+        .get('/repos/fake/fake/git/trees/invalid-branch?recursive=true')
+        .reply(404, {
+          message: 'Not Found',
+        });
+      await assert.rejects(async () => {
+        await github.findFilesByFilenameAndRef('pom.xml', 'invalid-branch');
+      }, GitHubAPIError);
       req.done();
     });
   });
 
   describe('findFilesByGlob', () => {
-    it('returns empty array when GitHub returns 422 (e.g. invalid object / submodule)', async () => {
+    it('falls back to non-recursive tree traversal when 422 is returned and finds files by glob while ignoring submodules', async () => {
       req.get('/repos/fake/fake/git/trees/main?recursive=true').reply(422, {
         message:
           'Invalid object requested. SHA must identify a commit or a tree.',
       });
-      const files = await github.findFilesByGlob('*.xml');
-      expect(files).to.deep.equal([]);
+      req.get('/repos/fake/fake/git/trees/main').reply(200, {
+        sha: 'main-tree-sha',
+        tree: [
+          {
+            path: 'pom.xml',
+            mode: '100644',
+            type: 'blob',
+            sha: 'pom-blob-sha',
+          },
+          {
+            path: 'submodule-crc32c',
+            mode: '160000',
+            type: 'commit',
+            sha: 'submodule-sha-12345',
+          },
+          {
+            path: 'packages',
+            mode: '040000',
+            type: 'tree',
+            sha: 'packages-tree-sha',
+          },
+        ],
+        truncated: false,
+      });
+      req
+        .get('/repos/fake/fake/git/trees/packages-tree-sha?recursive=true')
+        .reply(200, {
+          sha: 'packages-tree-sha',
+          tree: [
+            {
+              path: 'pkg/setup.py',
+              mode: '100644',
+              type: 'blob',
+              sha: 'setup-blob-sha',
+            },
+          ],
+          truncated: false,
+        });
+      const files = await github.findFilesByGlob('**/*.py');
+      expect(files).to.deep.equal(['packages/pkg/setup.py']);
+      req.done();
+    });
+
+    it('throws GitHubAPIError when tree request fails with 404', async () => {
+      req
+        .get('/repos/fake/fake/git/trees/invalid-branch?recursive=true')
+        .reply(404, {
+          message: 'Not Found',
+        });
+      await assert.rejects(async () => {
+        await github.findFilesByGlobAndRef('*.xml', 'invalid-branch');
+      }, GitHubAPIError);
       req.done();
     });
   });
@@ -208,13 +320,63 @@ describe('GitHub', () => {
       req.done();
     });
 
-    it('returns empty array when GitHub returns 422', async () => {
+    it('falls back to non-recursive tree traversal when 422 is returned and finds files by extension while ignoring submodules', async () => {
       req.get('/repos/fake/fake/git/trees/main?recursive=true').reply(422, {
         message:
           'Invalid object requested. SHA must identify a commit or a tree.',
       });
-      const pomFiles = await github.findFilesByExtension('xml');
-      expect(pomFiles).to.deep.equal([]);
+      req.get('/repos/fake/fake/git/trees/main').reply(200, {
+        sha: 'main-tree-sha',
+        tree: [
+          {
+            path: 'pom.xml',
+            mode: '100644',
+            type: 'blob',
+            sha: 'pom-blob-sha',
+          },
+          {
+            path: 'submodule-crc32c',
+            mode: '160000',
+            type: 'commit',
+            sha: 'submodule-sha-12345',
+          },
+          {
+            path: 'packages',
+            mode: '040000',
+            type: 'tree',
+            sha: 'packages-tree-sha',
+          },
+        ],
+        truncated: false,
+      });
+      req
+        .get('/repos/fake/fake/git/trees/packages-tree-sha?recursive=true')
+        .reply(200, {
+          sha: 'packages-tree-sha',
+          tree: [
+            {
+              path: 'pkg/setup.py',
+              mode: '100644',
+              type: 'blob',
+              sha: 'setup-blob-sha',
+            },
+          ],
+          truncated: false,
+        });
+      const pomFiles = await github.findFilesByExtension('py');
+      expect(pomFiles).to.deep.equal(['packages/pkg/setup.py']);
+      req.done();
+    });
+
+    it('throws GitHubAPIError when tree request fails with 404', async () => {
+      req
+        .get('/repos/fake/fake/git/trees/invalid-branch?recursive=true')
+        .reply(404, {
+          message: 'Not Found',
+        });
+      await assert.rejects(async () => {
+        await github.findFilesByExtensionAndRef('xml', 'invalid-branch');
+      }, GitHubAPIError);
       req.done();
     });
 
@@ -311,13 +473,65 @@ describe('GitHub', () => {
   });
 
   describe('getFileContents on 422 tree response', () => {
-    it('should throw a missing file error when GitHub returns 422', async () => {
+    it('fetches file contents of a valid file on repo with submodules after 422 fallback', async () => {
       req.get('/repos/fake/fake/git/trees/main?recursive=true').reply(422, {
         message:
           'Invalid object requested. SHA must identify a commit or a tree.',
       });
+      req.get('/repos/fake/fake/git/trees/main').reply(200, {
+        sha: 'main-tree-sha',
+        tree: [
+          {
+            path: 'pom.xml',
+            mode: '100644',
+            type: 'blob',
+            sha: 'pom-blob-sha',
+          },
+          {
+            path: 'submodule-crc32c',
+            mode: '160000',
+            type: 'commit',
+            sha: 'submodule-sha-12345',
+          },
+        ],
+        truncated: false,
+      });
+      req.get('/repos/fake/fake/git/blobs/pom-blob-sha').reply(200, {
+        sha: 'pom-blob-sha',
+        content: Buffer.from('<project></project>').toString('base64'),
+      });
+
+      const file = await github.getFileContents('pom.xml');
+      expect(file.parsedContent).to.equal('<project></project>');
+      req.done();
+    });
+
+    it('throws FileNotFoundError when fetching a submodule gitlink', async () => {
+      req.get('/repos/fake/fake/git/trees/main?recursive=true').reply(422, {
+        message:
+          'Invalid object requested. SHA must identify a commit or a tree.',
+      });
+      req.get('/repos/fake/fake/git/trees/main').reply(200, {
+        sha: 'main-tree-sha',
+        tree: [
+          {
+            path: 'pom.xml',
+            mode: '100644',
+            type: 'blob',
+            sha: 'pom-blob-sha',
+          },
+          {
+            path: 'submodule-crc32c',
+            mode: '160000',
+            type: 'commit',
+            sha: 'submodule-sha-12345',
+          },
+        ],
+        truncated: false,
+      });
+
       await assert.rejects(async () => {
-        await github.getFileContents('submodule-file');
+        await github.getFileContents('submodule-crc32c');
       }, FileNotFoundError);
       req.done();
     });

--- a/test/local-github.ts
+++ b/test/local-github.ts
@@ -22,6 +22,77 @@ import {LocalGitHub} from '../src/local-github';
 import {FileNotFoundError} from '../src/errors';
 import {GitHubApi} from '../src/github-api';
 
+async function createSubmoduleRepo(): Promise<{
+  repoPath: string;
+  localGitHub: LocalGitHub;
+}> {
+  const tempDir = await fs.promises.mkdtemp(
+    path.join(os.tmpdir(), 'local-github-submodule-test-')
+  );
+  const fakeGlobalConfig = path.join(tempDir, '.gitconfig');
+  await fs.promises.writeFile(
+    fakeGlobalConfig,
+    '[user]\nname=Test\nemail=test@example.com\n'
+  );
+  const env = {...process.env, GIT_CONFIG_GLOBAL: fakeGlobalConfig};
+
+  child_process.execFileSync('git', ['init', '-b', 'main'], {
+    cwd: tempDir,
+    env,
+  });
+  child_process.execFileSync('git', ['config', 'user.name', 'Test'], {
+    cwd: tempDir,
+    env,
+  });
+  child_process.execFileSync(
+    'git',
+    ['config', 'user.email', 'test@example.com'],
+    {cwd: tempDir, env}
+  );
+  child_process.execFileSync('git', ['config', 'commit.gpgSign', 'false'], {
+    cwd: tempDir,
+    env,
+  });
+  await fs.promises.writeFile(
+    path.join(tempDir, 'pom.xml'),
+    '<project></project>'
+  );
+  await fs.promises.mkdir(path.join(tempDir, 'packages', 'pkg'), {
+    recursive: true,
+  });
+  await fs.promises.writeFile(
+    path.join(tempDir, 'packages', 'pkg', 'setup.py'),
+    '# setup'
+  );
+  await fs.promises.writeFile(
+    path.join(tempDir, 'packages', 'pkg', 'pom.xml'),
+    '<project>child</project>'
+  );
+  child_process.execFileSync('git', ['add', '.'], {cwd: tempDir, env});
+  child_process.execFileSync(
+    'git',
+    [
+      'update-index',
+      '--add',
+      '--cacheinfo',
+      '160000,1111111111111111111111111111111111111111,submodule-pkg',
+    ],
+    {cwd: tempDir, env}
+  );
+  child_process.execFileSync(
+    'git',
+    ['commit', '-m', 'initial commit with submodule'],
+    {cwd: tempDir, env}
+  );
+
+  const localGitHub = new LocalGitHub(
+    {owner: 'fake', repo: 'fake', defaultBranch: 'main'},
+    null as unknown as GitHubApi,
+    tempDir
+  );
+  return {repoPath: tempDir, localGitHub};
+}
+
 describe('LocalGitHub', function () {
   this.timeout(60000);
   let localGitHub: LocalGitHub;
@@ -93,60 +164,7 @@ describe('LocalGitHub', function () {
     });
 
     it('throws FileNotFoundError when encountering a submodule entry (mode 160000)', async () => {
-      const tempDir = await fs.promises.mkdtemp(
-        path.join(os.tmpdir(), 'submodule-test-')
-      );
-      const fakeGlobalConfig = path.join(tempDir, '.gitconfig');
-      await fs.promises.writeFile(
-        fakeGlobalConfig,
-        '[user]\nname=Test\nemail=test@example.com\n'
-      );
-      const env = {...process.env, GIT_CONFIG_GLOBAL: fakeGlobalConfig};
-
-      child_process.execFileSync('git', ['init', '-b', 'main'], {
-        cwd: tempDir,
-        env,
-      });
-      child_process.execFileSync('git', ['config', 'user.name', 'Test'], {
-        cwd: tempDir,
-        env,
-      });
-      child_process.execFileSync(
-        'git',
-        ['config', 'user.email', 'test@example.com'],
-        {cwd: tempDir, env}
-      );
-      child_process.execFileSync('git', ['config', 'commit.gpgSign', 'false'], {
-        cwd: tempDir,
-        env,
-      });
-      child_process.execFileSync(
-        'git',
-        ['commit', '--allow-empty', '-m', 'initial'],
-        {cwd: tempDir, env}
-      );
-      child_process.execFileSync(
-        'git',
-        [
-          'update-index',
-          '--add',
-          '--cacheinfo',
-          '160000,1111111111111111111111111111111111111111,submodule-pkg',
-        ],
-        {cwd: tempDir, env}
-      );
-      child_process.execFileSync(
-        'git',
-        ['commit', '-m', 'add submodule gitlink'],
-        {cwd: tempDir, env}
-      );
-
-      const submoduleGitHub = new LocalGitHub(
-        {owner: 'fake', repo: 'fake', defaultBranch: 'main'},
-        null as unknown as GitHubApi,
-        tempDir
-      );
-
+      const {localGitHub: submoduleGitHub} = await createSubmoduleRepo();
       try {
         await submoduleGitHub.getFileContentsOnBranch('submodule-pkg', 'main');
         expect.fail('Expected FileNotFoundError to be thrown');
@@ -235,6 +253,12 @@ describe('LocalGitHub', function () {
       );
       expect(files).to.include('package.json');
     });
+
+    it('ignores git submodules and returns only matching files', async () => {
+      const {localGitHub: submoduleGitHub} = await createSubmoduleRepo();
+      const files = await submoduleGitHub.findFilesByFilename('pom.xml');
+      expect(files).to.have.members(['pom.xml', 'packages/pkg/pom.xml']);
+    });
   });
 
   describe('findFilesByGlobAndRef', () => {
@@ -246,6 +270,12 @@ describe('LocalGitHub', function () {
     it('finds files by glob on a branch', async () => {
       const files = await localGitHub.findFilesByGlobAndRef('*.json', '12.x');
       expect(files).to.include('package.json');
+    });
+
+    it('ignores git submodules and returns only matching files by glob', async () => {
+      const {localGitHub: submoduleGitHub} = await createSubmoduleRepo();
+      const files = await submoduleGitHub.findFilesByGlob('**/*.py');
+      expect(files).to.deep.equal(['packages/pkg/setup.py']);
     });
   });
 
@@ -264,6 +294,12 @@ describe('LocalGitHub', function () {
         '12.x'
       );
       expect(files).to.include('package.json');
+    });
+
+    it('ignores git submodules and returns only matching files by extension', async () => {
+      const {localGitHub: submoduleGitHub} = await createSubmoduleRepo();
+      const files = await submoduleGitHub.findFilesByExtension('py');
+      expect(files).to.deep.equal(['packages/pkg/setup.py']);
     });
   });
 

--- a/test/local-github.ts
+++ b/test/local-github.ts
@@ -12,9 +12,15 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+import * as fs from 'fs';
+import * as path from 'path';
+import * as os from 'os';
+import * as child_process from 'child_process';
 import {expect} from 'chai';
 import {describe, it, before} from 'mocha';
 import {LocalGitHub} from '../src/local-github';
+import {FileNotFoundError} from '../src/errors';
+import {GitHubApi} from '../src/github-api';
 
 describe('LocalGitHub', function () {
   this.timeout(60000);
@@ -83,6 +89,132 @@ describe('LocalGitHub', function () {
       } catch (err) {
         const error = err as Error;
         expect(error.name).to.equal('FileNotFoundError');
+      }
+    });
+
+    it('throws FileNotFoundError when encountering a submodule entry (mode 160000)', async () => {
+      const tempDir = await fs.promises.mkdtemp(
+        path.join(os.tmpdir(), 'submodule-test-')
+      );
+      const fakeGlobalConfig = path.join(tempDir, '.gitconfig');
+      await fs.promises.writeFile(
+        fakeGlobalConfig,
+        '[user]\nname=Test\nemail=test@example.com\n'
+      );
+      const env = {...process.env, GIT_CONFIG_GLOBAL: fakeGlobalConfig};
+
+      child_process.execFileSync('git', ['init', '-b', 'main'], {
+        cwd: tempDir,
+        env,
+      });
+      child_process.execFileSync('git', ['config', 'user.name', 'Test'], {
+        cwd: tempDir,
+        env,
+      });
+      child_process.execFileSync(
+        'git',
+        ['config', 'user.email', 'test@example.com'],
+        {cwd: tempDir, env}
+      );
+      child_process.execFileSync('git', ['config', 'commit.gpgSign', 'false'], {
+        cwd: tempDir,
+        env,
+      });
+      child_process.execFileSync(
+        'git',
+        ['commit', '--allow-empty', '-m', 'initial'],
+        {cwd: tempDir, env}
+      );
+      child_process.execFileSync(
+        'git',
+        [
+          'update-index',
+          '--add',
+          '--cacheinfo',
+          '160000,1111111111111111111111111111111111111111,submodule-pkg',
+        ],
+        {cwd: tempDir, env}
+      );
+      child_process.execFileSync(
+        'git',
+        ['commit', '-m', 'add submodule gitlink'],
+        {cwd: tempDir, env}
+      );
+
+      const submoduleGitHub = new LocalGitHub(
+        {owner: 'fake', repo: 'fake', defaultBranch: 'main'},
+        null as unknown as GitHubApi,
+        tempDir
+      );
+
+      try {
+        await submoduleGitHub.getFileContentsOnBranch('submodule-pkg', 'main');
+        expect.fail('Expected FileNotFoundError to be thrown');
+      } catch (err) {
+        expect(err).to.be.instanceOf(FileNotFoundError);
+      }
+    });
+
+    it('throws FileNotFoundError when git ls-tree or ref resolution fails', async () => {
+      try {
+        await localGitHub.getFileContentsOnBranch(
+          'package.json',
+          'non-existent-ref-xyz'
+        );
+        expect.fail('Expected FileNotFoundError to be thrown');
+      } catch (err) {
+        expect(err).to.be.instanceOf(FileNotFoundError);
+      }
+    });
+
+    it('throws FileNotFoundError when git show fails', async () => {
+      const tempDir = await fs.promises.mkdtemp(
+        path.join(os.tmpdir(), 'git-show-test-')
+      );
+      const fakeGlobalConfig = path.join(tempDir, '.gitconfig');
+      await fs.promises.writeFile(
+        fakeGlobalConfig,
+        '[user]\nname=Test\nemail=test@example.com\n'
+      );
+      const env = {...process.env, GIT_CONFIG_GLOBAL: fakeGlobalConfig};
+
+      child_process.execFileSync('git', ['init', '-b', 'main'], {
+        cwd: tempDir,
+        env,
+      });
+      child_process.execFileSync('git', ['config', 'user.name', 'Test'], {
+        cwd: tempDir,
+        env,
+      });
+      child_process.execFileSync(
+        'git',
+        ['config', 'user.email', 'test@example.com'],
+        {cwd: tempDir, env}
+      );
+      child_process.execFileSync('git', ['config', 'commit.gpgSign', 'false'], {
+        cwd: tempDir,
+        env,
+      });
+      child_process.execFileSync(
+        'git',
+        ['commit', '--allow-empty', '-m', 'initial'],
+        {cwd: tempDir, env}
+      );
+
+      const localGitHubInstance = new LocalGitHub(
+        {owner: 'fake', repo: 'fake', defaultBranch: 'main'},
+        null as unknown as GitHubApi,
+        tempDir
+      );
+
+      try {
+        await localGitHubInstance.getFileContentsOnBranch(
+          'invalid-file.txt',
+          'main'
+        );
+        expect.fail('Expected FileNotFoundError to be thrown');
+      } catch (err) {
+        expect(err).to.be.instanceOf(FileNotFoundError);
       }
     });
   });

--- a/typings/minimatch.d.ts
+++ b/typings/minimatch.d.ts
@@ -1,0 +1,50 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+declare module 'minimatch' {
+  export interface IMinimatch {
+    pattern: string;
+    options: any;
+    set: any[][];
+    regexp: RegExp;
+    negate: boolean;
+    comment: boolean;
+    empty: boolean;
+    partial: boolean;
+    match(fname: string, partial?: boolean): boolean;
+    makeRe(): RegExp | false;
+  }
+
+  export class Minimatch implements IMinimatch {
+    constructor(pattern: string, options?: any);
+    pattern: string;
+    options: any;
+    set: any[][];
+    regexp: RegExp;
+    negate: boolean;
+    comment: boolean;
+    empty: boolean;
+    partial: boolean;
+    match(fname: string, partial?: boolean): boolean;
+    makeRe(): RegExp | false;
+  }
+
+  function minimatch(target: string, pattern: string, options?: any): boolean;
+
+  namespace minimatch {
+    export {Minimatch, IMinimatch};
+  }
+
+  export default minimatch;
+}


### PR DESCRIPTION
## Description
Fixes an issue where GitHub's Git Trees API returns HTTP 422 (`Invalid object requested. SHA must identify a commit or a tree`) when traversing repositories containing Git submodules (mode `160000` / type `commit`).

### Changes
* **Remote Tree Traversal (`src/util/file-cache.ts`)**: Fall back to non-recursive tree traversal when recursive requests return 422, explicitly skipping submodule entries while discovering all valid files.
* **Local Git Traversal (`src/local-github.ts`)**: Filter out mode `160000` gitlink entries during file searches and file reads.
* **Testing**: Added unit tests covering repositories containing Git submodules across both remote and local execution paths.