### PR TITLE
build(deps): bump @google-automations/git-file-utils to ^3.2.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "license": "Apache-2.0",
       "dependencies": {
         "@conventional-commits/parser": "^0.4.1",
-        "@google-automations/git-file-utils": "^3.0.0",
+        "@google-automations/git-file-utils": "^3.2.0",
         "@iarna/toml": "^3.0.0",
         "@octokit/graphql": "^7.1.0",
         "@octokit/request": "^8.3.1",
@@ -256,32 +256,31 @@
       }
     },
     "node_modules/@google-automations/git-file-utils": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/@google-automations/git-file-utils/-/git-file-utils-3.0.0.tgz",
-      "integrity": "sha512-e+WLoKR0TchIhKsSDOnd/su171eXKAAdLpP2tS825UAloTgfYus53kW8uKoVj9MAsMjXGXsJ2s1ASgjq81xVdA==",
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/@google-automations/git-file-utils/-/git-file-utils-3.2.0.tgz",
+      "integrity": "sha512-EtQD1DX17kGpckDNCdI0jvMdF98EWR/TM9uogQtnhK0ODv8z5tPSPMICv2lk54c/9ucUgbfdLDrRdDyx56Sznw==",
       "license": "Apache-2.0",
       "dependencies": {
         "@octokit/rest": "^20.1.1",
-        "@octokit/types": "^13.0.0",
-        "minimatch": "^5.1.0"
+        "minimatch": "^10.2.4"
       },
       "engines": {
-        "node": ">= 18"
+        "node": ">= 22"
       }
     },
-    "node_modules/@google-automations/git-file-utils/node_modules/@octokit/openapi-types": {
-      "version": "24.2.0",
-      "resolved": "https://registry.npmjs.org/@octokit/openapi-types/-/openapi-types-24.2.0.tgz",
-      "integrity": "sha512-9sIH3nSUttelJSXUrmGzl7QUBFul0/mB8HRYl3fOlgHbIWG+WnYDXU3v/2zMtAvuzZ/ed00Ei6on975FhBfzrg==",
-      "license": "MIT"
-    },
-    "node_modules/@google-automations/git-file-utils/node_modules/@octokit/types": {
-      "version": "13.10.0",
-      "resolved": "https://registry.npmjs.org/@octokit/types/-/types-13.10.0.tgz",
-      "integrity": "sha512-ifLaO34EbbPj0Xgro4G5lP5asESjwHracYJvVaPIyXMuiuXLlhic3S47cBdTb+jfODkTE5YtGCLt3Ay3+J97sA==",
-      "license": "MIT",
+    "node_modules/@google-automations/git-file-utils/node_modules/minimatch": {
+      "version": "10.2.6",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.6.tgz",
+      "integrity": "sha512-vpLQEs+VLCr1nU0BXS07maYoFwlDAH0gngQuuttxIwutDFEMHq2blX+8vpgxDdK3J1PwjCJiep77OitTZ4Ll1A==",
+      "license": "BlueOak-1.0.0",
       "dependencies": {
-        "@octokit/openapi-types": "^24.2.0"
+        "brace-expansion": "^5.0.8"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
       }
     },
     "node_modules/@humanwhocodes/config-array": {
@@ -3652,6 +3651,7 @@
       "version": "5.1.9",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-5.1.9.tgz",
       "integrity": "sha512-7o1wEA2RyMP7Iu7GNba9vc0RWWGACJOCZBJX2GJWip0ikV+wcOsgVuY9uE8CPiyQhkGFSlhuSkZPavN7u1c2Fw==",
+      "dev": true,
       "license": "ISC",
       "dependencies": {
         "brace-expansion": "^2.0.1"

--- a/package.json
+++ b/package.json
@@ -68,7 +68,7 @@
   },
   "dependencies": {
     "@conventional-commits/parser": "^0.4.1",
-    "@google-automations/git-file-utils": "^3.0.0",
+    "@google-automations/git-file-utils": "^3.2.0",
     "@iarna/toml": "^3.0.0",
     "@octokit/graphql": "^7.1.0",
     "@octokit/request": "^8.3.1",


### PR DESCRIPTION
Bumps `@google-automations/git-file-utils` to `^3.2.0`.

This release includes the fix for handling Git submodules (`mode 160000` / `type commit`), preventing unhandled HTTP 422 errors during Git tree traversal and file retrieval on repositories containing submodules (such as `googleapis/google-cloud-python`).

I verified locally that just taking this dependency update fixed the 422 errors we were seeing.

Updates: #2881

BEGIN_COMMIT_OVERRIDE
fix: bump @google-automations/git-file-utils to ^3.2.0

Bumps `@google-automations/git-file-utils` to `^3.2.0`.

This release includes the fix for handling Git submodules (`mode 160000` / `type commit`), preventing unhandled HTTP 422 errors during Git tree traversal and file retrieval on repositories containing submodules (such as `googleapis/google-cloud-python`).

I verified locally that just taking this dependency update fixed the 422 errors we were seeing.
END_COMMIT_OVERRIDE